### PR TITLE
#345 spec(auth): map otp control contracts

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -131,6 +131,21 @@ OTP recovery SHALL provide an in-place resend action that confirms resend progre
 - **AND** MUST show a deterministic resend progress/confirmation message
 - **AND** MUST NOT redirect to `/sign-in`
 
+### Requirement UI-SCREEN-ONBOARDING-AUTH-015: OTP verify control SHALL enforce deterministic threshold and submit handoff
+OTP verification controls SHALL keep the verify action disabled until a full six-digit code is present and SHALL transition deterministically once a valid code is submitted.
+
+#### Scenario: OTP verify enablement threshold
+- **GIVEN** user is on `/otp`
+- **WHEN** fewer than six digits are present in the OTP input
+- **THEN** `Verify` MUST remain disabled
+- **AND** once six digits are present `Verify` MUST become enabled without leaving the route
+
+#### Scenario: OTP verify submit handoff
+- **GIVEN** six digits are present in the OTP input
+- **WHEN** user submits verification from the OTP form
+- **THEN** UI MUST show deterministic in-flight handling
+- **AND** MUST complete the happy-path handoff without redirecting back to `/sign-in`
+
 ## Acceptance Criteria
 - Each onboarding critical step has UC ID and deterministic outcome.
 - E2E mapping includes first-run completion and resume behavior.
@@ -156,3 +171,4 @@ OTP recovery SHALL provide an in-place resend action that confirms resend progre
 | UC-ONB-12 | Privacy legal route | `/privacy` renders public Privacy Policy content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Privacy Policy content on the public privacy route` |
 | UC-ONB-13 | Terms legal route | `/terms` renders public Terms of Service content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Terms of Service content on the public terms route` |
 | UC-ONB-14 | OTP resend flow | `/otp` resend keeps the user in OTP recovery flow with visible resend confirmation instead of redirecting to sign-in | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-014 keeps resend in OTP context with deterministic feedback` |
+| UC-ONB-15 | OTP verify control | `/otp` keeps Verify disabled until six digits are present, then submits deterministically from the OTP route | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-015 enforces OTP verify threshold and submit handoff` |

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -240,4 +240,19 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
       .and('contain', 'Stay on this screen and enter the latest code.');
     cy.contains('Sign in').should('not.exist');
   });
+
+  it('UI-SCREEN-ONBOARDING-AUTH-015 enforces OTP verify threshold and submit handoff', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/otp');
+    cy.get('[data-slot="input-otp"]').type('12345');
+    cy.get('[data-testid="otp-verify"]').should('be.disabled');
+
+    cy.get('[data-slot="input-otp"]').type('6{enter}');
+    cy.get('[data-testid="otp-verify"]').should('not.be.disabled');
+    cy.location('pathname', { timeout: 15000 }).should('match', /^(\/|\/_authenticated\/?|\/dashboard\/?)$/);
+    cy.contains('Sign in').should('not.exist');
+  });
 });

--- a/ui.web/src/features/auth/otp/components/otp-form.tsx
+++ b/ui.web/src/features/auth/otp/components/otp-form.tsx
@@ -91,7 +91,11 @@ export function OtpForm({ className, ...props }: OtpFormProps) {
             </FormItem>
           )}
         />
-        <Button className='mt-2' disabled={otp.length < 6 || isLoading}>
+        <Button
+          className='mt-2'
+          disabled={otp.length < 6 || isLoading}
+          data-testid='otp-verify'
+        >
           Verify
         </Button>
       </form>


### PR DESCRIPTION
## Summary
- add explicit OTP verify threshold + submit handoff contracts under onboarding auth spec
- add stable OTP verify control targeting for route-level verification tests
- extend auth Cypress coverage to prove Verify stays disabled below 6 digits, enables at 6 digits, and submits from /otp without redirecting to /sign-in

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1