### PR TITLE
#453 test(routes): align parity and components specs

### DIFF
--- a/openspec/specs/general/ui-data-contract-parity/spec.md
+++ b/openspec/specs/general/ui-data-contract-parity/spec.md
@@ -6,7 +6,7 @@ Define strict UI-to-API parity requirements so every production screen is fully 
 Each top-level authenticated screen SHALL declare the APIs it depends on for read and mutation flows.
 
 #### Scenario: Screen parity review
-- **GIVEN** an authenticated local profile session is active and the user opens `/`, `/inventory`, and `/integrations`
+- **GIVEN** an authenticated local profile session is active and the user opens `/dashboard`, `/inventory`, and `/integrations`
 - **WHEN** each route initializes
 - **THEN** dashboard SHALL call `GET /api/dashboard`, inventory SHALL call `GET /api/items*`, and integrations SHALL call `GET /api/profiles/active` + `GET /api/providers/registry` + `GET /api/profiles/{id}/settings`
 
@@ -14,7 +14,7 @@ Each top-level authenticated screen SHALL declare the APIs it depends on for rea
 For each API-backed screen section, UI SHALL define deterministic behavior for loading, empty, error, and ready states.
 
 #### Scenario: API error on screen load
-- **GIVEN** dashboard route `/` is opened with an authenticated local profile
+- **GIVEN** dashboard route `/dashboard` is opened with an authenticated local profile
 - **WHEN** `GET /api/dashboard` returns `500` then succeeds on retry with `200`
 - **THEN** UI SHALL show `Dashboard unavailable` + retry action on failure
 - **AND** retry SHALL return to ready metric cards without routing to the global fatal error page
@@ -23,9 +23,9 @@ For each API-backed screen section, UI SHALL define deterministic behavior for l
 Each mutation control SHALL declare request payload contract and expected success/failure rendering behavior.
 
 #### Scenario: Mutation failure handling
-- **GIVEN** authenticated user is on `/settings` profile form with valid editable values
+- **GIVEN** authenticated user is on `/settings/profile` form with valid editable values
 - **WHEN** `PUT /api/profiles/{id}/settings` returns `500`
-- **THEN** route context SHALL remain on `/settings`
+- **THEN** route context SHALL remain on `/settings/profile`
 - **AND** inline error feedback SHALL render with actionable retry/edit context
 
 ### Requirement UI-DATA-CONTRACT-PARITY-004: Endpoint parity SHALL include E2E verification mapping

--- a/ui.web/cypress/e2e/general/ui-data-contract-parity/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-data-contract-parity/spec.cy.ts
@@ -1,5 +1,5 @@
 describe('general/ui-data-contract-parity', () => {
-  function bootstrapAndSignIn(path = '/') {
+  function bootstrapAndSignIn(path = '/dashboard') {
     cy.e2eReset()
     cy.e2eBootstrap().then((bootstrap) => {
       cy.useBootstrappedProfile(bootstrap.profile_id, bootstrap.profile_name, { path })
@@ -59,7 +59,7 @@ describe('general/ui-data-contract-parity', () => {
       body: { settings: {} },
     }).as('settings')
 
-    bootstrapAndSignIn('/')
+    bootstrapAndSignIn('/dashboard')
     cy.wait('@dashboard')
     cy.contains('Home').should('be.visible')
 
@@ -99,7 +99,7 @@ describe('general/ui-data-contract-parity', () => {
       })
     }).as('dashboardRetry')
 
-    bootstrapAndSignIn('/')
+    bootstrapAndSignIn('/dashboard')
     cy.wait('@dashboardRetry')
     cy.contains('Dashboard unavailable').should('be.visible')
     cy.contains('button', 'Retry').click()
@@ -115,7 +115,7 @@ describe('general/ui-data-contract-parity', () => {
       body: { error: 'profile_settings_save_500' },
     }).as('saveProfileSettings')
 
-    bootstrapAndSignIn('/settings/')
+    bootstrapAndSignIn('/settings/profile')
     cy.get('input[placeholder="cabinet-user"]').clear().type('parity-user')
     cy.contains('button', 'Update profile').click()
     cy.wait('@saveProfileSettings')

--- a/ui.web/cypress/e2e/general/ui-foundation-components/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-foundation-components/spec.cy.ts
@@ -1,5 +1,5 @@
 describe('general/ui-foundation-components', () => {
-  function bootstrapAndSignIn(path = '/settings/') {
+  function bootstrapAndSignIn(path = '/settings/profile') {
     cy.e2eReset()
     cy.e2eBootstrap().then((bootstrap) => {
       cy.useBootstrappedProfile(bootstrap.profile_id, bootstrap.profile_name, { path })
@@ -7,7 +7,7 @@ describe('general/ui-foundation-components', () => {
   }
 
   it('UI-FOUNDATION-COMPONENTS-001 exposes explicit foundation component contract surface on settings profile', () => {
-    bootstrapAndSignIn('/settings/')
+    bootstrapAndSignIn('/settings/profile')
     cy.get('main').within(() => {
       cy.contains('h1, h2, h3, [data-slot="card-title"]', /^\s*Profile\s*$/).should(
         'be.visible'
@@ -66,7 +66,7 @@ describe('general/ui-foundation-components', () => {
       req.reply({ delay: 1200, statusCode: 200, body: req.body })
     }).as('saveSettings')
 
-    bootstrapAndSignIn('/settings/')
+    bootstrapAndSignIn('/settings/profile')
     cy.get('input[placeholder="cabinet-user"]').clear().type(targetUsername)
     cy.contains('button', 'Update profile').dblclick()
     cy.contains('button', 'Update profile').should('be.disabled')
@@ -75,7 +75,7 @@ describe('general/ui-foundation-components', () => {
   })
 
   it('UI-FOUNDATION-COMPONENTS-004 enforces keyboard dialog open/escape-close with trigger focus restore', () => {
-    bootstrapAndSignIn('/settings/')
+    bootstrapAndSignIn('/settings/profile')
     cy.get('[aria-label="Open theme settings"]').as('themeTrigger').click()
     cy.contains('Theme Settings').should('be.visible')
     cy.focused().type('{esc}')
@@ -84,7 +84,7 @@ describe('general/ui-foundation-components', () => {
   })
 
   it('UI-FOUNDATION-COMPONENTS-005 links component contract testability artifacts to executable coverage', () => {
-    bootstrapAndSignIn('/settings/')
+    bootstrapAndSignIn('/settings/profile')
     cy.contains('button', 'Update profile').should('be.visible')
     cy.get('[aria-label="Open theme settings"]').should('be.visible')
     cy.visit('/users')


### PR DESCRIPTION
## Summary
- align ui-data-contract-parity to canonical Cabinet home/settings routes
- update ui-foundation-components settings bootstrap to the canonical `/settings/profile` surface
- keep OpenSpec route wording consistent with the executable Cypress coverage

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-data-contract-parity/spec.cy.ts -Browser chrome -RequireE2EHooks -RuntimeExecutablePath bin\cabinet.exe
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-foundation-components/spec.cy.ts -Browser chrome -RequireE2EHooks -RuntimeExecutablePath bin\cabinet.exe

## Follow-up before merge
- run local pipeline on local dev instance
- deploy locally
- run full regression suite / relevant broader gate
- comment validation/deploy report before merge