### PR TITLE
#355 Add Clerk exploration auth launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ openspec validate --changes --strict --no-interactive
 Exploratory auth setup guide:
 - `docs/auth/exploration-auth-setup.md`
 - preferred local exploration launcher: `scripts/runtime/start-exploration-local.ps1`
+- preferred Clerk exploration launcher: `scripts/runtime/start-exploration-clerk.ps1`
 
 eBay provider settings are stored per profile via `PUT /api/profiles/{profileID}/settings`:
 - `ebay_bearer_token`

--- a/docs/auth/exploration-auth-setup.md
+++ b/docs/auth/exploration-auth-setup.md
@@ -86,11 +86,29 @@ Before attempting Clerk exploration, confirm all of the following:
 3. The browser origin you are using is allowed by Clerk.
 4. If passkeys are involved, the active domain/origin matches the configured passkey relying-party expectations.
 
+### Preferred Clerk startup example
+From the repo root:
+
+```powershell
+pwsh -NoLogo -NoProfile -File .\scripts\runtime\start-exploration-clerk.ps1 -ClerkPublishableKey 'pk_test_your_key' -Rebuild -Background
+```
+
+What this launcher does:
+- exports `VITE_CLERK_PUBLISHABLE_KEY` for the build/runtime process
+- exports `CABINET_AUTH_IDENTITY_MODE=clerk`
+- starts a dedicated Clerk exploration profile on port `17883`
+- gives a deterministic verification target: `GET /api/auth/provider-options`
+
+Expected verification after launch:
+- `http://127.0.0.1:17883/healthz` returns `200 ok`
+- `http://127.0.0.1:17883/api/auth/provider-options` returns `identity_mode = "clerk"`
+- first-run flows should be completed with **Auth Mode = clerk**
+
 ## Troubleshooting matrix
 | Symptom | Likely cause | What to do |
 | --- | --- | --- |
 | `Missing Clerk key` in setup wizard | Clerk mode selected without publishable key | Switch back to `local` for exploratory work, or provide `VITE_CLERK_PUBLISHABLE_KEY` before continuing |
-| `/clerk` route shows "No Publishable Key Found!" | `VITE_CLERK_PUBLISHABLE_KEY` not loaded | Create/update `.env`, restart the app, and confirm the key is visible to the UI runtime |
+| `/clerk` route shows "No Publishable Key Found!" | `VITE_CLERK_PUBLISHABLE_KEY` not loaded | Create/update `.env`, rebuild/restart the app, or use `start-exploration-clerk.ps1`; then confirm `/api/auth/provider-options` reports `identity_mode = "clerk"` |
 | `This is an invalid domain.` during passkey sign-in | Current origin/domain is not passkey-enabled for the auth setup | Prefer local password/provider sign-in for exploration; if validating Clerk/passkeys specifically, align the active domain/origin with the configured relying-party/domain settings |
 | Passkey guidance says `Passkey sign-in is not available on this domain yet...` | Cabinet normalized a domain/origin mismatch into deterministic fallback guidance | Treat this as an auth-environment setup issue, not a generic UI failure; continue with password/provider sign-in or fix the domain/origin setup |
 | Clerk sign-in page loads but session/bootstrap fails | Incomplete Clerk env, origin, or token/bootstrap configuration | Re-check publishable key, allowed origins, and the exact runtime URL being used |
@@ -105,7 +123,7 @@ Before attempting Clerk exploration, confirm all of the following:
 Whenever auth affects a route review, record:
 - auth mode used (`local` or `clerk`)
 - runtime URL
-- startup path used (`start-exploration-local.ps1`, direct `bin\cabinet.exe`, or other explicit launcher)
+- startup path used (`start-exploration-local.ps1`, `start-exploration-clerk.ps1`, direct `bin\cabinet.exe`, or other explicit launcher)
 - whether setup wizard was completed or bypassed
 - whether the session used first-sign-in local bootstrap or an existing local account
 - active profile/sample-data path used (`starter` vs `Showcase DB`)

--- a/openspec/specs/general/exploration-auth-setup/spec.md
+++ b/openspec/specs/general/exploration-auth-setup/spec.md
@@ -20,6 +20,7 @@ Cabinet documentation SHALL distinguish Clerk-only auth prerequisites from the d
 - **WHEN** the reviewer follows the exploratory auth setup guide
 - **THEN** the guide MUST enumerate Clerk publishable-key and auth-mode prerequisites
 - **AND** the guide MUST identify common Clerk/domain/origin blockers with actionable next steps
+- **AND** the guide MUST include a concrete repo-level Clerk startup example and verification target
 
 ### Requirement EXPLORATION-AUTH-SETUP-003: Exploratory auth guidance SHALL document sample-data/bootstrap paths
 Cabinet documentation SHALL identify how exploratory sessions obtain authenticated sample data for route traversal.
@@ -40,6 +41,16 @@ Cabinet documentation SHALL define the expected local exploratory account behavi
 - **THEN** the guide MUST state that no pre-seeded local account is required
 - **AND** the guide MUST state that first successful local sign-in is the expected bootstrap path
 - **AND** the guide MUST provide example local exploratory credentials that satisfy current validation constraints
+
+### Requirement EXPLORATION-AUTH-SETUP-006: Exploratory auth guidance SHALL provide a repo-level Clerk launcher contract
+Cabinet documentation and scripts SHALL provide a deterministic Clerk exploration launcher so reviewers can start a Clerk-oriented runtime with explicit env expectations and verification targets.
+
+#### Scenario: Start Clerk exploration runtime from repo launcher
+- **GIVEN** the reviewer needs Clerk-specific exploratory auth coverage
+- **WHEN** they run the documented Clerk exploration launcher with a publishable key
+- **THEN** the launcher MUST set Clerk-specific env expectations for the child build/runtime process
+- **AND** the guide MUST identify the expected runtime URL and verification endpoints
+- **AND** the launcher MUST fail fast with actionable guidance when the Clerk publishable key is missing
 
 ### Requirement EXPLORATION-AUTH-SETUP-004: Exploratory auth guidance SHALL normalize passkey domain mismatch diagnosis
 Cabinet documentation SHALL describe passkey domain/origin mismatch as an auth-environment setup problem and SHALL direct exploratory users toward deterministic fallback behavior.

--- a/openspec/traceability.md
+++ b/openspec/traceability.md
@@ -481,10 +481,11 @@
 | AUTH-PERM-004 | openspec/specs/general/auth-permissions-test-matrix/spec.md | UI/API gate validation by account level | `TestAuthPermissionsFeatureGateMatrixFromCloudPlan` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
 | AUTH-PERM-005 | openspec/specs/general/auth-permissions-test-matrix/spec.md | effective permissions diagnostics | `TestAuthPermissionsEffectiveDiagnosticsContract` (`internal/app/auth_permissions_matrix_api_test.go`) | implemented |
 | EXPLORATION-AUTH-SETUP-001 | openspec/specs/general/exploration-auth-setup/spec.md | default local exploratory auth path + runnable startup/sign-in guidance | docs/auth/exploration-auth-setup.md; scripts/runtime/start-exploration-local.ps1; planned: docs QA walkthrough for local exploratory path | partial |
-| EXPLORATION-AUTH-SETUP-002 | openspec/specs/general/exploration-auth-setup/spec.md | Clerk prerequisite and blocker guidance for exploratory auth | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for Clerk setup blockers | partial |
+| EXPLORATION-AUTH-SETUP-002 | openspec/specs/general/exploration-auth-setup/spec.md | Clerk prerequisite and blocker guidance for exploratory auth | docs/auth/exploration-auth-setup.md; scripts/runtime/start-exploration-clerk.ps1; planned: docs QA walkthrough for Clerk setup blockers | partial |
 | EXPLORATION-AUTH-SETUP-003 | openspec/specs/general/exploration-auth-setup/spec.md | starter-data and Showcase DB bootstrap guidance for authenticated exploration | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for sample-data/bootstrap guidance | partial |
 | EXPLORATION-AUTH-SETUP-004 | openspec/specs/general/exploration-auth-setup/spec.md | passkey invalid-domain/origin mismatch diagnosis guidance | docs/auth/exploration-auth-setup.md; planned: docs QA walkthrough for passkey mismatch troubleshooting | partial |
 | EXPLORATION-AUTH-SETUP-005 | openspec/specs/general/exploration-auth-setup/spec.md | local exploratory account bootstrap expectations and example credentials | docs/auth/exploration-auth-setup.md; scripts/runtime/start-exploration-local.ps1; planned: docs QA walkthrough for first-sign-in local bootstrap expectations | partial |
+| EXPLORATION-AUTH-SETUP-006 | openspec/specs/general/exploration-auth-setup/spec.md | repo-level Clerk exploration launcher contract with env preflight and verification targets | docs/auth/exploration-auth-setup.md; scripts/runtime/start-exploration-clerk.ps1; planned: docs QA walkthrough for Clerk launcher contract | partial |
 
 
 

--- a/scripts/runtime/start-exploration-clerk.ps1
+++ b/scripts/runtime/start-exploration-clerk.ps1
@@ -1,0 +1,91 @@
+param(
+  [string]$ClerkPublishableKey,
+  [switch]$Rebuild,
+  [switch]$FreshData,
+  [switch]$Background,
+  [int]$Port = 17883
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptDir)
+$exePath = Join-Path $repoRoot 'bin\cabinet.exe'
+$dataDir = Join-Path $repoRoot 'tmp\exploration-clerk\data'
+$profile = 'exploration-clerk'
+$instanceName = 'exploration-clerk'
+$url = "http://127.0.0.1:$Port"
+
+if ([string]::IsNullOrWhiteSpace($ClerkPublishableKey)) {
+  $ClerkPublishableKey = $env:VITE_CLERK_PUBLISHABLE_KEY
+}
+
+if ([string]::IsNullOrWhiteSpace($ClerkPublishableKey)) {
+  throw 'Clerk publishable key is required. Pass -ClerkPublishableKey or set VITE_CLERK_PUBLISHABLE_KEY before launching Clerk exploration.'
+}
+
+$previousClerkKey = $env:VITE_CLERK_PUBLISHABLE_KEY
+$previousIdentityMode = $env:CABINET_AUTH_IDENTITY_MODE
+
+$env:VITE_CLERK_PUBLISHABLE_KEY = $ClerkPublishableKey
+$env:CABINET_AUTH_IDENTITY_MODE = 'clerk'
+
+try {
+  if ($Rebuild) {
+    Write-Host '[start-exploration-clerk] Rebuilding Cabinet first...'
+    & (Join-Path $repoRoot 'scripts\build-cabinet.ps1')
+  }
+
+  if (-not (Test-Path $exePath)) {
+    throw "Cabinet executable not found: $exePath`nRun .\scripts\build-cabinet.ps1 first or pass -Rebuild."
+  }
+
+  if ($FreshData -and (Test-Path $dataDir)) {
+    Write-Host "[start-exploration-clerk] Removing existing exploration-clerk data dir: $dataDir"
+    Remove-Item -Recurse -Force $dataDir
+  }
+
+  New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+
+  $existing = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+  if ($existing) {
+    $pids = @($existing | Select-Object -ExpandProperty OwningProcess -Unique)
+    throw "Port $Port is already in use by PID(s): $($pids -join ', '). Stop the existing listener first."
+  }
+
+  $args = @(
+    '--allow-parallel',
+    '--no-open-browser',
+    '--data-dir', $dataDir,
+    '--profile', $profile,
+    '--instance-name', $instanceName,
+    '--port', $Port
+  )
+
+  Write-Host "[start-exploration-clerk] Executable: $exePath"
+  Write-Host "[start-exploration-clerk] Data dir:   $dataDir"
+  Write-Host "[start-exploration-clerk] Port:       $Port"
+  Write-Host "[start-exploration-clerk] URL:        $url"
+  Write-Host '[start-exploration-clerk] Effective auth env:'
+  Write-Host '  CABINET_AUTH_IDENTITY_MODE=clerk'
+  Write-Host ('  VITE_CLERK_PUBLISHABLE_KEY=' + $ClerkPublishableKey)
+  Write-Host '[start-exploration-clerk] Expected Clerk exploration path:'
+  Write-Host '  1. Use a Clerk-allowed origin for the runtime URL'
+  Write-Host '  2. Complete setup wizard with Auth Mode = clerk when first-run config is required'
+  Write-Host '  3. Use /clerk/sign-in for Clerk route validation'
+  Write-Host '  4. Treat invalid-domain/passkey failures as auth-environment setup issues first'
+
+  if ($Background) {
+    $proc = Start-Process -FilePath $exePath -ArgumentList $args -WorkingDirectory $repoRoot -PassThru
+    Start-Sleep -Seconds 2
+    Write-Host "[start-exploration-clerk] Started in background. PID: $($proc.Id)"
+    Write-Host "[start-exploration-clerk] Verify with: Invoke-WebRequest -UseBasicParsing $url/api/auth/provider-options"
+    exit 0
+  }
+
+  & $exePath @args
+}
+finally {
+  $env:VITE_CLERK_PUBLISHABLE_KEY = $previousClerkKey
+  $env:CABINET_AUTH_IDENTITY_MODE = $previousIdentityMode
+}


### PR DESCRIPTION
## Summary
- add scripts/runtime/start-exploration-clerk.ps1 as the repo-level Clerk exploration launcher
- update the exploratory auth guide with a concrete Clerk startup example and verification targets
- extend EXPLORATION-AUTH-SETUP-* coverage/traceability with the Clerk launcher contract

## Validation
- openspec validate --all --strict --no-interactive
- missing-key preflight fails fast with actionable guidance
- start-exploration-clerk.ps1 -ClerkPublishableKey pk_test_cabinet_exploration -Rebuild -Background smoke: http://127.0.0.1:17883/healthz = 200, /api/auth/provider-options => identity_mode=clerk, clerk_configured=true

## Issue
- refs #355