### PR TITLE
#338 spec(auth): map sign-in github facebook contracts

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -87,6 +87,16 @@ Sign-in SHALL expose a visible forgot-password recovery entry path that supports
 - **AND** activation by mouse or keyboard MUST navigate deterministically to `/forgot-password`
 - **AND** focus/route handoff MUST complete without side effects on `/sign-in`
 
+### Requirement UI-SCREEN-ONBOARDING-AUTH-010BB: Sign-in GitHub/Facebook actions SHALL be explicit and deterministic
+Sign-in SHALL expose GitHub and Facebook provider actions with explicit visible/disabled behavior until provider sign-in flows are implemented.
+
+#### Scenario: Sign-in GitHub and Facebook actions
+- **GIVEN** runtime setup is complete and user is on `/sign-in`
+- **WHEN** user inspects alternative provider actions on the sign-in surface
+- **THEN** UI MUST show visible `GitHub` and `Facebook` actions
+- **AND** those actions MUST remain deterministically disabled when no sign-in provider flow is wired
+- **AND** keyboard focus/activation MUST NOT navigate away from `/sign-in`
+
 ### Requirement UI-SCREEN-ONBOARDING-AUTH-010C: Sign-up secondary links SHALL be visible and deterministic
 Sign-up SHALL expose visible return/legal links that support deterministic mouse and keyboard navigation to `/sign-in`, `/terms`, and `/privacy`.
 
@@ -224,6 +234,7 @@ OTP verification controls SHALL keep the verify action disabled until a full six
 | UC-ONB-09 | Passkey fallback | Unavailable passkey shows deterministic guidance and keeps alternate methods visible | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-008 shows deterministic fallback guidance when passkey is unavailable` |
 | UC-ONB-10 | Sign-up completion | Valid sign-up shows submit progress and navigates to authenticated shell on success | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011 completes sign-up and redirects to authenticated shell` |
 | UC-ONB-10A | Sign-in forgot-password entry | Sign-in shows visible forgot-password recovery entry with deterministic keyboard/mouse navigation to `/forgot-password` | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-010B exposes deterministic forgot-password entry from sign-in` |
+| UC-ONB-10AA | Sign-in GitHub/Facebook actions | Sign-in shows visible GitHub/Facebook actions with deterministic disabled state until provider flows are wired | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-010BB renders deterministic sign-in GitHub and Facebook actions` |
 | UC-ONB-10B | Sign-in password visibility toggle | Sign-in password field toggles deterministically between masked/text modes with updated accessible state and keyboard activation | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011B toggles sign-in password visibility deterministically` |
 | UC-ONB-10C | Sign-up secondary links | Sign-up shows visible sign-in/legal links with deterministic keyboard/mouse navigation to `/sign-in`, `/terms`, and `/privacy` | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-010C exposes deterministic sign-up secondary links` |
 | UC-ONB-10D | Sign-up GitHub/Facebook actions | Sign-up shows visible GitHub/Facebook actions with deterministic disabled state until provider flows are wired | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-010D renders deterministic sign-up GitHub and Facebook actions` |

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -98,6 +98,17 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
     cy.location('pathname').should('match', /^\/forgot-password\/?$/);
   });
 
+  it('UI-SCREEN-ONBOARDING-AUTH-010BB renders deterministic sign-in GitHub and Facebook actions', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/sign-in');
+    cy.get('[data-testid="sign-in-provider-github"]').should('be.visible').and('be.disabled');
+    cy.get('[data-testid="sign-in-provider-facebook"]').should('be.visible').and('be.disabled');
+    cy.location('pathname').should('match', /^\/sign-in\/?$/);
+  });
+
   it('UI-SCREEN-ONBOARDING-AUTH-010C exposes deterministic sign-up secondary links', () => {
     cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
       .its('status')

--- a/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
+++ b/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
@@ -278,10 +278,20 @@ export function UserAuthForm({
         </div>
 
         <div className='grid grid-cols-2 gap-2'>
-          <Button variant='outline' type='button' disabled={isLoading}>
+          <Button
+            variant='outline'
+            type='button'
+            disabled
+            data-testid='sign-in-provider-github'
+          >
             <IconGithub className='h-4 w-4' /> GitHub
           </Button>
-          <Button variant='outline' type='button' disabled={isLoading}>
+          <Button
+            variant='outline'
+            type='button'
+            disabled
+            data-testid='sign-in-provider-facebook'
+          >
             <IconFacebook className='h-4 w-4' /> Facebook
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- add explicit sign-in GitHub/Facebook provider-action contract coverage
- wire stable targeting for the sign-in GitHub/Facebook buttons
- extend auth Cypress coverage to prove visible disabled state and deterministic no-navigation behavior for both sign-in provider actions

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1