### PR TITLE
#355 Add local exploration auth launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ openspec validate --changes --strict --no-interactive
 
 Exploratory auth setup guide:
 - `docs/auth/exploration-auth-setup.md`
+- preferred local exploration launcher: `scripts/runtime/start-exploration-local.ps1`
 
 eBay provider settings are stored per profile via `PUT /api/profiles/{profileID}/settings`:
 - `ebay_bearer_token`

--- a/docs/auth/exploration-auth-setup.md
+++ b/docs/auth/exploration-auth-setup.md
@@ -14,7 +14,13 @@ Why:
 
 ## Local auth flow
 ### Startup
-From the repo root, start Cabinet with the project-local binary:
+From the repo root, preferred exploratory launcher:
+
+```powershell
+pwsh -NoLogo -NoProfile -File .\scripts\runtime\start-exploration-local.ps1 -Background
+```
+
+Manual fallback:
 
 ```powershell
 .\bin\cabinet.exe
@@ -32,7 +38,8 @@ If Cabinet is not configured yet:
 3. Finish config creation and launch.
 
 ### Local sign-in behavior
-For exploratory local auth, the current sign-in form accepts:
+For exploratory local auth, Cabinet does **not** require a pre-seeded local account.
+The current sign-in form accepts:
 - any syntactically valid email address
 - any password with length `>= 7`
 
@@ -40,13 +47,21 @@ Example exploratory credentials:
 - email: `explorer@cabinet.local`
 - password: `password123`
 
-These credentials are for local exploratory flow only. They are not a Clerk account requirement.
+Account-creation expectation:
+- treat the first successful local sign-in as the exploratory local account bootstrap path
+- do **not** block route audits waiting for a separately provisioned sample account
+- these credentials are local-only exploratory credentials, not a Clerk account requirement
 
 ## Getting authenticated sample data
 After local sign-in, use one of these paths:
 
 ### Option A: starter/onboarding sample flow
 Use the built-in onboarding sample data path after first auth completion when the task needs a freshly bootstrapped dataset.
+
+Concrete path:
+1. complete first local sign-in
+2. continue through the onboarding starter-data choice
+3. choose the starter/sample-data path so Cabinet seeds the profile via `POST /api/onboarding/sample-data`
 
 ### Option B: Showcase DB profile
 When the profile switcher is available, choose **Showcase DB** for deterministic demo content across inventory, wishlist, and related routes.
@@ -90,6 +105,8 @@ Before attempting Clerk exploration, confirm all of the following:
 Whenever auth affects a route review, record:
 - auth mode used (`local` or `clerk`)
 - runtime URL
+- startup path used (`start-exploration-local.ps1`, direct `bin\cabinet.exe`, or other explicit launcher)
 - whether setup wizard was completed or bypassed
+- whether the session used first-sign-in local bootstrap or an existing local account
 - active profile/sample-data path used (`starter` vs `Showcase DB`)
 - exact auth blocker text if any

--- a/openspec/specs/general/exploration-auth-setup/spec.md
+++ b/openspec/specs/general/exploration-auth-setup/spec.md
@@ -10,6 +10,7 @@ Cabinet documentation SHALL define a deterministic default exploratory auth path
 - **WHEN** they consult the exploratory auth setup guide
 - **THEN** the guide MUST direct them to use local auth mode by default
 - **AND** the guide MUST include a runnable startup path and example local sign-in expectations
+- **AND** the guide MUST identify the preferred repo-level local exploration launcher
 
 ### Requirement EXPLORATION-AUTH-SETUP-002: Exploratory auth guidance SHALL distinguish Clerk-specific prerequisites and blockers
 Cabinet documentation SHALL distinguish Clerk-only auth prerequisites from the default local exploratory path so Clerk configuration gaps are not confused with general product failures.
@@ -28,6 +29,17 @@ Cabinet documentation SHALL identify how exploratory sessions obtain authenticat
 - **WHEN** they follow the exploratory auth setup guide
 - **THEN** the guide MUST identify the starter-data path and Showcase DB profile path
 - **AND** the guide MUST state when each path should be preferred
+- **AND** the guide MUST identify the concrete first-sign-in starter-data path for local exploratory sessions
+
+### Requirement EXPLORATION-AUTH-SETUP-005: Exploratory auth guidance SHALL define local account bootstrap expectations
+Cabinet documentation SHALL define the expected local exploratory account behavior so reviewers do not wait for a separately provisioned account before route testing.
+
+#### Scenario: Bootstrap local exploratory account on first sign-in
+- **GIVEN** the reviewer is using local auth mode for exploratory work
+- **WHEN** they reach the sign-in form on a fresh local runtime
+- **THEN** the guide MUST state that no pre-seeded local account is required
+- **AND** the guide MUST state that first successful local sign-in is the expected bootstrap path
+- **AND** the guide MUST provide example local exploratory credentials that satisfy current validation constraints
 
 ### Requirement EXPLORATION-AUTH-SETUP-004: Exploratory auth guidance SHALL normalize passkey domain mismatch diagnosis
 Cabinet documentation SHALL describe passkey domain/origin mismatch as an auth-environment setup problem and SHALL direct exploratory users toward deterministic fallback behavior.

--- a/openspec/traceability.md
+++ b/openspec/traceability.md
@@ -480,10 +480,11 @@
 | AUTH-PERM-003 | openspec/specs/general/auth-permissions-test-matrix/spec.md | seeded multi-plan account matrix | `TestAuthPermissionsPlanCapabilityMatrix` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
 | AUTH-PERM-004 | openspec/specs/general/auth-permissions-test-matrix/spec.md | UI/API gate validation by account level | `TestAuthPermissionsFeatureGateMatrixFromCloudPlan` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
 | AUTH-PERM-005 | openspec/specs/general/auth-permissions-test-matrix/spec.md | effective permissions diagnostics | `TestAuthPermissionsEffectiveDiagnosticsContract` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
-| EXPLORATION-AUTH-SETUP-001 | openspec/specs/general/exploration-auth-setup/spec.md | default local exploratory auth path + runnable startup/sign-in guidance | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for local exploratory path | partial |
+| EXPLORATION-AUTH-SETUP-001 | openspec/specs/general/exploration-auth-setup/spec.md | default local exploratory auth path + runnable startup/sign-in guidance | docs/auth/exploration-auth-setup.md; scripts/runtime/start-exploration-local.ps1; planned: docs QA walkthrough for local exploratory path | partial |
 | EXPLORATION-AUTH-SETUP-002 | openspec/specs/general/exploration-auth-setup/spec.md | Clerk prerequisite and blocker guidance for exploratory auth | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for Clerk setup blockers | partial |
 | EXPLORATION-AUTH-SETUP-003 | openspec/specs/general/exploration-auth-setup/spec.md | starter-data and Showcase DB bootstrap guidance for authenticated exploration | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for sample-data/bootstrap guidance | partial |
 | EXPLORATION-AUTH-SETUP-004 | openspec/specs/general/exploration-auth-setup/spec.md | passkey invalid-domain/origin mismatch diagnosis guidance | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for passkey mismatch troubleshooting | partial |
+| EXPLORATION-AUTH-SETUP-005 | openspec/specs/general/exploration-auth-setup/spec.md | local exploratory account bootstrap expectations and example credentials | docs/auth/exploration-auth-setup.md; scripts/runtime/start-exploration-local.ps1; planned: docs QA walkthrough for first-sign-in local bootstrap expectations | partial |
 
 
 

--- a/scripts/runtime/start-exploration-local.ps1
+++ b/scripts/runtime/start-exploration-local.ps1
@@ -1,0 +1,67 @@
+param(
+  [switch]$Rebuild,
+  [switch]$FreshData,
+  [switch]$Background,
+  [int]$Port = 17880
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptDir)
+$exePath = Join-Path $repoRoot 'bin\cabinet.exe'
+$dataDir = Join-Path $repoRoot 'tmp\exploration-local\data'
+$profile = 'exploration-local'
+$instanceName = 'exploration-local'
+$url = "http://127.0.0.1:$Port"
+
+if ($Rebuild) {
+  Write-Host '[start-exploration-local] Rebuilding Cabinet first...'
+  & (Join-Path $repoRoot 'scripts\build-cabinet.ps1')
+}
+
+if (-not (Test-Path $exePath)) {
+  throw "Cabinet executable not found: $exePath`nRun .\scripts\build-cabinet.ps1 first or pass -Rebuild."
+}
+
+if ($FreshData -and (Test-Path $dataDir)) {
+  Write-Host "[start-exploration-local] Removing existing exploration-local data dir: $dataDir"
+  Remove-Item -Recurse -Force $dataDir
+}
+
+New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+
+$existing = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+if ($existing) {
+  $pids = @($existing | Select-Object -ExpandProperty OwningProcess -Unique)
+  throw "Port $Port is already in use by PID(s): $($pids -join ', '). Stop the existing listener first."
+}
+
+$args = @(
+  '--allow-parallel',
+  '--no-open-browser',
+  '--data-dir', $dataDir,
+  '--profile', $profile,
+  '--instance-name', $instanceName,
+  '--port', $Port
+)
+
+Write-Host "[start-exploration-local] Executable: $exePath"
+Write-Host "[start-exploration-local] Data dir:   $dataDir"
+Write-Host "[start-exploration-local] Port:       $Port"
+Write-Host "[start-exploration-local] URL:        $url"
+Write-Host '[start-exploration-local] Expected first-run path:'
+Write-Host '  1. Complete setup wizard'
+Write-Host '  2. Choose Auth Mode = local'
+Write-Host '  3. Sign in with any valid email + password length >= 7'
+Write-Host '  4. Use starter data or Showcase DB for authenticated exploration'
+
+if ($Background) {
+  $proc = Start-Process -FilePath $exePath -ArgumentList $args -WorkingDirectory $repoRoot -PassThru
+  Start-Sleep -Seconds 2
+  Write-Host "[start-exploration-local] Started in background. PID: $($proc.Id)"
+  Write-Host "[start-exploration-local] Verify with: Invoke-WebRequest -UseBasicParsing $url/"
+  exit 0
+}
+
+& $exePath @args


### PR DESCRIPTION
## Summary
- add scripts/runtime/start-exploration-local.ps1 as the preferred local exploratory auth launcher
- update the exploratory auth guide with explicit first-sign-in local bootstrap expectations and concrete starter-data path
- extend EXPLORATION-AUTH-SETUP-* coverage/traceability for the launcher and no-preseeded-account contract

## Validation
- openspec validate --all --strict --no-interactive
- start-exploration-local.ps1 smoke: reached http://127.0.0.1:17880/healthz = 200 ok and shut down cleanly

## Issue
- refs #355