### PR TITLE
#347 fix(auth): serve public terms of service route

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -115,6 +115,12 @@ Auth legal links SHALL route to public content pages instead of falling through 
 - **THEN** UI MUST render `Privacy Policy` content
 - **AND** MUST NOT render the generic `404` not-found screen
 
+#### Scenario: Terms of service route
+- **GIVEN** runtime setup is complete and an unauthenticated visitor opens `/terms`
+- **WHEN** the route renders from a sign-in or sign-up legal link
+- **THEN** UI MUST render `Terms of Service` content
+- **AND** MUST NOT render the generic `404` not-found screen
+
 ## Acceptance Criteria
 - Each onboarding critical step has UC ID and deterministic outcome.
 - E2E mapping includes first-run completion and resume behavior.
@@ -138,3 +144,4 @@ Auth legal links SHALL route to public content pages instead of falling through 
 | UC-ONB-10 | Sign-up completion | Valid sign-up shows submit progress and navigates to authenticated shell on success | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011 completes sign-up and redirects to authenticated shell` |
 | UC-ONB-11 | Forgot-password completion | Valid forgot-password submit shows progress and navigates to OTP recovery without fallback validation regression | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 completes forgot-password submit and routes to OTP recovery` |
 | UC-ONB-12 | Privacy legal route | `/privacy` renders public Privacy Policy content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Privacy Policy content on the public privacy route` |
+| UC-ONB-13 | Terms legal route | `/terms` renders public Terms of Service content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Terms of Service content on the public terms route` |

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -213,4 +213,17 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
     cy.contains(/^404$/).should('not.exist');
     cy.contains('Go Back').should('not.exist');
   });
+
+  it('UI-SCREEN-ONBOARDING-AUTH-013 renders Terms of Service content on the public terms route', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/terms');
+    cy.contains('h1', 'Terms of Service').should('be.visible');
+    cy.contains('Acceptable use').should('be.visible');
+    cy.contains('Account and data responsibility').should('be.visible');
+    cy.contains(/^404$/).should('not.exist');
+    cy.contains('Go Back').should('not.exist');
+  });
 });

--- a/ui.web/src/features/auth/terms-of-service/index.tsx
+++ b/ui.web/src/features/auth/terms-of-service/index.tsx
@@ -1,0 +1,42 @@
+export function TermsOfService() {
+  return (
+    <main className='container mx-auto flex min-h-svh max-w-3xl flex-col gap-6 px-6 py-12'>
+      <div className='space-y-2'>
+        <p className='text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground'>
+          Cabinet Legal
+        </p>
+        <h1 className='text-4xl font-semibold tracking-tight'>Terms of Service</h1>
+        <p className='text-base text-muted-foreground'>
+          Cabinet sets clear expectations for acceptable workspace use, account responsibility, and
+          how optional integrations and local runtime features should be used.
+        </p>
+      </div>
+
+      <section className='space-y-3'>
+        <h2 className='text-xl font-semibold'>Acceptable use</h2>
+        <p className='text-sm leading-7 text-muted-foreground'>
+          Cabinet is intended for lawful collection management, inventory workflows, and explicitly
+          user-directed automation. You remain responsible for the actions initiated from your
+          workspace and connected integrations.
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-xl font-semibold'>Account and data responsibility</h2>
+        <p className='text-sm leading-7 text-muted-foreground'>
+          You are responsible for protecting access to your local runtime, profile data, and any
+          credentials configured for providers, messaging, or external services.
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-xl font-semibold'>Service boundaries</h2>
+        <p className='text-sm leading-7 text-muted-foreground'>
+          Optional integrations depend on third-party availability and policies. Cabinet can expose
+          legal and operational guidance, but external provider behavior may change independently of
+          the local application runtime.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/ui.web/src/routeTree.gen.ts
+++ b/ui.web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as ClerkRouteRouteImport } from './routes/clerk/route'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
@@ -51,6 +52,11 @@ import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_a
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
 import { Route as AuthenticatedErrorsErrorRouteImport } from './routes/_authenticated/errors/$error'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PrivacyRoute = PrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
@@ -278,6 +284,7 @@ export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
   '/clerk': typeof ClerkAuthenticatedRouteRouteWithChildren
   '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/forgot-password': typeof authForgotPasswordRoute
   '/otp': typeof authOtpRoute
@@ -317,6 +324,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/clerk': typeof ClerkAuthenticatedRouteRouteWithChildren
   '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/forgot-password': typeof authForgotPasswordRoute
   '/otp': typeof authOtpRoute
   '/sign-in': typeof authSignInRoute
@@ -358,6 +366,7 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/clerk': typeof ClerkRouteRouteWithChildren
   '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/clerk/(auth)': typeof ClerkauthRouteRouteWithChildren
   '/clerk/_authenticated': typeof ClerkAuthenticatedRouteRouteWithChildren
@@ -403,6 +412,7 @@ export interface FileRouteTypes {
     | '/'
     | '/clerk'
     | '/privacy'
+    | '/terms'
     | '/settings'
     | '/forgot-password'
     | '/otp'
@@ -442,6 +452,7 @@ export interface FileRouteTypes {
   to:
     | '/clerk'
     | '/privacy'
+    | '/terms'
     | '/forgot-password'
     | '/otp'
     | '/sign-in'
@@ -482,6 +493,7 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/clerk'
     | '/privacy'
+    | '/terms'
     | '/_authenticated/settings'
     | '/clerk/(auth)'
     | '/clerk/_authenticated'
@@ -526,6 +538,7 @@ export interface RootRouteChildren {
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
   ClerkRouteRoute: typeof ClerkRouteRouteWithChildren
   PrivacyRoute: typeof PrivacyRoute
+  TermsRoute: typeof TermsRoute
   authForgotPasswordRoute: typeof authForgotPasswordRoute
   authOtpRoute: typeof authOtpRoute
   authSignInRoute: typeof authSignInRoute
@@ -540,6 +553,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/privacy': {
       id: '/privacy'
       path: '/privacy'
@@ -945,6 +965,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
   ClerkRouteRoute: ClerkRouteRouteWithChildren,
   PrivacyRoute: PrivacyRoute,
+  TermsRoute: TermsRoute,
   authForgotPasswordRoute: authForgotPasswordRoute,
   authOtpRoute: authOtpRoute,
   authSignInRoute: authSignInRoute,

--- a/ui.web/src/routes/terms.tsx
+++ b/ui.web/src/routes/terms.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { TermsOfService } from '@/features/auth/terms-of-service'
+
+export const Route = createFileRoute('/terms')({
+  component: TermsOfService,
+})


### PR DESCRIPTION
## Summary
- add a public /terms route so auth legal links no longer fall through to the generic 404 screen
- add visible Terms of Service content for unauthenticated users
- extend onboarding/auth spec and Cypress coverage for the public terms-route contract

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1