### PR TITLE
#342 spec(auth): map sign-up secondary link contracts

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -87,6 +87,16 @@ Sign-in SHALL expose a visible forgot-password recovery entry path that supports
 - **AND** activation by mouse or keyboard MUST navigate deterministically to `/forgot-password`
 - **AND** focus/route handoff MUST complete without side effects on `/sign-in`
 
+### Requirement UI-SCREEN-ONBOARDING-AUTH-010C: Sign-up secondary links SHALL be visible and deterministic
+Sign-up SHALL expose visible return/legal links that support deterministic mouse and keyboard navigation to `/sign-in`, `/terms`, and `/privacy`.
+
+#### Scenario: Sign-up sign-in/legal entry paths
+- **GIVEN** runtime setup is complete and user is on `/sign-up`
+- **WHEN** user scans the form header/footer for account-return and legal actions
+- **THEN** `Sign In`, `Terms of Service`, and `Privacy Policy` MUST be visible on the sign-up surface
+- **AND** activation by mouse or keyboard MUST navigate deterministically to `/sign-in`, `/terms`, and `/privacy`
+- **AND** route handoff MUST complete without side effects on `/sign-up`
+
 ### Requirement UI-SCREEN-ONBOARDING-AUTH-011: Sign-up submit SHALL provide deterministic completion feedback
 Sign-up flow SHALL provide a deterministic outcome after valid submission so first-time users are never left on a dead-end state.
 
@@ -195,6 +205,7 @@ OTP verification controls SHALL keep the verify action disabled until a full six
 | UC-ONB-10 | Sign-up completion | Valid sign-up shows submit progress and navigates to authenticated shell on success | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011 completes sign-up and redirects to authenticated shell` |
 | UC-ONB-10A | Sign-in forgot-password entry | Sign-in shows visible forgot-password recovery entry with deterministic keyboard/mouse navigation to `/forgot-password` | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-010B exposes deterministic forgot-password entry from sign-in` |
 | UC-ONB-10B | Sign-in password visibility toggle | Sign-in password field toggles deterministically between masked/text modes with updated accessible state and keyboard activation | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011B toggles sign-in password visibility deterministically` |
+| UC-ONB-10C | Sign-up secondary links | Sign-up shows visible sign-in/legal links with deterministic keyboard/mouse navigation to `/sign-in`, `/terms`, and `/privacy` | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-010C exposes deterministic sign-up secondary links` |
 | UC-ONB-11 | Forgot-password completion | Valid forgot-password submit shows progress and navigates to OTP recovery without fallback validation regression | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 completes forgot-password submit and routes to OTP recovery` |
 | UC-ONB-11B | Forgot-password controls | `/forgot-password` supports keyboard submit with deterministic loading state and keyboard-activatable `/sign-up` secondary handoff | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 supports forgot-password keyboard submit and sign-up handoff` |
 | UC-ONB-12 | Privacy legal route | `/privacy` renders public Privacy Policy content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Privacy Policy content on the public privacy route` |

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -98,6 +98,35 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
     cy.location('pathname').should('match', /^\/forgot-password\/?$/);
   });
 
+  it('UI-SCREEN-ONBOARDING-AUTH-010C exposes deterministic sign-up secondary links', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/sign-up');
+    cy.get('[data-testid="sign-up-sign-in-link"]')
+      .should('be.visible')
+      .and('have.attr', 'href', '/sign-in')
+      .focus()
+      .type('{enter}');
+    cy.location('pathname').should('match', /^\/sign-in\/?$/);
+
+    cy.visit('/sign-up');
+    cy.get('[data-testid="sign-up-terms-link"]')
+      .should('be.visible')
+      .and('have.attr', 'href', '/terms')
+      .click();
+    cy.location('pathname').should('match', /^\/terms\/?$/);
+
+    cy.visit('/sign-up');
+    cy.get('[data-testid="sign-up-privacy-link"]')
+      .should('be.visible')
+      .and('have.attr', 'href', '/privacy')
+      .focus()
+      .type('{enter}');
+    cy.location('pathname').should('match', /^\/privacy\/?$/);
+  });
+
   it('UI-SCREEN-ONBOARDING-AUTH-006 renders Google, Apple, and Microsoft provider actions deterministically', () => {
     cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
       .its('status')

--- a/ui.web/src/features/auth/sign-up/index.tsx
+++ b/ui.web/src/features/auth/sign-up/index.tsx
@@ -23,6 +23,7 @@ export function SignUp() {
             Already have an account?{' '}
             <Link
               to='/sign-in'
+              data-testid='sign-up-sign-in-link'
               className='underline underline-offset-4 hover:text-primary'
             >
               Sign In
@@ -37,6 +38,7 @@ export function SignUp() {
             By creating an account, you agree to our{' '}
             <a
               href='/terms'
+              data-testid='sign-up-terms-link'
               className='underline underline-offset-4 hover:text-primary'
             >
               Terms of Service
@@ -44,6 +46,7 @@ export function SignUp() {
             and{' '}
             <a
               href='/privacy'
+              data-testid='sign-up-privacy-link'
               className='underline underline-offset-4 hover:text-primary'
             >
               Privacy Policy


### PR DESCRIPTION
## Summary
- add explicit sign-up secondary-link contract coverage for Sign In, Terms of Service, and Privacy Policy
- add stable targeting for the sign-up sign-in/legal links
- extend auth Cypress coverage to prove visible links, keyboard/mouse activation, and deterministic route handoff from /sign-up

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1