### PR TITLE
#355 Add exploratory auth setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ openspec validate --changes --strict --no-interactive
 - `CABINET_BACKUP_INTERVAL_MINUTES` default: `60`
 - `VITE_CLERK_PUBLISHABLE_KEY` enables Clerk sign-in gate and cloud entitlement bootstrap in the web UI
 
+Exploratory auth setup guide:
+- `docs/auth/exploration-auth-setup.md`
+
 eBay provider settings are stored per profile via `PUT /api/profiles/{profileID}/settings`:
 - `ebay_bearer_token`
 - `ebay_marketplace` (example: `EBAY_US`)

--- a/docs/auth/exploration-auth-setup.md
+++ b/docs/auth/exploration-auth-setup.md
@@ -1,0 +1,95 @@
+# Exploration Auth Setup
+
+## Purpose
+This guide makes Cabinet exploratory auth deterministic for local development, review, and route-audit work.
+
+## Default exploratory path: use local auth
+For exploratory testing, prefer **local auth mode** unless the specific task is explicitly about Clerk.
+
+Why:
+- no external auth dependency
+- no publishable-key/domain setup required
+- fastest path to authenticated route coverage
+- avoids Clerk-origin and passkey-domain blockers during routine UI review
+
+## Local auth flow
+### Startup
+From the repo root, start Cabinet with the project-local binary:
+
+```powershell
+.\bin\cabinet.exe
+```
+
+Default local runtime assumptions:
+- app URL: `http://127.0.0.1:17880`
+- WebAuthn RP ID: `127.0.0.1`
+- WebAuthn origin: `http://127.0.0.1:17880`
+
+### First-run setup wizard
+If Cabinet is not configured yet:
+1. Complete the setup wizard.
+2. Choose **Auth Mode = local**.
+3. Finish config creation and launch.
+
+### Local sign-in behavior
+For exploratory local auth, the current sign-in form accepts:
+- any syntactically valid email address
+- any password with length `>= 7`
+
+Example exploratory credentials:
+- email: `explorer@cabinet.local`
+- password: `password123`
+
+These credentials are for local exploratory flow only. They are not a Clerk account requirement.
+
+## Getting authenticated sample data
+After local sign-in, use one of these paths:
+
+### Option A: starter/onboarding sample flow
+Use the built-in onboarding sample data path after first auth completion when the task needs a freshly bootstrapped dataset.
+
+### Option B: Showcase DB profile
+When the profile switcher is available, choose **Showcase DB** for deterministic demo content across inventory, wishlist, and related routes.
+
+Use Showcase DB when you need:
+- repeatable route traversal
+- visible seeded content for demos
+- stable exploratory screenshots/evidence
+
+## When to use Clerk instead
+Use **Clerk auth mode** only when the task explicitly needs:
+- Clerk route coverage (`/clerk/*`)
+- Clerk token/session bootstrap behavior
+- Clerk billing/plan/permissions verification
+- Clerk-specific auth UX or error handling
+
+## Clerk exploratory prerequisites
+Before attempting Clerk exploration, confirm all of the following:
+
+1. `VITE_CLERK_PUBLISHABLE_KEY` is set.
+2. The runtime/setup flow is configured for `clerk` auth mode.
+3. The browser origin you are using is allowed by Clerk.
+4. If passkeys are involved, the active domain/origin matches the configured passkey relying-party expectations.
+
+## Troubleshooting matrix
+| Symptom | Likely cause | What to do |
+| --- | --- | --- |
+| `Missing Clerk key` in setup wizard | Clerk mode selected without publishable key | Switch back to `local` for exploratory work, or provide `VITE_CLERK_PUBLISHABLE_KEY` before continuing |
+| `/clerk` route shows "No Publishable Key Found!" | `VITE_CLERK_PUBLISHABLE_KEY` not loaded | Create/update `.env`, restart the app, and confirm the key is visible to the UI runtime |
+| `This is an invalid domain.` during passkey sign-in | Current origin/domain is not passkey-enabled for the auth setup | Prefer local password/provider sign-in for exploration; if validating Clerk/passkeys specifically, align the active domain/origin with the configured relying-party/domain settings |
+| Passkey guidance says `Passkey sign-in is not available on this domain yet...` | Cabinet normalized a domain/origin mismatch into deterministic fallback guidance | Treat this as an auth-environment setup issue, not a generic UI failure; continue with password/provider sign-in or fix the domain/origin setup |
+| Clerk sign-in page loads but session/bootstrap fails | Incomplete Clerk env, origin, or token/bootstrap configuration | Re-check publishable key, allowed origins, and the exact runtime URL being used |
+| Exploratory route audit is blocked on auth ambiguity | Wrong auth mode chosen for the task | Reset to the default rule: local mode for routine exploration, Clerk only for Clerk-specific work |
+
+## Recommended exploratory decision rule
+- **Routine route audits / UI review:** use **local** auth mode
+- **Cloud/plan/entitlement verification:** use **Clerk**
+- **Passkey-specific validation:** confirm domain/origin first; otherwise do not treat passkey domain mismatch as a product-route blocker
+
+## Evidence to capture in exploratory reports
+Whenever auth affects a route review, record:
+- auth mode used (`local` or `clerk`)
+- runtime URL
+- whether setup wizard was completed or bypassed
+- active profile/sample-data path used (`starter` vs `Showcase DB`)
+- exact auth blocker text if any

--- a/openspec/specs/general/README.md
+++ b/openspec/specs/general/README.md
@@ -12,6 +12,7 @@ Contains cross-cutting platform, security, runtime, and UI foundation capabiliti
 - `documentation-governance` -> `openspec/specs/general/documentation-governance/spec.md`
 - `entitlements` -> `openspec/specs/general/entitlements/spec.md`
 - `errors` -> `openspec/specs/general/errors/spec.md`
+- `exploration-auth-setup` -> `openspec/specs/general/exploration-auth-setup/spec.md`
 - `future-hooks` -> `openspec/specs/general/future-hooks/spec.md`
 - `licensing` -> `openspec/specs/general/licensing/spec.md`
 - `logging` -> `openspec/specs/general/logging/spec.md`
@@ -53,6 +54,7 @@ Contains cross-cutting platform, security, runtime, and UI foundation capabiliti
 - `DOCUMENTATION-GOVERNANCE-*`
 - `ENTITLEMENTS-*`
 - `ERRORS-*`
+- `EXPLORATION-AUTH-SETUP-*`
 - `FUTURE-HOOKS-*`
 - `LICENSING-*`
 - `LOGGING-*`

--- a/openspec/specs/general/exploration-auth-setup/spec.md
+++ b/openspec/specs/general/exploration-auth-setup/spec.md
@@ -1,0 +1,39 @@
+## Purpose
+Define deterministic exploratory auth setup guidance for Cabinet so route audits and UI review do not stall on avoidable local-vs-Clerk ambiguity.
+
+## Requirements
+### Requirement EXPLORATION-AUTH-SETUP-001: Exploratory auth guidance SHALL define local mode as the default route-audit path
+Cabinet documentation SHALL define a deterministic default exploratory auth path that prefers local mode for routine route audits and general UI review.
+
+#### Scenario: Choose default exploratory auth mode
+- **GIVEN** a developer or reviewer is starting exploratory work not explicitly scoped to Clerk behavior
+- **WHEN** they consult the exploratory auth setup guide
+- **THEN** the guide MUST direct them to use local auth mode by default
+- **AND** the guide MUST include a runnable startup path and example local sign-in expectations
+
+### Requirement EXPLORATION-AUTH-SETUP-002: Exploratory auth guidance SHALL distinguish Clerk-specific prerequisites and blockers
+Cabinet documentation SHALL distinguish Clerk-only auth prerequisites from the default local exploratory path so Clerk configuration gaps are not confused with general product failures.
+
+#### Scenario: Resolve Clerk exploratory prerequisites
+- **GIVEN** exploratory work explicitly targets Clerk flows or permissions behavior
+- **WHEN** the reviewer follows the exploratory auth setup guide
+- **THEN** the guide MUST enumerate Clerk publishable-key and auth-mode prerequisites
+- **AND** the guide MUST identify common Clerk/domain/origin blockers with actionable next steps
+
+### Requirement EXPLORATION-AUTH-SETUP-003: Exploratory auth guidance SHALL document sample-data/bootstrap paths
+Cabinet documentation SHALL identify how exploratory sessions obtain authenticated sample data for route traversal.
+
+#### Scenario: Choose authenticated sample-data path
+- **GIVEN** a reviewer needs representative authenticated data after sign-in
+- **WHEN** they follow the exploratory auth setup guide
+- **THEN** the guide MUST identify the starter-data path and Showcase DB profile path
+- **AND** the guide MUST state when each path should be preferred
+
+### Requirement EXPLORATION-AUTH-SETUP-004: Exploratory auth guidance SHALL normalize passkey domain mismatch diagnosis
+Cabinet documentation SHALL describe passkey domain/origin mismatch as an auth-environment setup problem and SHALL direct exploratory users toward deterministic fallback behavior.
+
+#### Scenario: Diagnose passkey invalid-domain failure during exploration
+- **GIVEN** passkey sign-in fails with an invalid-domain, origin-mismatch, or relying-party mismatch symptom
+- **WHEN** the reviewer consults the exploratory auth setup guide
+- **THEN** the guide MUST describe the failure as an environment/domain setup issue rather than a generic route failure
+- **AND** the guide MUST direct the reviewer to continue with password/provider auth unless the task explicitly requires passkey validation

--- a/openspec/traceability.md
+++ b/openspec/traceability.md
@@ -480,6 +480,10 @@
 | AUTH-PERM-003 | openspec/specs/general/auth-permissions-test-matrix/spec.md | seeded multi-plan account matrix | `TestAuthPermissionsPlanCapabilityMatrix` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
 | AUTH-PERM-004 | openspec/specs/general/auth-permissions-test-matrix/spec.md | UI/API gate validation by account level | `TestAuthPermissionsFeatureGateMatrixFromCloudPlan` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
 | AUTH-PERM-005 | openspec/specs/general/auth-permissions-test-matrix/spec.md | effective permissions diagnostics | `TestAuthPermissionsEffectiveDiagnosticsContract` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
+| EXPLORATION-AUTH-SETUP-001 | openspec/specs/general/exploration-auth-setup/spec.md | default local exploratory auth path + runnable startup/sign-in guidance | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for local exploratory path | partial |
+| EXPLORATION-AUTH-SETUP-002 | openspec/specs/general/exploration-auth-setup/spec.md | Clerk prerequisite and blocker guidance for exploratory auth | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for Clerk setup blockers | partial |
+| EXPLORATION-AUTH-SETUP-003 | openspec/specs/general/exploration-auth-setup/spec.md | starter-data and Showcase DB bootstrap guidance for authenticated exploration | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for sample-data/bootstrap guidance | partial |
+| EXPLORATION-AUTH-SETUP-004 | openspec/specs/general/exploration-auth-setup/spec.md | passkey invalid-domain/origin mismatch diagnosis guidance | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for passkey mismatch troubleshooting | partial |
 
 
 


### PR DESCRIPTION
## Summary
- add an explicit exploratory auth setup guide for local-vs-Clerk work
- define a new EXPLORATION-AUTH-SETUP-* OpenSpec namespace for auth exploration guidance
- bind traceability entries for default local auth, Clerk prerequisites, sample-data/bootstrap, and passkey invalid-domain diagnosis
- link the guide from the main README

## Validation
- openspec validate --all --strict --no-interactive

## Issue
- refs #355