### PR TITLE
#349 spec(auth): map sign-in-2 password visibility contracts

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -140,6 +140,16 @@ Sign-up password and confirm-password fields SHALL expose visibility toggles tha
 - **AND** each toggle accessible label/state MUST update to reflect the current mode
 - **AND** focus/activation MUST remain on the sign-up route without side effects
 
+### Requirement UI-SCREEN-ONBOARDING-AUTH-011D: Sign-in-2 password visibility toggle SHALL be deterministic and keyboard-accessible
+The `/sign-in-2` password field SHALL expose a visibility toggle that switches deterministically, updates accessible state/label, and remains keyboard-activatable.
+
+#### Scenario: Sign-in-2 password visibility toggle
+- **GIVEN** runtime setup is complete and user is on `/sign-in-2`
+- **WHEN** user activates the password visibility toggle by mouse or keyboard
+- **THEN** password input MUST switch deterministically between masked and text-visible modes
+- **AND** toggle accessible label/state MUST update to reflect the current mode
+- **AND** focus/activation MUST remain on the `/sign-in-2` route without side effects
+
 #### Scenario: Successful sign-up completion
 - **GIVEN** user is on `/sign-up` with valid email/password/confirm password values
 - **WHEN** user activates `Create Account`
@@ -240,6 +250,7 @@ OTP verification controls SHALL keep the verify action disabled until a full six
 | UC-ONB-10D | Sign-up GitHub/Facebook actions | Sign-up shows visible GitHub/Facebook actions with deterministic disabled state until provider flows are wired | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-010D renders deterministic sign-up GitHub and Facebook actions` |
 | UC-ONB-11 | Forgot-password completion | Valid forgot-password submit shows progress and navigates to OTP recovery without fallback validation regression | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 completes forgot-password submit and routes to OTP recovery` |
 | UC-ONB-11C | Sign-up password visibility toggles | Sign-up password + confirm-password fields toggle deterministically between masked/text modes with updated accessible state and keyboard activation | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011C toggles sign-up password fields deterministically` |
+| UC-ONB-11D | Sign-in-2 password visibility toggle | `/sign-in-2` password field toggles deterministically between masked/text modes with updated accessible state and keyboard activation | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-011D toggles sign-in-2 password visibility deterministically` |
 | UC-ONB-11B | Forgot-password controls | `/forgot-password` supports keyboard submit with deterministic loading state and keyboard-activatable `/sign-up` secondary handoff | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-012 supports forgot-password keyboard submit and sign-up handoff` |
 | UC-ONB-12 | Privacy legal route | `/privacy` renders public Privacy Policy content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Privacy Policy content on the public privacy route` |
 | UC-ONB-13 | Terms legal route | `/terms` renders public Terms of Service content instead of the 404 screen | implemented: `ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts` `UI-SCREEN-ONBOARDING-AUTH-013 renders Terms of Service content on the public terms route` |

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -291,6 +291,27 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
     cy.location('pathname').should('match', /^\/sign-up\/?$/);
   });
 
+  it('UI-SCREEN-ONBOARDING-AUTH-011D toggles sign-in-2 password visibility deterministically', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/sign-in-2');
+    cy.get('input[name="password"]').should('have.attr', 'type', 'password');
+    cy.get('[data-testid="sign-in-password-toggle"]')
+      .should('have.attr', 'aria-label', 'Show password')
+      .and('have.attr', 'aria-pressed', 'false')
+      .focus()
+      .type('{enter}');
+    cy.get('input[name="password"]').should('have.attr', 'type', 'text');
+    cy.get('[data-testid="sign-in-password-toggle"]')
+      .should('have.attr', 'aria-label', 'Hide password')
+      .and('have.attr', 'aria-pressed', 'true')
+      .type(' ');
+    cy.get('input[name="password"]').should('have.attr', 'type', 'password');
+    cy.location('pathname').should('match', /^\/sign-in-2\/?$/);
+  });
+
   it('UI-SCREEN-ONBOARDING-AUTH-011 completes sign-up and redirects to authenticated shell', () => {
     cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
       .its('status')


### PR DESCRIPTION
## Summary
- add explicit /sign-in-2 password visibility toggle contract coverage
- extend auth Cypress coverage to prove masked/text switching, accessible label/state updates, and keyboard activation on /sign-in-2

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1