### PR TITLE
#420 fix(runtime): create timestamped log sets per start

### DIFF
--- a/internal/app/runtime_lifecycle_logging.go
+++ b/internal/app/runtime_lifecycle_logging.go
@@ -15,11 +15,16 @@ import (
 )
 
 type runtimeLogManager struct {
-	cfg        config.Config
-	mu         sync.Mutex
-	runtimeLog *os.File
-	errorLog   *os.File
-	accessLog  *os.File
+	cfg          config.Config
+	mu           sync.Mutex
+	startedAtUTC time.Time
+	logSetID     string
+	runtimePath  string
+	errorPath    string
+	accessPath   string
+	runtimeLog   *os.File
+	errorLog     *os.File
+	accessLog    *os.File
 }
 
 type runtimeStatusRecorder struct {
@@ -32,38 +37,61 @@ func (r *runtimeStatusRecorder) WriteHeader(code int) {
 	r.ResponseWriter.WriteHeader(code)
 }
 
-func runtimeLogPath(cfg config.Config) string {
-	return filepath.Join(cfg.DataDir, "cabinet.runtime.log")
+func runtimeLogSetID(startedAtUTC time.Time) string {
+	return startedAtUTC.UTC().Format("20060102T150405.000Z")
 }
 
-func runtimeErrorLogPath(cfg config.Config) string {
-	return filepath.Join(cfg.DataDir, "cabinet.error.log")
+func runtimeLogsDir(cfg config.Config) string {
+	return filepath.Join(cfg.DataDir, "logs")
 }
 
-func runtimeAccessLogPath(cfg config.Config) string {
-	return filepath.Join(cfg.DataDir, "cabinet.access.log")
+func runtimeLogPath(cfg config.Config, startedAtUTC time.Time) string {
+	return filepath.Join(runtimeLogsDir(cfg), fmt.Sprintf("cabinet.runtime.%s.log", runtimeLogSetID(startedAtUTC)))
+}
+
+func runtimeErrorLogPath(cfg config.Config, startedAtUTC time.Time) string {
+	return filepath.Join(runtimeLogsDir(cfg), fmt.Sprintf("cabinet.error.%s.log", runtimeLogSetID(startedAtUTC)))
+}
+
+func runtimeAccessLogPath(cfg config.Config, startedAtUTC time.Time) string {
+	return filepath.Join(runtimeLogsDir(cfg), fmt.Sprintf("cabinet.access.%s.log", runtimeLogSetID(startedAtUTC)))
 }
 
 func newRuntimeLogManager(cfg config.Config) (*runtimeLogManager, error) {
-	if err := os.MkdirAll(cfg.DataDir, 0o755); err != nil {
+	if err := os.MkdirAll(runtimeLogsDir(cfg), 0o755); err != nil {
 		return nil, err
 	}
-	runtimeFile, err := os.OpenFile(runtimeLogPath(cfg), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	startedAtUTC := time.Now().UTC()
+	logSetID := runtimeLogSetID(startedAtUTC)
+	runtimePath := runtimeLogPath(cfg, startedAtUTC)
+	errorPath := runtimeErrorLogPath(cfg, startedAtUTC)
+	accessPath := runtimeAccessLogPath(cfg, startedAtUTC)
+	runtimeFile, err := os.OpenFile(runtimePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, err
 	}
-	errorFile, err := os.OpenFile(runtimeErrorLogPath(cfg), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	errorFile, err := os.OpenFile(errorPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		_ = runtimeFile.Close()
 		return nil, err
 	}
-	accessFile, err := os.OpenFile(runtimeAccessLogPath(cfg), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	accessFile, err := os.OpenFile(accessPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		_ = runtimeFile.Close()
 		_ = errorFile.Close()
 		return nil, err
 	}
-	return &runtimeLogManager{cfg: cfg, runtimeLog: runtimeFile, errorLog: errorFile, accessLog: accessFile}, nil
+	return &runtimeLogManager{
+		cfg:          cfg,
+		startedAtUTC: startedAtUTC,
+		logSetID:     logSetID,
+		runtimePath:  runtimePath,
+		errorPath:    errorPath,
+		accessPath:   accessPath,
+		runtimeLog:   runtimeFile,
+		errorLog:     errorFile,
+		accessLog:    accessFile,
+	}, nil
 }
 
 func (m *runtimeLogManager) Close() error {
@@ -99,13 +127,17 @@ func (m *runtimeLogManager) writeJSONLine(file *os.File, payload map[string]any)
 
 func (m *runtimeLogManager) writeRuntimeEvent(level, event, message string, extra map[string]any) {
 	payload := map[string]any{
-		"ts":      time.Now().UTC().Format(time.RFC3339),
-		"level":   level,
-		"type":    "runtime",
-		"event":   event,
-		"message": message,
-		"pid":     os.Getpid(),
-		"dataDir": strings.TrimSpace(m.cfg.DataDir),
+		"ts":         time.Now().UTC().Format(time.RFC3339),
+		"level":      level,
+		"type":       "runtime",
+		"event":      event,
+		"message":    message,
+		"pid":        os.Getpid(),
+		"dataDir":    strings.TrimSpace(m.cfg.DataDir),
+		"logSetId":   m.logSetID,
+		"runtimeLog": m.runtimePath,
+		"errorLog":   m.errorPath,
+		"accessLog":  m.accessPath,
 	}
 	instanceName, profileKey := readRuntimeSetupIdentity(m.cfg)
 	if instanceName != "" {
@@ -122,12 +154,15 @@ func (m *runtimeLogManager) writeRuntimeEvent(level, event, message string, extr
 
 func (m *runtimeLogManager) writeErrorEvent(event, message string, extra map[string]any) {
 	payload := map[string]any{
-		"ts":      time.Now().UTC().Format(time.RFC3339),
-		"level":   "error",
-		"type":    "error",
-		"event":   event,
-		"message": message,
-		"pid":     os.Getpid(),
+		"ts":        time.Now().UTC().Format(time.RFC3339),
+		"level":     "error",
+		"type":      "error",
+		"event":     event,
+		"message":   message,
+		"pid":       os.Getpid(),
+		"logSetId":  m.logSetID,
+		"errorLog":  m.errorPath,
+		"dataDir":   strings.TrimSpace(m.cfg.DataDir),
 	}
 	for key, value := range extra {
 		payload[key] = value
@@ -147,6 +182,9 @@ func (m *runtimeLogManager) writeAccessEvent(r *http.Request, status int, durati
 		"status":     status,
 		"durationMs": duration.Milliseconds(),
 		"remoteAddr": strings.TrimSpace(r.RemoteAddr),
+		"logSetId":   m.logSetID,
+		"accessLog":  m.accessPath,
+		"dataDir":    strings.TrimSpace(m.cfg.DataDir),
 	}
 	m.writeJSONLine(m.accessLog, payload)
 }

--- a/internal/app/runtime_lifecycle_logging_test.go
+++ b/internal/app/runtime_lifecycle_logging_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -123,7 +124,11 @@ func TestRuntimeLifecycleMetadataAndStructuredLogs(t *testing.T) {
 		t.Fatalf("expected meta.lastRunClean=true after clean shutdown, got %+v", updated.Meta)
 	}
 
-	runtimeLines, err := readStructuredLogLines(runtimeLogPath(cfg))
+	runtimeLogPath, err := singleTimestampedLogPath(filepath.Join(base, "logs"), "cabinet.runtime.*.log")
+	if err != nil {
+		t.Fatalf("find runtime log: %v", err)
+	}
+	runtimeLines, err := readStructuredLogLines(runtimeLogPath)
 	if err != nil {
 		t.Fatalf("read runtime log: %v", err)
 	}
@@ -137,7 +142,11 @@ func TestRuntimeLifecycleMetadataAndStructuredLogs(t *testing.T) {
 		t.Fatalf("expected shutdown event in runtime log, got %+v", runtimeLines)
 	}
 
-	accessLines, err := readStructuredLogLines(runtimeAccessLogPath(cfg))
+	accessLogPath, err := singleTimestampedLogPath(filepath.Join(base, "logs"), "cabinet.access.*.log")
+	if err != nil {
+		t.Fatalf("find access log: %v", err)
+	}
+	accessLines, err := readStructuredLogLines(accessLogPath)
 	if err != nil {
 		t.Fatalf("read access log: %v", err)
 	}
@@ -150,6 +159,30 @@ func TestRuntimeLifecycleMetadataAndStructuredLogs(t *testing.T) {
 	if !containsPath(accessLines, "/api/runtime") {
 		t.Fatalf("expected /api/runtime access log entry, got %+v", accessLines)
 	}
+
+	errorLogPath, err := singleTimestampedLogPath(filepath.Join(base, "logs"), "cabinet.error.*.log")
+	if err != nil {
+		t.Fatalf("find error log: %v", err)
+	}
+	if _, err := os.Stat(errorLogPath); err != nil {
+		t.Fatalf("stat error log: %v", err)
+	}
+	for _, legacy := range []string{"cabinet.runtime.log", "cabinet.access.log", "cabinet.error.log"} {
+		if _, err := os.Stat(filepath.Join(base, legacy)); err == nil {
+			t.Fatalf("expected legacy fixed log filename %s to be absent", legacy)
+		}
+	}
+}
+
+func singleTimestampedLogPath(base, pattern string) (string, error) {
+	matches, err := filepath.Glob(filepath.Join(base, pattern))
+	if err != nil {
+		return "", err
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("expected exactly one match for %s, got %d (%v)", pattern, len(matches), matches)
+	}
+	return matches[0], nil
 }
 
 func containsEvent(lines []map[string]any, event string) bool {

--- a/openspec/specs/general/runtime-core/spec.md
+++ b/openspec/specs/general/runtime-core/spec.md
@@ -154,6 +154,7 @@ Cabinet MUST write machine-readable JSONL log files for runtime lifecycle, reque
 #### Scenario: Structured runtime log files during local execution
 - **GIVEN** Cabinet starts successfully with writable data directory
 - **WHEN** runtime lifecycle events occur and HTTP requests are served
-- **THEN** Cabinet MUST append JSONL entries under the active data directory for runtime, access, and error streams
-- **AND** runtime log entries MUST include timestamp, level, event/type, and process/runtime context
+- **THEN** Cabinet MUST create a fresh timestamped JSONL log set under the active data directory's `logs/` subfolder for runtime, access, and error streams on every process start
+- **AND** runtime log entries MUST append only to that process start's own runtime log file and include timestamp, level, event/type, and process/runtime context
 - **AND** access log entries MUST include method, path, status, and duration
+- **AND** fixed shared filenames like `cabinet.runtime.log`, `cabinet.access.log`, and `cabinet.error.log` MUST NOT be reused across multiple starts, and the timestamped files MUST live under that `logs/` subfolder


### PR DESCRIPTION
## Summary
- create a fresh timestamped runtime/access/error log set on every Cabinet process start
- stop reusing fixed shared runtime log filenames across multiple starts
- update runtime-core spec and focused runtime logging test to assert the timestamped per-start behavior

## Validation
- openspec validate --all --strict --no-interactive
- go test ./internal/app -run TestRuntimeLifecycleMetadataAndStructuredLogs
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1