### PR TITLE
#334 Normalize passkey domain mismatch guidance

### DIFF
--- a/openspec/specs/general/ui-screen-onboarding-auth/spec.md
+++ b/openspec/specs/general/ui-screen-onboarding-auth/spec.md
@@ -55,6 +55,12 @@ Sign-in flow SHALL support passkey authentication compatible with platform authe
 - **WHEN** passkey auth attempt fails
 - **THEN** UI MUST provide deterministic fallback to other enabled methods (password/social) with actionable error message
 
+#### Scenario: Passkey domain or origin mismatch fallback behavior
+- **GIVEN** passkey runtime returns a domain, origin, or relying-party mismatch error during sign-in
+- **WHEN** the passkey auth attempt fails before credential completion
+- **THEN** UI MUST normalize the raw provider/browser mismatch into deterministic guidance that the current domain is not yet passkey-enabled
+- **AND** UI MUST keep password and provider sign-in methods visible as immediate fallback options
+
 ### Requirement UI-SCREEN-ONBOARDING-AUTH-009: Setup wizard SHALL gate sign-in when runtime setup config is missing
 Sign-in route SHALL present a full-screen setup wizard before auth controls when runtime setup config file is missing.
 

--- a/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts
@@ -237,6 +237,39 @@ describe('UI-SCREEN-ONBOARDING-AUTH', () => {
     cy.contains('button', 'Sign in').should('be.visible');
   });
 
+  it('UI-SCREEN-ONBOARDING-AUTH-008 normalizes passkey domain mismatch into actionable fallback guidance', () => {
+    cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
+      .its('status')
+      .should('eq', 200);
+
+    cy.visit('/sign-in', {
+      onBeforeLoad(win) {
+        (win as Window & { PublicKeyCredential?: unknown }).PublicKeyCredential =
+          function PublicKeyCredential() {
+            return undefined;
+          };
+        Object.defineProperty(win.navigator, 'credentials', {
+          configurable: true,
+          value: {
+            get: () => Promise.reject(new Error('This is an invalid domain.')),
+          },
+        });
+      },
+    });
+
+    cy.get('[data-testid="passkey-signin"]').click();
+    cy.get('[data-testid="passkey-error"]')
+      .should('be.visible')
+      .and(
+        'contain.text',
+        'Passkey sign-in is not available on this domain yet. Use password or provider sign-in.'
+      )
+      .and('not.contain.text', 'This is an invalid domain.');
+    cy.contains('button', 'Sign in').should('be.visible');
+    cy.get('[data-testid="provider-google"]').should('be.visible');
+    cy.location('pathname').should('match', /^\/sign-in\/?$/);
+  });
+
   it('UI-SCREEN-ONBOARDING-AUTH-011B toggles sign-in password visibility deterministically', () => {
     cy.request('POST', '/api/test/runtime/setup-status', { state: 'present' })
       .its('status')

--- a/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
+++ b/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
@@ -45,6 +45,27 @@ type ProviderOptionsPayload = {
   providers?: ProviderOption[]
 }
 
+function normalizePasskeyError(error: unknown) {
+  const fallback = 'Passkey sign-in failed. Use password or provider sign-in.'
+  if (!(error instanceof Error)) {
+    return fallback
+  }
+
+  const message = error.message.trim()
+  const lower = message.toLowerCase()
+  if (
+    lower.includes('invalid domain') ||
+    lower.includes('invalid rp id') ||
+    lower.includes('relying party') ||
+    lower.includes('origin mismatch') ||
+    lower.includes('domain mismatch')
+  ) {
+    return 'Passkey sign-in is not available on this domain yet. Use password or provider sign-in.'
+  }
+
+  return message || fallback
+}
+
 export function UserAuthForm({
   className,
   redirectTo,
@@ -139,11 +160,7 @@ export function UserAuthForm({
       const targetPath = redirectTo || '/dashboard'
       navigate({ to: targetPath, replace: true })
     } catch (error) {
-      setPasskeyError(
-        error instanceof Error
-          ? error.message
-          : 'Passkey sign-in failed. Use password or provider sign-in.'
-      )
+      setPasskeyError(normalizePasskeyError(error))
     } finally {
       setPasskeyLoading(false)
     }


### PR DESCRIPTION
## Summary
- normalize raw passkey domain/origin mismatch failures into deterministic user guidance on /sign-in
- add explicit onboarding-auth spec scenario for passkey domain/origin mismatch fallback behavior
- add targeted Cypress coverage that reproduces This is an invalid domain. and asserts the normalized fallback message

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/ui-screen-onboarding-auth/spec.cy.ts -Browser chrome -RequireE2EHooks

## Issue
- closes #334