### PR TITLE
#371 fix(scanner): block empty-state actions with explicit validation

### DIFF
--- a/openspec/specs/integrations/ui-screen-scanner/spec.md
+++ b/openspec/specs/integrations/ui-screen-scanner/spec.md
@@ -10,6 +10,13 @@ Market Watch SHALL allow creating/loading query sets and triggering manual/sched
 - **WHEN** user enters query set name/keywords and clicks `Create Query Set`
 - **THEN** query set MUST be created and displayed in Market Watch list with deterministic success/error feedback
 
+#### Scenario: Blank Create Query Set attempt
+- **GIVEN** Market Watch route is loaded and no query set has been created yet
+- **WHEN** user clicks `Create Query Set` with blank required fields
+- **THEN** Market Watch MUST keep the form in place
+- **AND** MUST show explicit inline validation for each missing required field
+- **AND** MUST surface action-specific guidance instead of silently ignoring the submit
+
 #### Scenario: Run query set
 - **GIVEN** an authenticated actor with the required role is operating an active local profile, required capability configuration is enabled, and scenario fixture data exists for execution
 - **WHEN** user runs a selected query set
@@ -30,6 +37,12 @@ The screen SHALL support loading, empty, error, and ready states for query sets 
 - **GIVEN** an authenticated actor with the required role is operating an active local profile, required capability configuration is enabled, and scenario fixture data exists for execution
 - **WHEN** no query sets exist
 - **THEN** screen SHALL provide create-first guidance
+
+#### Scenario: Scheduled refresh from empty state
+- **GIVEN** no runnable query sets exist
+- **WHEN** user clicks `Run Scheduled Refresh`
+- **THEN** Market Watch MUST block the action in-screen without issuing a generic scheduled failure
+- **AND** MUST explain that a query set with valid criteria is required before scheduled refresh can run
 
 ### Requirement UI-SCREEN-SCANNER-004: Market Watch run failures SHALL surface actionable guidance instead of raw keys
 Market Watch run and retry failures SHALL map backend taxonomy/status to user-readable guidance with deterministic recovery actions.

--- a/ui.web/cypress/e2e/integrations/ui-screen-scanner/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-scanner/spec.cy.ts
@@ -114,10 +114,35 @@ describe('integrations/ui-screen-scanner', () => {
       statusCode: 200,
       body: { status: 'ok' },
     }).as('providerHealth')
+    cy.intercept('POST', '/api/scanner/query-sets', () => {
+      throw new Error('Create Query Set should stay client-side when required fields are blank')
+    }).as('createQuerySetBlocked')
+    cy.intercept('POST', '/api/scanner/run/scheduled', () => {
+      throw new Error('Scheduled refresh should stay client-side when no query sets exist')
+    }).as('scheduledRefreshBlocked')
 
     signInToScanner()
     cy.wait(['@emptyQuerySets', '@emptyFailures', '@providerHealth'])
     cy.get('[data-testid="scanner-empty-state"]').should('be.visible')
+
+    cy.get('[data-testid="scanner-create-query"]').click()
+    cy.get('[data-testid="scanner-new-query-name-validation"]')
+      .should('be.visible')
+      .and('contain', 'Query set name is required.')
+    cy.get('[data-testid="scanner-new-query-keywords-validation"]')
+      .should('be.visible')
+      .and('contain', 'Enter at least one keyword before creating a query set.')
+    cy.get('[data-testid="scanner-action-feedback"]')
+      .should('contain', 'Create Query Set requires the highlighted fields.')
+      .and('contain', 'Provide a query set name.')
+      .and('contain', 'Enter at least one keyword before creating a query set.')
+
+    cy.get('[data-testid="scanner-run-scheduled-refresh"]').click()
+    cy.get('[data-testid="scanner-action-status"]').should('contain', 'scheduled_run_blocked_empty')
+    cy.get('[data-testid="scanner-action-feedback"]')
+      .should('contain', 'Run Scheduled Refresh needs at least one runnable query set.')
+      .and('contain', 'Create a query set first.')
+      .and('contain', 'Add keywords so the first scheduled run has valid criteria.')
 
     cy.intercept('GET', '/api/scanner/query-sets', {
       statusCode: 500,

--- a/ui.web/src/features/scanner/index.tsx
+++ b/ui.web/src/features/scanner/index.tsx
@@ -80,6 +80,11 @@ const MARKET_WATCH_PROVIDER_OPTIONS = [
 
 type ProviderMode = 'single' | 'multi'
 
+type CreateQueryValidation = {
+  name?: string
+  keywords?: string
+}
+
 function parseErrorCode(payload: unknown, fallback: string): string {
   if (payload && typeof payload === 'object' && 'error' in payload) {
     const value = (payload as { error?: unknown }).error
@@ -149,6 +154,7 @@ export function Scanner() {
   const [newName, setNewName] = useState('')
   const [newKeywords, setNewKeywords] = useState('')
   const [newScheduleCron, setNewScheduleCron] = useState('0 */6 * * *')
+  const [createValidation, setCreateValidation] = useState<CreateQueryValidation>({})
   const [providerMode, setProviderMode] = useState<ProviderMode>('single')
   const [singleProvider, setSingleProvider] = useState('ebay')
   const [multiProviders, setMultiProviders] = useState<string[]>(['ebay', 'amazon'])
@@ -227,19 +233,36 @@ export function Scanner() {
   }
 
   const createQuerySet = async () => {
+    const keywords = newKeywords
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+    const nextValidation: CreateQueryValidation = {}
     if (!newName.trim()) {
+      nextValidation.name = 'Query set name is required.'
+    }
+    if (keywords.length === 0) {
+      nextValidation.keywords = 'Enter at least one keyword before creating a query set.'
+    }
+    if (nextValidation.name || nextValidation.keywords) {
+      setCreateValidation(nextValidation)
+      setActionStatus('create_query_set_validation_failed')
+      setActionFeedback({
+        summary: 'Create Query Set requires the highlighted fields.',
+        actions: [
+          nextValidation.name ?? 'Provide a query set name.',
+          nextValidation.keywords ?? 'Provide at least one keyword.',
+        ],
+      })
       return
     }
+    setCreateValidation({})
     const providerScope = resolveProviderScope()
     if (providerScope.length === 0) {
       setProviderValidation('Select at least one provider')
       return
     }
     setProviderValidation(null)
-    const keywords = newKeywords
-      .split(',')
-      .map((value) => value.trim())
-      .filter(Boolean)
     const response = await fetch('/api/scanner/query-sets', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -263,6 +286,7 @@ export function Scanner() {
     setActionStatus('query_set_created')
     setActionFeedback(null)
     setQuerySets((current) => [...current, createdQuerySet])
+    setCreateValidation({})
     setRunMetaByQuerySet((current) => ({
       ...current,
       [createdQuerySet.id]: { status: 'never' },
@@ -334,6 +358,17 @@ export function Scanner() {
   }
 
   const runScheduledRefresh = async () => {
+    if (querySets.length === 0) {
+      setActionStatus('scheduled_run_blocked_empty')
+      setActionFeedback({
+        summary: 'Run Scheduled Refresh needs at least one runnable query set.',
+        actions: [
+          'Create a query set first.',
+          'Add keywords so the first scheduled run has valid criteria.',
+        ],
+      })
+      return
+    }
     const response = await fetch('/api/scanner/run/scheduled', {
       method: 'POST',
     })
@@ -692,18 +727,40 @@ export function Scanner() {
         </div>
 
         <section className='grid gap-2 md:grid-cols-3'>
-          <Input
-            value={newName}
-            onChange={(event) => setNewName(event.target.value)}
-            placeholder='Query set name'
-            data-testid='scanner-new-query-name'
-          />
-          <Input
-            value={newKeywords}
-            onChange={(event) => setNewKeywords(event.target.value)}
-            placeholder='Keywords (comma-separated)'
-            data-testid='scanner-new-query-keywords'
-          />
+          <div className='space-y-1'>
+            <Input
+              value={newName}
+              onChange={(event) => {
+                setNewName(event.target.value)
+                setCreateValidation((current) => ({ ...current, name: undefined }))
+              }}
+              placeholder='Query set name'
+              aria-invalid={createValidation.name ? 'true' : 'false'}
+              data-testid='scanner-new-query-name'
+            />
+            {createValidation.name ? (
+              <p className='text-xs text-destructive' data-testid='scanner-new-query-name-validation'>
+                {createValidation.name}
+              </p>
+            ) : null}
+          </div>
+          <div className='space-y-1'>
+            <Input
+              value={newKeywords}
+              onChange={(event) => {
+                setNewKeywords(event.target.value)
+                setCreateValidation((current) => ({ ...current, keywords: undefined }))
+              }}
+              placeholder='Keywords (comma-separated)'
+              aria-invalid={createValidation.keywords ? 'true' : 'false'}
+              data-testid='scanner-new-query-keywords'
+            />
+            {createValidation.keywords ? (
+              <p className='text-xs text-destructive' data-testid='scanner-new-query-keywords-validation'>
+                {createValidation.keywords}
+              </p>
+            ) : null}
+          </div>
           <Input
             value={newScheduleCron}
             onChange={(event) => setNewScheduleCron(event.target.value)}


### PR DESCRIPTION
## Summary
- block blank Create Query Set attempts with explicit inline validation and action-specific guidance
- block Run Scheduled Refresh from the empty state with clear create-first remediation instead of generic scheduled failure handling
- extend the Market Watch spec and scanner Cypress coverage for the empty-state validation contract

## Validation
- openspec validate --all --strict --no-interactive
- go test ./tests/... -count=1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-scanner/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts -Browser chrome -RequireE2EHooks