### PR TITLE
#445 Fix chats workspace empty-state regression fixture drift

### DIFF
--- a/ui.web/cypress/e2e/chats/chats-workspace/spec.cy.ts
+++ b/ui.web/cypress/e2e/chats/chats-workspace/spec.cy.ts
@@ -1,7 +1,7 @@
 describe('chats/chats-workspace', () => {
   function openChats() {
     cy.e2eReset()
-    cy.e2eBootstrap()
+    cy.e2eBootstrap({ minimalProfile: true })
     cy.e2eSetSetupState('present')
     cy.useBootstrappedProfile('e2e-profile-001', 'E2E Local', { path: '/chats/' })
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/chats\/?$/)


### PR DESCRIPTION
## Summary
Fix the chats workspace empty-state regression test so it exercises a genuinely empty chat profile.

The issue was test-fixture drift, not a UI rendering bug:
- `openChats()` expected an empty thread list
- but the default E2E bootstrap fixture seeds `E2E Thread`
- so `CHATS-WORKSPACE-001` was asserting impossible state on the seeded profile

## Change
- switch the chats workspace spec bootstrap to `minimalProfile: true`

## Validation
- `openspec validate --all --strict --no-interactive` ✅
- `npx cypress run --browser chrome --config-file .\cypress.config.runtime.cjs --config baseUrl=http://127.0.0.1:17882 --spec cypress/e2e/chats/chats-workspace/spec.cy.ts` ✅

## Related
- fixes #445