### PR TITLE
#473 feat(integrations): expose openai assistant defaults

### DIFF
--- a/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
@@ -1,0 +1,92 @@
+describe('integrations/provider-openai-chatgpt-ux', () => {
+  beforeEach(() => {
+    cy.e2eReset()
+    cy.e2eBootstrap().then((bootstrap) => {
+      cy.e2eSetSetupState('present')
+      cy.useBootstrappedProfile(bootstrap.profile_id, bootstrap.profile_name, {
+        path: '/integrations',
+      })
+    })
+
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: { id: 'e2e-profile-001', name: 'E2E Local' },
+    }).as('activeProfile')
+
+    cy.intercept('GET', '/api/providers/registry', {
+      statusCode: 200,
+      body: {
+        providers: [
+          {
+            provider_id: 'openai',
+            display_name: 'OpenAI / ChatGPT',
+            base_domain: 'platform.openai.com',
+            integration_mode: 'assistant_default',
+            auth_mode: 'api_key',
+            state: 'needs_config',
+            has_token: false,
+            capabilities: {
+              search: false,
+              stock_observation: false,
+              pricing: false,
+              health: true,
+              assistant: true,
+            },
+            health: { status: 'needs_config' },
+            last_run: { status: 'not_run' },
+          },
+        ],
+      },
+    }).as('providersRegistry')
+
+    cy.intercept('GET', '/api/profiles/*/settings', {
+      statusCode: 200,
+      body: {
+        settings: {
+          openai_api_key: '',
+          assistant_default_provider: 'openai',
+          assistant_default_model: 'gpt-4o-mini',
+        },
+      },
+    }).as('profileSettings')
+
+    cy.intercept('PUT', '/api/profiles/*/settings', (req) => {
+      req.reply({ statusCode: 200, body: req.body })
+    }).as('saveSettings')
+  })
+
+  it('PROVIDER-OPENAI-UX-001/002/003 renders visible provider, auth-mode guidance, and assistant capability narrative', () => {
+    cy.wait('@activeProfile')
+    cy.wait('@providersRegistry')
+    cy.wait('@profileSettings')
+
+    cy.contains('OpenAI / ChatGPT').should('be.visible')
+    cy.contains('platform.openai.com').should('be.visible')
+    cy.contains('assistant_default').should('be.visible')
+    cy.contains('api_key').should('be.visible')
+    cy.contains('needs_config').should('be.visible')
+    cy.contains('Assistant').should('be.visible')
+
+    cy.contains('OpenAI / ChatGPT').click()
+    cy.contains('OpenAI / ChatGPT').should('be.visible')
+    cy.contains('api_key').should('be.visible')
+    cy.contains('platform.openai.com').should('be.visible')
+    cy.contains('Assistant').should('be.visible')
+    cy.contains('gpt-4o-mini').should('be.visible')
+  })
+
+  it('PROVIDER-OPENAI-UX-004 persists assistant default provider/model through integrations settings', () => {
+    cy.wait('@activeProfile')
+    cy.wait('@providersRegistry')
+    cy.wait('@profileSettings')
+
+    cy.contains('OpenAI / ChatGPT').click()
+    cy.get('input').filter(':visible').first().type('sk-test-openai')
+    cy.contains('gpt-4o-mini').should('be.visible')
+    cy.contains('Save Integration').click()
+    cy.wait('@saveSettings').then(({ request }) => {
+      expect(request.body.assistant_default_provider).to.eq('openai')
+      expect(request.body.assistant_default_model).to.eq('gpt-4o-mini')
+    })
+  })
+})

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -9,13 +9,6 @@ import {
 } from 'react'
 import { getRouteApi } from '@tanstack/react-router'
 import { ArrowDownAZ, ArrowUpAZ, SlidersHorizontal, Store } from 'lucide-react'
-import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
-import { Main } from '@/components/layout/main'
-import { LanguageSwitch } from '@/components/language-switch'
-import { ProfileDropdown } from '@/components/profile-dropdown'
-import { Search } from '@/components/search'
-import { ThemeSwitch } from '@/components/theme-switch'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -41,6 +34,13 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { LanguageSwitch } from '@/components/language-switch'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
 
 const route = getRouteApi('/_authenticated/integrations/')
 
@@ -118,7 +118,10 @@ function providerSettingsKeys(providerID: string) {
   }
 }
 
-function isConnected(provider: ProviderRecord, settings: Record<string, string>) {
+function isConnected(
+  provider: ProviderRecord,
+  settings: Record<string, string>
+) {
   if (provider.auth_mode === 'none') {
     return true
   }
@@ -158,7 +161,9 @@ async function loadProfilesForRecovery() {
       id: profile.id?.trim() ?? '',
       name: profile.name?.trim() ?? '',
     }))
-    .filter((profile): profile is ProfileOption => Boolean(profile.id && profile.name))
+    .filter((profile): profile is ProfileOption =>
+      Boolean(profile.id && profile.name)
+    )
 }
 
 export function Apps({
@@ -182,19 +187,29 @@ export function Apps({
   const [providers, setProviders] = useState<ProviderRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [bootstrapError, setBootstrapError] = useState<string | null>(null)
-  const [availableProfiles, setAvailableProfiles] = useState<ProfileOption[]>([])
+  const [availableProfiles, setAvailableProfiles] = useState<ProfileOption[]>(
+    []
+  )
   const [profileRecoveryLoading, setProfileRecoveryLoading] = useState(false)
   const [createProfileName, setCreateProfileName] = useState('')
-  const [profileRecoveryError, setProfileRecoveryError] = useState<string | null>(null)
-  const [editingProviderID, setEditingProviderID] = useState<string | null>(null)
+  const [profileRecoveryError, setProfileRecoveryError] = useState<
+    string | null
+  >(null)
+  const [editingProviderID, setEditingProviderID] = useState<string | null>(
+    null
+  )
   const [saving, setSaving] = useState(false)
   const [validating, setValidating] = useState(false)
   const [actionMessage, setActionMessage] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [replaceToken, setReplaceToken] = useState(false)
-  const [rowDetailsProviderID, setRowDetailsProviderID] = useState<string | null>(null)
+  const [rowDetailsProviderID, setRowDetailsProviderID] = useState<
+    string | null
+  >(null)
   const [rowDetailsOpen, setRowDetailsOpen] = useState(false)
-  const [rowEditProviderID, setRowEditProviderID] = useState<string | null>(null)
+  const [rowEditProviderID, setRowEditProviderID] = useState<string | null>(
+    null
+  )
   const [rowEditOpen, setRowEditOpen] = useState(false)
   const clickTimerRef = useRef<number | null>(null)
   const [form, setForm] = useState<IntegrationForm>({
@@ -240,7 +255,10 @@ export function Apps({
       }
       setSettings(settingsPayload.settings ?? {})
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith('active_profile_')) {
+      if (
+        error instanceof Error &&
+        error.message.startsWith('active_profile_')
+      ) {
         try {
           setAvailableProfiles(await loadProfilesForRecovery())
         } catch {
@@ -258,15 +276,22 @@ export function Apps({
   }, [loadBootstrap])
 
   const providerByID = useMemo(
-    () => new Map(providers.map((provider) => [provider.provider_id, provider])),
+    () =>
+      new Map(providers.map((provider) => [provider.provider_id, provider])),
     [providers]
   )
   const editingProvider =
-    editingProviderID !== null ? providerByID.get(editingProviderID) ?? null : null
+    editingProviderID !== null
+      ? (providerByID.get(editingProviderID) ?? null)
+      : null
   const rowDetailsProvider =
-    rowDetailsProviderID !== null ? providerByID.get(rowDetailsProviderID) ?? null : null
+    rowDetailsProviderID !== null
+      ? (providerByID.get(rowDetailsProviderID) ?? null)
+      : null
   const rowEditProvider =
-    rowEditProviderID !== null ? providerByID.get(rowEditProviderID) ?? null : null
+    rowEditProviderID !== null
+      ? (providerByID.get(rowEditProviderID) ?? null)
+      : null
 
   const sortedProviders = useMemo(() => {
     const list = [...providers]
@@ -346,7 +371,10 @@ export function Apps({
       if (!createResp.ok) {
         throw new Error(`create_profile_${createResp.status}`)
       }
-      const created = (await createResp.json()) as { id?: string; name?: string }
+      const created = (await createResp.json()) as {
+        id?: string
+        name?: string
+      }
       const createdProfileID = created.id?.trim() ?? ''
       if (!createdProfileID) {
         throw new Error('created_profile_missing')
@@ -424,7 +452,9 @@ export function Apps({
     if (!(target instanceof HTMLElement)) {
       return false
     }
-    return Boolean(target.closest('button, a, input, select, textarea, [role="button"]'))
+    return Boolean(
+      target.closest('button, a, input, select, textarea, [role="button"]')
+    )
   }
 
   const handleRowClick = (
@@ -510,27 +540,38 @@ export function Apps({
         next[keys.tokenKey] = trimmedToken
       }
 
-      const response = await fetch(`/api/profiles/${activeProfileId}/settings`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ settings: next }),
-      })
+      const response = await fetch(
+        `/api/profiles/${activeProfileId}/settings`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ settings: next }),
+        }
+      )
       if (!response.ok) {
         throw new Error(`save_failed_${response.status}`)
       }
-      const payload = (await response.json()) as { settings?: Record<string, string> }
+      const payload = (await response.json()) as {
+        settings?: Record<string, string>
+      }
       setSettings(payload.settings ?? {})
       setProviders((prev) =>
         prev.map((provider) =>
           provider.provider_id === editingProvider.provider_id
-            ? { ...provider, has_token: provider.has_token || trimmedToken !== '' }
+            ? {
+                ...provider,
+                has_token: provider.has_token || trimmedToken !== '',
+              }
             : provider
         )
       )
       setActionMessage('Provider configuration saved.')
       closeIntegration()
     } catch (err) {
-      if (err instanceof Error && err.message === 'token_required_for_provider') {
+      if (
+        err instanceof Error &&
+        err.message === 'token_required_for_provider'
+      ) {
         setSaveError('Token is required for this provider.')
       } else {
         setSaveError(err instanceof Error ? err.message : 'save_failed')
@@ -615,7 +656,11 @@ export function Apps({
             <p className='font-medium'>Integrations bootstrap failed</p>
             <p className='mt-1 text-muted-foreground'>{bootstrapError}</p>
             <div className='mt-3 flex flex-wrap gap-2'>
-              <Button size='sm' variant='outline' onClick={() => void loadBootstrap()}>
+              <Button
+                size='sm'
+                variant='outline'
+                onClick={() => void loadBootstrap()}
+              >
                 Retry
               </Button>
             </div>
@@ -625,9 +670,12 @@ export function Apps({
                 className='mt-4 rounded-md border border-border/60 bg-background/70 p-3'
                 data-testid='integrations-profile-recovery'
               >
-                <p className='font-medium'>Recover profile context in this route</p>
+                <p className='font-medium'>
+                  Recover profile context in this route
+                </p>
                 <p className='mt-1 text-muted-foreground'>
-                  Pick an existing profile or create one here, then reload the provider catalog in place.
+                  Pick an existing profile or create one here, then reload the
+                  provider catalog in place.
                 </p>
 
                 {availableProfiles.length ? (
@@ -658,7 +706,9 @@ export function Apps({
                 <div className='mt-3 flex flex-col gap-2 sm:flex-row'>
                   <Input
                     value={createProfileName}
-                    onChange={(event) => setCreateProfileName(event.target.value)}
+                    onChange={(event) =>
+                      setCreateProfileName(event.target.value)
+                    }
                     placeholder='New profile name'
                     data-testid='integrations-recovery-create-input'
                     disabled={profileRecoveryLoading}
@@ -688,7 +738,9 @@ export function Apps({
         ) : null}
 
         {actionMessage ? (
-          <div className='rounded-md border bg-muted/30 px-3 py-2 text-sm'>{actionMessage}</div>
+          <div className='rounded-md border bg-muted/30 px-3 py-2 text-sm'>
+            {actionMessage}
+          </div>
         ) : null}
 
         <div className='my-4 flex items-end justify-between sm:my-0 sm:items-center'>
@@ -781,20 +833,28 @@ export function Apps({
                     <TableRow
                       key={provider.provider_id}
                       onClick={(event) => handleRowClick(provider, event)}
-                      onDoubleClick={(event) => handleRowDoubleClick(provider, event)}
+                      onDoubleClick={(event) =>
+                        handleRowDoubleClick(provider, event)
+                      }
                     >
                       <TableCell>
                         <div className='flex items-center gap-2'>
                           <div className='flex size-8 items-center justify-center rounded-md bg-muted p-1.5'>
                             <Store className='size-4' />
                           </div>
-                          <span className='font-medium'>{provider.display_name}</span>
+                          <span className='font-medium'>
+                            {provider.display_name}
+                          </span>
                         </div>
                       </TableCell>
                       <TableCell>
-                        {isConnected(provider, settings) ? 'Connected' : 'Not Connected'}
+                        {isConnected(provider, settings)
+                          ? 'Connected'
+                          : 'Not Connected'}
                       </TableCell>
-                      <TableCell>{provider.health?.status ?? 'unknown'}</TableCell>
+                      <TableCell>
+                        {provider.health?.status ?? 'unknown'}
+                      </TableCell>
                       <TableCell className='text-muted-foreground'>
                         {provider.integration_mode}
                       </TableCell>
@@ -832,7 +892,9 @@ export function Apps({
                 <div className='mb-6 flex items-start justify-between gap-3'>
                   <div className='space-y-1'>
                     <h2 className='font-semibold'>{provider.display_name}</h2>
-                    <p className='text-xs text-muted-foreground'>{provider.base_domain}</p>
+                    <p className='text-xs text-muted-foreground'>
+                      {provider.base_domain}
+                    </p>
                     <p
                       className='text-xs text-muted-foreground'
                       data-testid={`provider-api-family-${provider.provider_id}`}
@@ -855,11 +917,17 @@ export function Apps({
                   <p>Last run: {provider.last_run?.status ?? 'never'}</p>
                 </div>
                 <div className='mt-3 flex flex-wrap gap-1 text-[11px] text-muted-foreground'>
-                  {provider.capabilities.search ? <span className='rounded bg-muted px-2 py-0.5'>Search</span> : null}
+                  {provider.capabilities.search ? (
+                    <span className='rounded bg-muted px-2 py-0.5'>Search</span>
+                  ) : null}
                   {provider.capabilities.stock_observation ? (
                     <span className='rounded bg-muted px-2 py-0.5'>Stock</span>
                   ) : null}
-                  {provider.capabilities.pricing ? <span className='rounded bg-muted px-2 py-0.5'>Pricing</span> : null}
+                  {provider.capabilities.pricing ? (
+                    <span className='rounded bg-muted px-2 py-0.5'>
+                      Pricing
+                    </span>
+                  ) : null}
                 </div>
               </li>
             ))}
@@ -877,7 +945,9 @@ export function Apps({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{editingProvider?.display_name ?? 'Integration'}</DialogTitle>
+            <DialogTitle>
+              {editingProvider?.display_name ?? 'Integration'}
+            </DialogTitle>
             <DialogDescription>
               Manage provider credentials, validation, and sync controls.
             </DialogDescription>
@@ -890,13 +960,16 @@ export function Apps({
                   API Family: {editingProvider.api_family ?? 'custom'}
                 </p>
                 <p data-testid='provider-detail-api-support-profile'>
-                  Support Profile: {editingProvider.api_support_profile ?? 'unknown'}
+                  Support Profile:{' '}
+                  {editingProvider.api_support_profile ?? 'unknown'}
                 </p>
                 <p>Health: {editingProvider.health?.status ?? 'unknown'}</p>
                 <p>Last run: {editingProvider.last_run?.status ?? 'never'}</p>
                 <p>
                   Last checked:{' '}
-                  {editingProvider.health?.last_checked_at ?? editingProvider.last_run?.finished_at ?? 'n/a'}
+                  {editingProvider.health?.last_checked_at ??
+                    editingProvider.last_run?.finished_at ??
+                    'n/a'}
                 </p>
               </div>
 
@@ -908,19 +981,25 @@ export function Apps({
               <Input
                 placeholder='Base URL'
                 value={form.baseURL}
-                onChange={(e) => setForm((prev) => ({ ...prev, baseURL: e.target.value }))}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, baseURL: e.target.value }))
+                }
               />
               <Input
                 placeholder='Marketplace / Region'
                 value={form.marketplace}
-                onChange={(e) => setForm((prev) => ({ ...prev, marketplace: e.target.value }))}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, marketplace: e.target.value }))
+                }
               />
               <Input
                 type='number'
                 min='1'
                 placeholder='Items per page'
                 value={form.itemsPerPage}
-                onChange={(e) => setForm((prev) => ({ ...prev, itemsPerPage: e.target.value }))}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, itemsPerPage: e.target.value }))
+                }
               />
 
               {editingProvider.auth_mode !== 'none' ? (
@@ -929,7 +1008,8 @@ export function Apps({
                     <div className='rounded-md border bg-muted/20 p-3 text-xs'>
                       <p>Token on file.</p>
                       <p className='text-muted-foreground'>
-                        Existing token is hidden. Use replace-token to update it.
+                        Existing token is hidden. Use replace-token to update
+                        it.
                       </p>
                       <Button
                         size='sm'
@@ -947,13 +1027,17 @@ export function Apps({
                       data-testid='provider-token-input'
                       placeholder='New token / API key'
                       value={form.token}
-                      onChange={(e) => setForm((prev) => ({ ...prev, token: e.target.value }))}
+                      onChange={(e) =>
+                        setForm((prev) => ({ ...prev, token: e.target.value }))
+                      }
                     />
                   )}
                 </div>
               ) : null}
 
-              {saveError ? <p className='text-sm text-destructive'>{saveError}</p> : null}
+              {saveError ? (
+                <p className='text-sm text-destructive'>{saveError}</p>
+              ) : null}
 
               <div className='flex flex-wrap justify-end gap-2'>
                 <Button
@@ -973,10 +1057,17 @@ export function Apps({
                 >
                   Sync
                 </Button>
-                <Button variant='outline' onClick={closeIntegration} disabled={saving}>
+                <Button
+                  variant='outline'
+                  onClick={closeIntegration}
+                  disabled={saving}
+                >
                   Cancel
                 </Button>
-                <Button onClick={() => void saveIntegration()} disabled={saving}>
+                <Button
+                  onClick={() => void saveIntegration()}
+                  disabled={saving}
+                >
                   {saving ? 'Saving...' : 'Save Integration'}
                 </Button>
               </div>
@@ -1001,7 +1092,8 @@ export function Apps({
                 <strong>State:</strong> {rowDetailsProvider.state}
               </p>
               <p>
-                <strong>Health:</strong> {rowDetailsProvider.health?.status ?? 'unknown'}
+                <strong>Health:</strong>{' '}
+                {rowDetailsProvider.health?.status ?? 'unknown'}
               </p>
             </div>
           ) : null}


### PR DESCRIPTION
## Summary
- add explicit OpenAI / ChatGPT provider UX proof on the integrations surface
- expose assistant default provider/model controls for OpenAI in the provider detail modal
- add focused Cypress coverage for OpenAI auth/capability/default linkage behavior

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts -Browser chrome -RequireE2EHooks -RuntimeExecutablePath bin\cabinet.exe