### PR TITLE
#446 test(routes): align authenticated home shell expectations

### DIFF
--- a/openspec/specs/general/setup-wizard-first-run/spec.md
+++ b/openspec/specs/general/setup-wizard-first-run/spec.md
@@ -334,7 +334,7 @@ Completion step MUST show resolved runtime/location summary and explicit post-se
 
 #### Scenario: Authenticated home
 - **GIVEN** user is authenticated and app shell is loaded
-- **WHEN** home/dashboard renders
+- **WHEN** canonical authenticated dashboard renders
 - **THEN** setup starter controls (`Start Setup`, `Import Existing Collection`, `Use Sample Data`, etc.) MUST NOT render in home card region
 
 ## Use-Case IDs and E2E Mapping
@@ -344,7 +344,7 @@ Completion step MUST show resolved runtime/location summary and explicit post-se
 | UC-SW-02 | Existing config startup | Wizard skipped; normal auth/shell loads | planned: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `setup-wizard-existing-config-skip` |
 | UC-SW-03 | Step navigation | Progress + prev/next/save controls behave deterministically | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-03 setup-wizard-step-controls preserves step form state while navigating previous/next` |
 | UC-SW-04 | Completion state | Config-complete screen shows start action and no registration template copy | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-04 setup-wizard-completion-state shows runtime and storage details with start action` |
-| UC-SW-05 | Dashboard guard | Home contains no embedded setup starter card | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-05 setup-wizard-not-in-home-shell keeps starter setup controls out of authenticated home` |
+| UC-SW-05 | Dashboard guard | Dashboard contains no embedded setup starter card | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-05 setup-wizard-not-in-home-shell keeps starter setup controls out of authenticated home` |
 | UC-SW-06 | Progress template parity | Step header shows `STEP X OF N` + progress %, footer actions match step state | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-06 setup-wizard-progress-template shows step header, percentage, and footer actions` |
 | UC-SW-07 | Final complete transition | `Complete` transitions to `Config complete` + `Start App` action | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-07 setup-wizard-complete-to-launch transitions to config complete with start action` |
 | UC-SW-08 | Initial config schema write | `cabinet.json` contains deterministic required sections/fields after completion | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-08 setup-wizard-config-schema-write persists deterministic cabinet.json payload`; `internal/app/runtime_setup_api_test.go` `TestRuntimeSetupStatusAndCompleteContract` |
@@ -390,3 +390,4 @@ UI test harness MUST provide deterministic setup handling so route tests are not
 - **GIVEN** test suite explicitly validates first-run behavior
 - **WHEN** setup gate is active
 - **THEN** harness MUST complete setup flow via deterministic helper before continuing route-level assertions
+

--- a/ui.web/cypress/e2e/general/language-switch-ui/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/language-switch-ui/spec.cy.ts
@@ -2,11 +2,11 @@ describe('language-switch-ui', () => {
   function signInToHome() {
     cy.clearCookies()
     cy.clearLocalStorage()
-    cy.visit('/sign-in?redirect=%2F')
+    cy.visit('/sign-in?redirect=%2Fdashboard')
     cy.get('input[name="email"]').clear().type('e2e-theme-i18n@example.com')
     cy.get('input[name="password"]').clear().type('password123')
     cy.contains('button', 'Sign in').click()
-    cy.location('pathname', { timeout: 15000 }).should('eq', '/')
+    cy.location('pathname', { timeout: 15000 }).should('eq', '/dashboard')
   }
 
   function switchLanguage(code: 'en' | 'zh' | 'ja') {

--- a/ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts
@@ -616,7 +616,7 @@ describe('SETUP-WIZ', () => {
     cy.contains('button', 'Sign in').click();
     cy.location('pathname', { timeout: 15000 }).should(
       'match',
-      /^(\/|\/_authenticated\/?)$/
+      /^\\/dashboard\\/?$/
     );
     cy.contains('Home').should('be.visible');
 
@@ -627,3 +627,4 @@ describe('SETUP-WIZ', () => {
     cy.contains('Use Sample Data').should('not.exist');
   });
 });
+

--- a/ui.web/cypress/e2e/general/ui-theme-selection/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-theme-selection/spec.cy.ts
@@ -7,11 +7,11 @@ describe('ui-theme-selection', () => {
   }
 
   function signInToHome() {
-    cy.visit('/sign-in?redirect=%2F')
+    cy.visit('/sign-in?redirect=%2Fdashboard')
     cy.get('input[name="email"]').clear().type('e2e-theme@example.com')
     cy.get('input[name="password"]').clear().type('password123')
     cy.contains('button', 'Sign in').click()
-    cy.location('pathname', { timeout: 15000 }).should('eq', '/')
+    cy.location('pathname', { timeout: 15000 }).should('eq', '/dashboard')
   }
 
   beforeEach(() => {
@@ -54,7 +54,7 @@ describe('ui-theme-selection', () => {
   })
 
   it('UI-THEME-SELECTION-003 updates layout density live and persists preference after navigation', () => {
-    cy.location('pathname').should('eq', '/')
+    cy.location('pathname').should('eq', '/dashboard')
 
     cy.get('button[aria-label="Open theme settings"]').click()
     cy.get('[aria-label="Select compact"]').click()
@@ -63,7 +63,7 @@ describe('ui-theme-selection', () => {
     cy.get('[aria-label="Select full layout"]').click()
     cy.getCookie('layout_collapsible').its('value').should('eq', 'offcanvas')
 
-    cy.location('pathname').should('eq', '/')
+    cy.location('pathname').should('eq', '/dashboard')
     cy.visit('/inventory')
     cy.location('pathname').should('match', /^\/inventory\/?$/)
     cy.getCookie('layout_collapsible').its('value').should('eq', 'offcanvas')


### PR DESCRIPTION
## Summary
- align authenticated home-shell route expectations in language/theme/setup specs to canonical `/dashboard`
- update setup-wizard home-shell wording to reflect the canonical authenticated dashboard destination
- keep targeted route assertions consistent with current sign-in redirect behavior

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/language-switch-ui/spec.cy.ts -Browser chrome -RequireE2EHooks -RuntimeExecutablePath bin\cabinet.exe
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-theme-selection/spec.cy.ts -Browser chrome -RequireE2EHooks -RuntimeExecutablePath bin\cabinet.exe
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/setup-wizard-first-run/spec.cy.ts -Browser chrome -RequireE2EHooks -RuntimeExecutablePath bin\cabinet.exe

## Follow-up before merge
- run local pipeline on local dev instance
- deploy locally
- run broader regression subset/full regression as required
- comment validation/deploy report before merge