### PR TITLE
#348 fix(auth): serve public privacy policy route

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -106,6 +106,15 @@ Forgot-password flow SHALL provide a deterministic next-step outcome after valid
 - **WHEN** submission fails
 - **THEN** UI MUST show actionable error feedback and remain recoverable on `/forgot-password`
 
+### Requirement UI-SCREEN-ONBOARDING-AUTH-013: Legal auth links SHALL resolve to public policy content
+Auth legal links SHALL route to public content pages instead of falling through to the generic not-found screen.
+
+#### Scenario: Privacy policy route
+- **GIVEN** runtime setup is complete and an unauthenticated visitor opens `/privacy`
+- **WHEN** the route renders from a sign-in or sign-up legal link
+- **THEN** UI MUST render `Privacy Policy` content
+- **AND** MUST NOT render the generic `404` not-found screen
+
 ## Acceptance Criteria
 - Each onboarding critical step has UC ID and deterministic outcome.
 - E2E mapping includes first-run completion and resume behavior.
@@ -128,3 +137,4 @@ Forgot-password flow SHALL provide a deterministic next-step outcome after valid
 | UC-ONB-09 | Passkey fallback | Unavailable passkey shows deterministic guidance and keeps alternate methods visible | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-008 shows deterministic fallback guidance when passkey is unavailable` |
 | UC-ONB-10 | Sign-up completion | Valid sign-up shows submit progress and navigates to authenticated shell on success | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011 completes sign-up and redirects to authenticated shell` |
 | UC-ONB-11 | Forgot-password completion | Valid forgot-password submit shows progress and navigates to OTP recovery without fallback validation regression | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 completes forgot-password submit and routes to OTP recovery` |
+| UC-ONB-12 | Privacy legal route | `/privacy` renders public Privacy Policy content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Privacy Policy content on the public privacy route` |

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -200,4 +200,17 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/otp\/?$/);
     cy.contains(/please enter your email/i).should('not.exist');
   });
+
+  it('UI-SCREEN-ONBOARDING-AUTH-013 renders Privacy Policy content on the public privacy route', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/privacy');
+    cy.contains('h1', 'Privacy Policy').should('be.visible');
+    cy.contains('What Cabinet stores').should('be.visible');
+    cy.contains('Optional integrations').should('be.visible');
+    cy.contains(/^404$/).should('not.exist');
+    cy.contains('Go Back').should('not.exist');
+  });
 });

--- a/ui.web/src/features/auth/privacy-policy/index.tsx
+++ b/ui.web/src/features/auth/privacy-policy/index.tsx
@@ -1,0 +1,40 @@
+export function PrivacyPolicy() {
+  return (
+    <main className='container mx-auto flex min-h-svh max-w-3xl flex-col gap-6 px-6 py-12'>
+      <div className='space-y-2'>
+        <p className='text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground'>
+          Cabinet Legal
+        </p>
+        <h1 className='text-4xl font-semibold tracking-tight'>Privacy Policy</h1>
+        <p className='text-base text-muted-foreground'>
+          Cabinet explains what profile data is stored locally, what optional integrations can
+          transmit externally, and how users retain control over workspace data.
+        </p>
+      </div>
+
+      <section className='space-y-3'>
+        <h2 className='text-xl font-semibold'>What Cabinet stores</h2>
+        <p className='text-sm leading-7 text-muted-foreground'>
+          Cabinet stores profile-scoped collection records, settings, activity history, and any
+          optional media that you explicitly add to the workspace runtime.
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-xl font-semibold'>Optional integrations</h2>
+        <p className='text-sm leading-7 text-muted-foreground'>
+          External providers run only when you enable them. Search, scanner, and AI integrations may
+          send the query, item, or provider configuration required to complete the action you choose.
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-xl font-semibold'>Your control</h2>
+        <p className='text-sm leading-7 text-muted-foreground'>
+          You can review, export, update, or remove your collection data from Cabinet, and you can
+          return to sign-in or home without losing access to this policy page.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/ui.web/src/routeTree.gen.ts
+++ b/ui.web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as ClerkRouteRouteImport } from './routes/clerk/route'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
@@ -50,6 +51,11 @@ import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_a
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
 import { Route as AuthenticatedErrorsErrorRouteImport } from './routes/_authenticated/errors/$error'
 
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ClerkRouteRoute = ClerkRouteRouteImport.update({
   id: '/clerk',
   path: '/clerk',
@@ -271,6 +277,7 @@ const AuthenticatedErrorsErrorRoute =
 export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
   '/clerk': typeof ClerkAuthenticatedRouteRouteWithChildren
+  '/privacy': typeof PrivacyRoute
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/forgot-password': typeof authForgotPasswordRoute
   '/otp': typeof authOtpRoute
@@ -309,6 +316,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/clerk': typeof ClerkAuthenticatedRouteRouteWithChildren
+  '/privacy': typeof PrivacyRoute
   '/forgot-password': typeof authForgotPasswordRoute
   '/otp': typeof authOtpRoute
   '/sign-in': typeof authSignInRoute
@@ -349,6 +357,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/clerk': typeof ClerkRouteRouteWithChildren
+  '/privacy': typeof PrivacyRoute
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/clerk/(auth)': typeof ClerkauthRouteRouteWithChildren
   '/clerk/_authenticated': typeof ClerkAuthenticatedRouteRouteWithChildren
@@ -393,6 +402,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/clerk'
+    | '/privacy'
     | '/settings'
     | '/forgot-password'
     | '/otp'
@@ -431,6 +441,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/clerk'
+    | '/privacy'
     | '/forgot-password'
     | '/otp'
     | '/sign-in'
@@ -470,6 +481,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/_authenticated'
     | '/clerk'
+    | '/privacy'
     | '/_authenticated/settings'
     | '/clerk/(auth)'
     | '/clerk/_authenticated'
@@ -513,6 +525,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
   ClerkRouteRoute: typeof ClerkRouteRouteWithChildren
+  PrivacyRoute: typeof PrivacyRoute
   authForgotPasswordRoute: typeof authForgotPasswordRoute
   authOtpRoute: typeof authOtpRoute
   authSignInRoute: typeof authSignInRoute
@@ -527,6 +540,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/clerk': {
       id: '/clerk'
       path: '/clerk'
@@ -924,6 +944,7 @@ const ClerkRouteRouteWithChildren = ClerkRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
   ClerkRouteRoute: ClerkRouteRouteWithChildren,
+  PrivacyRoute: PrivacyRoute,
   authForgotPasswordRoute: authForgotPasswordRoute,
   authOtpRoute: authOtpRoute,
   authSignInRoute: authSignInRoute,

--- a/ui.web/src/routes/privacy.tsx
+++ b/ui.web/src/routes/privacy.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { PrivacyPolicy } from '@/features/auth/privacy-policy'
+
+export const Route = createFileRoute('/privacy')({
+  component: PrivacyPolicy,
+})


### PR DESCRIPTION
## Summary
- add a public /privacy route so auth legal links no longer fall through to the generic 404 screen
- add visible privacy policy content for unauthenticated users
- extend onboarding/auth spec and Cypress coverage for the public legal-route contract

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1