### PR TITLE
#337 spec(auth): map sign-in password visibility contracts

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -80,6 +80,16 @@ Sign-in screen SHALL include a first-time-user CTA that routes deterministically
 ### Requirement UI-SCREEN-ONBOARDING-AUTH-011: Sign-up submit SHALL provide deterministic completion feedback
 Sign-up flow SHALL provide a deterministic outcome after valid submission so first-time users are never left on a dead-end state.
 
+### Requirement UI-SCREEN-ONBOARDING-AUTH-011B: Sign-in password visibility toggle SHALL be deterministic and keyboard-accessible
+Sign-in password field SHALL expose a visibility toggle that switches the input type deterministically, updates accessible state/label, and remains keyboard-activatable.
+
+#### Scenario: Sign-in password visibility toggle
+- **GIVEN** runtime setup is complete and user is on `/sign-in`
+- **WHEN** user activates the password visibility toggle by mouse or keyboard
+- **THEN** password input MUST switch deterministically between masked and text-visible modes
+- **AND** toggle accessible label/state MUST update to reflect the current mode
+- **AND** focus/activation MUST remain on the sign-in route without side effects
+
 #### Scenario: Successful sign-up completion
 - **GIVEN** user is on `/sign-up` with valid email/password/confirm password values
 - **WHEN** user activates `Create Account`
@@ -173,6 +183,7 @@ OTP verification controls SHALL keep the verify action disabled until a full six
 | UC-ONB-08 | Passkey sign-in | Enrolled passkey auth redirects to authenticated shell without password prompt | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-008 signs in with passkey and redirects without password prompt` |
 | UC-ONB-09 | Passkey fallback | Unavailable passkey shows deterministic guidance and keeps alternate methods visible | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-008 shows deterministic fallback guidance when passkey is unavailable` |
 | UC-ONB-10 | Sign-up completion | Valid sign-up shows submit progress and navigates to authenticated shell on success | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011 completes sign-up and redirects to authenticated shell` |
+| UC-ONB-10B | Sign-in password visibility toggle | Sign-in password field toggles deterministically between masked/text modes with updated accessible state and keyboard activation | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011B toggles sign-in password visibility deterministically` |
 | UC-ONB-11 | Forgot-password completion | Valid forgot-password submit shows progress and navigates to OTP recovery without fallback validation regression | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 completes forgot-password submit and routes to OTP recovery` |
 | UC-ONB-11B | Forgot-password controls | `/forgot-password` supports keyboard submit with deterministic loading state and keyboard-activatable `/sign-up` secondary handoff | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 supports forgot-password keyboard submit and sign-up handoff` |
 | UC-ONB-12 | Privacy legal route | `/privacy` renders public Privacy Policy content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Privacy Policy content on the public privacy route` |

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -172,6 +172,27 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
     cy.contains('button', 'Sign in').should('be.visible');
   });
 
+  it('UI-SCREEN-ONBOARDING-AUTH-011B toggles sign-in password visibility deterministically', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/sign-in');
+    cy.get('input[name="password"]').should('have.attr', 'type', 'password');
+    cy.get('[data-testid="sign-in-password-toggle"]')
+      .should('have.attr', 'aria-label', 'Show password')
+      .and('have.attr', 'aria-pressed', 'false')
+      .focus()
+      .type('{enter}');
+    cy.get('input[name="password"]').should('have.attr', 'type', 'text');
+    cy.get('[data-testid="sign-in-password-toggle"]')
+      .should('have.attr', 'aria-label', 'Hide password')
+      .and('have.attr', 'aria-pressed', 'true')
+      .type(' ');
+    cy.get('input[name="password"]').should('have.attr', 'type', 'password');
+    cy.location('pathname').should('match', /^\/sign-in\/?$/);
+  });
+
   it('UI-SCREEN-ONBOARDING-AUTH-011 completes sign-up and redirects to authenticated shell', () => {
     cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
       .its('status')

--- a/ui.web/src/components/password-input.tsx
+++ b/ui.web/src/components/password-input.tsx
@@ -8,12 +8,14 @@ type PasswordInputProps = Omit<
   'type'
 > & {
   ref?: React.Ref<HTMLInputElement>
+  toggleTestId?: string
 }
 
 export function PasswordInput({
   className,
   disabled,
   ref,
+  toggleTestId,
   ...props
 }: PasswordInputProps) {
   const [showPassword, setShowPassword] = React.useState(false)
@@ -33,6 +35,8 @@ export function PasswordInput({
         variant='ghost'
         disabled={disabled}
         aria-label={showPassword ? 'Hide password' : 'Show password'}
+        aria-pressed={showPassword}
+        data-testid={toggleTestId}
         className='absolute end-1 top-1/2 h-6 w-6 -translate-y-1/2 rounded-md text-muted-foreground'
         onClick={() => setShowPassword((prev) => !prev)}
       >

--- a/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
+++ b/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
@@ -210,7 +210,7 @@ export function UserAuthForm({
             <FormItem className='relative'>
               <FormLabel>Password</FormLabel>
               <FormControl>
-                <PasswordInput placeholder='********' {...field} />
+                <PasswordInput placeholder='********' toggleTestId='sign-in-password-toggle' {...field} />
               </FormControl>
               <FormMessage />
               <Link


### PR DESCRIPTION
## Summary
- add explicit sign-in password visibility toggle contract coverage
- expose stable toggle targeting and accessible pressed-state through the shared password input
- extend auth Cypress coverage to prove masked/text switching, accessible label/state updates, and keyboard activation on /sign-in

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1