### PR TITLE
#457 Restore dashboard home English copy contracts

### DIFF
--- a/openspec/changes/restore-dashboard-home-copy-contracts/.openspec.yaml
+++ b/openspec/changes/restore-dashboard-home-copy-contracts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/restore-dashboard-home-copy-contracts/proposal.md
+++ b/openspec/changes/restore-dashboard-home-copy-contracts/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+The broader regression chain surfaced dashboard home-screen failures that turned out to be a real product-side locale bug. The English pages bundle was missing the dashboard keys used by the current home screen, causing raw `dashboard.*` translation keys to leak into the UI and break the dashboard shell copy contract.
+
+## What Changes
+
+- Restore the missing English dashboard pages translations.
+- Keep the dashboard actionable/loading/error/recent-items shell aligned with the current UI contract.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `dashboard-home-copy`: the English dashboard home shell SHALL render the expected actionable/loading/error/recent-items copy instead of raw translation keys.
+
+## Impact
+
+- Affected product file: `ui.web/src/locales/en/pages.json`
+- Affected test: `ui.web/cypress/e2e/dashboard/ui-screen-home/spec.cy.ts`
+- Related issues: `#457`

--- a/openspec/changes/restore-dashboard-home-copy-contracts/specs/dashboard-home-copy/spec.md
+++ b/openspec/changes/restore-dashboard-home-copy-contracts/specs/dashboard-home-copy/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard home English copy SHALL resolve current shell translations
+Cabinet SHALL render the dashboard home shell using resolved English dashboard translations for the current actionable, loading, empty, and error states.
+
+#### Scenario: Dashboard home renders resolved English shell copy
+- **GIVEN** the dashboard home screen renders in the English locale
+- **WHEN** it shows actionable, loading, empty, recent-items, or unavailable states
+- **THEN** it SHALL render resolved English copy rather than raw `dashboard.*` translation keys

--- a/openspec/changes/restore-dashboard-home-copy-contracts/tasks.md
+++ b/openspec/changes/restore-dashboard-home-copy-contracts/tasks.md
@@ -1,0 +1,13 @@
+## 1. Reproduce and isolate
+
+- [x] 1.1 Reproduce the dashboard home copy failures on a fresh 17882 branch build.
+- [x] 1.2 Confirm the UI is leaking raw translation keys because the English dashboard locale entries are missing.
+
+## 2. Product fix
+
+- [x] 2.1 Restore the missing English dashboard locale keys used by the current home screen.
+
+## 3. Validation
+
+- [x] 3.1 Re-run `dashboard/ui-screen-home/spec.cy.ts` on a fresh 17882 branch build.
+- [ ] 3.2 Feed the result back into the broader regression gate.

--- a/ui.web/src/locales/en/pages.json
+++ b/ui.web/src/locales/en/pages.json
@@ -1,7 +1,27 @@
 {
   "dashboard": {
     "title": "Home",
-    "subtitle": "What needs action now in your collection."
+    "subtitle": "What needs action now in your collection.",
+    "refresh": "Refresh",
+    "refreshing": "Refreshing...",
+    "unavailable": "Dashboard unavailable",
+    "attentionTitle": "What needs attention now",
+    "attentionDescription": "New discoveries, watchlist hits, and price changes.",
+    "loadingActivity": "Loading activity signals...",
+    "pending": "pending",
+    "open": "Open",
+    "noActionItems": "No action items right now.",
+    "recentlyAdded": "Recently added",
+    "recentlyAddedDescription": "Items recently added to inventory.",
+    "loadingItems": "Loading items...",
+    "noRecentlyAdded": "No recently added items yet.",
+    "openInventory": "Open inventory",
+    "metrics": {
+      "inventoryItems": "Inventory Items",
+      "inventoryUnits": "Inventory Units",
+      "wishlistHits": "Wishlist Hits",
+      "estimatedValue": "Estimated Value"
+    }
   },
   "inventory": {
     "title": "Inventory"


### PR DESCRIPTION
## Summary
Restore the missing English dashboard home translations so the Home shell renders resolved copy instead of raw `dashboard.*` keys.

This is a product-side fix, not just a test update. The broader regression chain surfaced that the current dashboard component expects English `pages.dashboard.*` keys which were missing from `ui.web/src/locales/en/pages.json`.

## Validation
- `openspec validate --all --strict --no-interactive` ✅
- fresh 17882 branch-build rerun:
  - `cypress/e2e/dashboard/ui-screen-home/spec.cy.ts` ✅ 5/5

Artifacts:
- `.logs/issue-457-home-20260403-0935/home-rerun.log`
- matching runtime logs in the same directory

## Related
- fixes #457