### PR TITLE
#477 feat(assistant): sync defaults after integrations save

### DIFF
--- a/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
@@ -106,4 +106,27 @@ describe('integrations/provider-openai-chatgpt-ux', () => {
     cy.get('[data-testid="shell-assistant-thread-provider"]').should('contain', 'openai')
     cy.get('[data-testid="shell-assistant-thread-model"]').should('contain', 'gpt-4.1-mini')
   })
+
+  it('PROVIDER-OPENAI-UX-004 syncs Assistant defaults immediately after integrations save without reload', () => {
+    cy.wait('@activeProfile')
+    cy.wait('@providersRegistry')
+    cy.wait('@profileSettings')
+
+    cy.visit('/inventory')
+    cy.get('[data-testid="shell-chat-toggle"]').click()
+    cy.get('[data-testid="shell-assistant-thread-provider"]').should('contain', 'openai')
+    cy.get('[data-testid="shell-assistant-thread-model"]').should('contain', 'gpt-4o-mini')
+
+    cy.visit('/integrations')
+    cy.contains('OpenAI / ChatGPT').click()
+    cy.get('[data-testid="provider-openai-default-provider"]').clear().type('openai')
+    cy.get('[data-testid="provider-openai-default-model"]').select('gpt-4.1-mini')
+    cy.contains('Save Integration').click()
+    cy.wait('@saveSettings')
+
+    cy.visit('/inventory')
+    cy.get('[data-testid="shell-chat-toggle"]').click()
+    cy.get('[data-testid="shell-assistant-thread-provider"]').should('contain', 'openai')
+    cy.get('[data-testid="shell-assistant-thread-model"]').should('contain', 'gpt-4.1-mini')
+  })
 })

--- a/ui.web/src/components/layout/assistant-workspace-panel.tsx
+++ b/ui.web/src/components/layout/assistant-workspace-panel.tsx
@@ -106,6 +106,23 @@ function defaultModelForProvider(provider: string) {
   )
 }
 
+async function loadAssistantDefaultSettings(profileId: string) {
+  const response = await fetch(`/api/profiles/${profileId}/settings`)
+  if (!response.ok) {
+    throw new Error(`profile_settings_${response.status}`)
+  }
+  const payload = (await response.json()) as {
+    settings?: Record<string, string>
+  }
+  const settings = payload.settings ?? {}
+  const nextProvider =
+    settings.assistant_default_provider?.trim() || 'openai'
+  const nextModel =
+    settings.assistant_default_model?.trim() ||
+    defaultModelForProvider(nextProvider)
+  return { nextProvider, nextModel }
+}
+
 export function AssistantWorkspacePanel() {
   const { activeProfileId } = useShellWorkspace()
   const authUser = useAuthStore((state) => state.auth.user)
@@ -263,12 +280,20 @@ export function AssistantWorkspacePanel() {
     setError('')
     void (async () => {
       try {
-        const storedProvider =
-          window.localStorage.getItem(assistantProviderKey(activeProfileId)) ||
-          'openai'
-        const storedModel =
-          window.localStorage.getItem(assistantModelKey(activeProfileId)) ||
-          defaultModelForProvider(storedProvider)
+        const { nextProvider: storedProvider, nextModel: storedModel } =
+          await loadAssistantDefaultSettings(activeProfileId)
+        try {
+          window.localStorage.setItem(
+            assistantProviderKey(activeProfileId),
+            storedProvider
+          )
+          window.localStorage.setItem(
+            assistantModelKey(activeProfileId),
+            storedModel
+          )
+        } catch {
+          // ignore storage issues
+        }
         if (!cancelled) {
           setProvider(storedProvider)
           setModel(storedModel)
@@ -306,6 +331,62 @@ export function AssistantWorkspacePanel() {
       cancelled = true
     }
   }, [activeProfileId])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!activeProfileId || loading) return
+
+    void (async () => {
+      try {
+        const { nextProvider, nextModel } =
+          await loadAssistantDefaultSettings(activeProfileId)
+        if (cancelled) return
+        const threadSemantics = threadMetadata.thread_semantics || ''
+        const allowsDefaultSync =
+          threadSemantics === '' ||
+          threadSemantics === 'assistant_workspace_session'
+        if (!allowsDefaultSync) {
+          return
+        }
+        if (provider === nextProvider && model === nextModel) {
+          return
+        }
+        try {
+          window.localStorage.setItem(
+            assistantProviderKey(activeProfileId),
+            nextProvider
+          )
+          window.localStorage.setItem(
+            assistantModelKey(activeProfileId),
+            nextModel
+          )
+        } catch {
+          // ignore storage issues
+        }
+        setProvider(nextProvider)
+        setModel(nextModel)
+        setThreadMetadata((current) => ({
+          ...current,
+          provider: nextProvider,
+          model: nextModel,
+        }))
+      } catch {
+        // best-effort live sync only
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    activeProfileId,
+    loading,
+    location.pathname,
+    location.search,
+    provider,
+    model,
+    threadMetadata.thread_semantics,
+  ])
 
   async function handleProviderChange(nextProvider: string) {
     if (!activeProfileId) return


### PR DESCRIPTION
## Summary
- sync Assistant workspace provider/model defaults from saved profile settings during bootstrap
- live-sync Assistant defaults after Integrations saves when current thread semantics still allow default-driven behavior
- add focused Cypress proof for integrations save -> Assistant default synchronization

## Validation
- npm run build (ui.web)
- pwsh -NoLogo -NoProfile -File ..\cypress.ps1 -Spec cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts -Browser chrome -RequireE2EHooks
- pre-push OpenSpec validation
- pre-push fast API docs smoke test (`ok github.com/collectors-tech/cabinet/internal/app 1.051s`)

Closes #477