### PR TITLE
#393 fix(onboarding): seed representative category sample content

### DIFF
--- a/internal/app/onboarding_api_test.go
+++ b/internal/app/onboarding_api_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -70,6 +71,49 @@ func TestOnboardingSampleDataEndpointIsIdempotent(t *testing.T) {
 	}
 	if secondPayload.TotalItems != firstPayload.TotalItems {
 		t.Fatalf("expected stable total_items across reruns, first=%d second=%d", firstPayload.TotalItems, secondPayload.TotalItems)
+	}
+
+	itemsResp := doRequest(t, a, http.MethodGet, "/api/items", nil, nil)
+	if itemsResp.Code != http.StatusOK {
+		t.Fatalf("list items status=%d body=%s", itemsResp.Code, itemsResp.Body.String())
+	}
+	var itemsPayload struct {
+		Items []struct {
+			Category string `json:"category"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(itemsResp.Body).Decode(&itemsPayload); err != nil {
+		t.Fatalf("decode items payload: %v", err)
+	}
+	categories := make(map[string]struct{})
+	for _, item := range itemsPayload.Items {
+		if strings.TrimSpace(item.Category) != "" {
+			categories[strings.TrimSpace(item.Category)] = struct{}{}
+		}
+	}
+	if len(categories) < 6 {
+		keys := make([]string, 0, len(categories))
+		for category := range categories {
+			keys = append(keys, category)
+		}
+		sort.Strings(keys)
+		t.Fatalf("expected representative seeded category coverage (>=6 categories), got %d: %v", len(categories), keys)
+	}
+	for _, required := range []string{"Diecast", "Slot Car", "Trading Card", "Action Figure", "Comic", "Model Kit"} {
+		if _, ok := categories[required]; !ok {
+			keys := make([]string, 0, len(categories))
+			for category := range categories {
+				keys = append(keys, category)
+			}
+			sort.Strings(keys)
+			t.Fatalf("expected seeded category %q, got %v", required, keys)
+		}
+	}
+	if firstPayload.TotalItems < 6 {
+		t.Fatalf("expected at least 6 seeded items for representative sample content, got %+v", firstPayload)
+	}
+	if firstPayload.TotalWishlist < 3 {
+		t.Fatalf("expected seeded wishlist coverage, got %+v", firstPayload)
 	}
 }
 

--- a/internal/app/onboarding_sample.go
+++ b/internal/app/onboarding_sample.go
@@ -100,32 +100,110 @@ func seedOnboardingSampleData(
 		{
 			Item: collection.Item{
 				Brand:       "Cabinet",
-				Category:    "Diecast",
+				Category:    "Trading Card",
 				PartNumber:  "CAB-DEMO-003",
-				Title:       "Starter Ford GT40",
-				Make:        "Ford",
-				Model:       "GT40 Mk II",
-				Year:        "1966",
-				Scale:       "1:64",
+				Title:       "Starter Charizard Holo",
+				Make:        "Pokemon",
+				Model:       "Base Set",
+				Year:        "1999",
+				Scale:       "Card",
 				Series:      "Welcome Set",
-				Description: "Starter sample item for first-time onboarding.",
-				Tags:        []string{"starter", "sample", "classic"},
+				Description: "Starter trading card sample for first-time onboarding.",
+				Tags:        []string{"starter", "sample", "tcg"},
 			},
 			Instance: collection.Instance{
-				Condition:        "Good",
-				Status:           "loose",
+				Condition:        "Very Good",
+				Status:           "custom",
 				Quantity:         1,
-				StorageLocation:  "Starter Shelf B1",
-				AcquisitionPrice: 6.5,
+				StorageLocation:  "Starter Binder 1",
+				AcquisitionPrice: 15.25,
 				AcquisitionDate:  "2026-01-22",
 				Notes:            "Included as sample onboarding data.",
 			},
 			Wishlist:    true,
-			TargetPrice: 9,
+			TargetPrice: 18,
+		},
+		{
+			Item: collection.Item{
+				Brand:       "Cabinet",
+				Category:    "Action Figure",
+				PartNumber:  "CAB-DEMO-004",
+				Title:       "Starter Mandalorian Figure",
+				Make:        "Star Wars",
+				Model:       "The Mandalorian",
+				Year:        "2021",
+				Scale:       "6in",
+				Series:      "Welcome Set",
+				Description: "Starter action figure sample for first-time onboarding.",
+				Tags:        []string{"starter", "sample", "display"},
+			},
+			Instance: collection.Instance{
+				Condition:        "Mint",
+				Status:           "custom",
+				Quantity:         1,
+				StorageLocation:  "Display Shelf C1",
+				AcquisitionPrice: 24.99,
+				AcquisitionDate:  "2026-01-24",
+				Notes:            "Included as sample onboarding data.",
+			},
+			Wishlist:    false,
+			TargetPrice: 0,
+		},
+		{
+			Item: collection.Item{
+				Brand:       "Cabinet",
+				Category:    "Comic",
+				PartNumber:  "CAB-DEMO-005",
+				Title:       "Starter Amazing Fantasy #15",
+				Make:        "Marvel",
+				Model:       "Spider-Man Debut",
+				Year:        "1962",
+				Scale:       "Issue",
+				Series:      "Welcome Set",
+				Description: "Starter comic sample for first-time onboarding.",
+				Tags:        []string{"starter", "sample", "silver-age"},
+			},
+			Instance: collection.Instance{
+				Condition:        "Fine",
+				Status:           "custom",
+				Quantity:         1,
+				StorageLocation:  "Comic Box D2",
+				AcquisitionPrice: 12.75,
+				AcquisitionDate:  "2026-01-26",
+				Notes:            "Included as sample onboarding data.",
+			},
+			Wishlist:    true,
+			TargetPrice: 20,
+		},
+		{
+			Item: collection.Item{
+				Brand:       "Cabinet",
+				Category:    "Model Kit",
+				PartNumber:  "CAB-DEMO-006",
+				Title:       "Starter RX-78-2 Gundam",
+				Make:        "Bandai",
+				Model:       "RX-78-2",
+				Year:        "1979",
+				Scale:       "1:144",
+				Series:      "Welcome Set",
+				Description: "Starter model kit sample for first-time onboarding.",
+				Tags:        []string{"starter", "sample", "mecha"},
+			},
+			Instance: collection.Instance{
+				Condition:        "New",
+				Status:           "sealed",
+				Quantity:         1,
+				StorageLocation:  "Workshop Shelf E1",
+				AcquisitionPrice: 19.95,
+				AcquisitionDate:  "2026-01-28",
+				Notes:            "Included as sample onboarding data.",
+			},
+			Wishlist:    false,
+			TargetPrice: 0,
 		},
 	}
 
-	existingItems, err := collectionRepo.ListItems(ctx)
+	existingItems, err := collectionRepo.ListItemsByProfile(ctx, active.ID)
 	if err != nil {
 		return onboardingSampleSeedResult{}, fmt.Errorf("list items: %w", err)
 	}
@@ -134,7 +212,7 @@ func seedOnboardingSampleData(
 		itemByPart[item.PartNumber] = item
 	}
 
-	existingWishlist, err := wishlistSvc.List(ctx)
+	existingWishlist, err := wishlistSvc.ListByProfile(ctx, active.ID)
 	if err != nil {
 		return onboardingSampleSeedResult{}, fmt.Errorf("list wishlist: %w", err)
 	}
@@ -150,7 +228,7 @@ func seedOnboardingSampleData(
 	for _, spec := range specs {
 		item, ok := itemByPart[spec.Item.PartNumber]
 		if !ok {
-			created, createErr := collectionRepo.CreateItem(ctx, spec.Item)
+			created, createErr := collectionRepo.CreateItemForProfile(ctx, active.ID, spec.Item)
 			if createErr != nil {
 				return onboardingSampleSeedResult{}, fmt.Errorf("create sample item %s: %w", spec.Item.PartNumber, createErr)
 			}
@@ -174,7 +252,7 @@ func seedOnboardingSampleData(
 
 		if spec.Wishlist {
 			if _, exists := wishlistByItemID[item.ID]; !exists {
-				createdEntry, createErr := wishlistSvc.Create(ctx, wishlist.Entry{
+				createdEntry, createErr := wishlistSvc.CreateForProfile(ctx, active.ID, wishlist.Entry{
 					ItemID:       item.ID,
 					TargetPrice:  spec.TargetPrice,
 					Priority:     "normal",
@@ -190,11 +268,11 @@ func seedOnboardingSampleData(
 		}
 	}
 
-	totalItems, err := collectionRepo.ListItems(ctx)
+	totalItems, err := collectionRepo.ListItemsByProfile(ctx, active.ID)
 	if err != nil {
 		return onboardingSampleSeedResult{}, fmt.Errorf("reload items: %w", err)
 	}
-	totalWishlist, err := wishlistSvc.List(ctx)
+	totalWishlist, err := wishlistSvc.ListByProfile(ctx, active.ID)
 	if err != nil {
 		return onboardingSampleSeedResult{}, fmt.Errorf("reload wishlist: %w", err)
 	}

--- a/openspec/specs/general/onboarding-starter-data/spec.md
+++ b/openspec/specs/general/onboarding-starter-data/spec.md
@@ -18,6 +18,13 @@ Cabinet SHALL support one-click sample data import in onboarding after identity/
 - **WHEN** user selects `Use Sample Data` from starter setup flows
 - **THEN** runtime MUST create starter dataset and return seed summary (`folders_created`, `items_created`, `media_created`)
 
+#### Scenario: Seed representative category coverage
+- **GIVEN** active profile has no prior onboarding sample dataset
+- **WHEN** runtime seeds onboarding sample data
+- **THEN** sample items MUST cover multiple distinct collecting categories so inventory/category views do not look empty or repetitive
+- **AND** MUST include a mix of immediately-owned examples and wishlist-target examples
+- **AND** rerunning the same seed for the same profile MUST remain idempotent
+
 ### Requirement ONBOARDING-STARTER-DATA-003: Starter flow SHALL support import-existing alternative
 Cabinet SHALL provide import-existing-collection option as an alternative to sample data.
 


### PR DESCRIPTION
## Summary
- expand onboarding sample seed to a representative six-category starter dataset
- bind seeded items and wishlist entries to the active profile so real inventory/category views actually show the sample data
- prove category coverage and idempotency through the onboarding sample API test

## Validation
- openspec validate --all --strict --no-interactive
- go test ./internal/app -run TestOnboardingSampleDataEndpointIsIdempotent -count=1
- go test ./tests/... -count=1