### PR TITLE
#475 feat(assistant): read saved provider defaults

### DIFF
--- a/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
@@ -89,4 +89,21 @@ describe('integrations/provider-openai-chatgpt-ux', () => {
       expect(request.body.assistant_default_model).to.eq('gpt-4o-mini')
     })
   })
+
+  it('PROVIDER-OPENAI-UX-004 boots Assistant workspace from saved provider/model defaults', () => {
+    cy.wait('@activeProfile')
+    cy.wait('@providersRegistry')
+    cy.wait('@profileSettings')
+
+    cy.contains('OpenAI / ChatGPT').click()
+    cy.get('[data-testid="provider-openai-default-provider"]').clear().type('openai')
+    cy.get('[data-testid="provider-openai-default-model"]').select('gpt-4.1-mini')
+    cy.contains('Save Integration').click()
+    cy.wait('@saveSettings')
+
+    cy.visit('/inventory')
+    cy.get('[data-testid="shell-chat-toggle"]').click()
+    cy.get('[data-testid="shell-assistant-thread-provider"]').should('contain', 'openai')
+    cy.get('[data-testid="shell-assistant-thread-model"]').should('contain', 'gpt-4.1-mini')
+  })
 })


### PR DESCRIPTION
## Summary
- bootstrap Assistant workspace provider/model from saved profile settings before localStorage fallbacks
- prove OpenAI integrations-saved defaults drive Assistant initial provider/model

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts -Browser chrome -RequireE2EHooks -RuntimeExecutablePath bin\cabinet.exe