### PR TITLE
#481 fix(dashboard): route recently added card to collections

### DIFF
--- a/internal/dashboard/service.go
+++ b/internal/dashboard/service.go
@@ -117,7 +117,7 @@ func (s *Service) Summary(ctx context.Context) (Summary, error) {
 		{Title: "Wishlist Hits", Value: out.WishlistHits, Link: "/wishlist"},
 		{Title: "Price Drops", Value: out.PriceDrops, Link: "/pricing"},
 		{Title: "Restocks", Value: out.Restocks, Link: "/pricing"},
-		{Title: "Recently Added", Value: len(out.RecentlyAdded), Link: "/collection"},
+		{Title: "Recently Added", Value: len(out.RecentlyAdded), Link: "/collections"},
 	}
 	return out, nil
 }

--- a/internal/dashboard/service_test.go
+++ b/internal/dashboard/service_test.go
@@ -55,4 +55,18 @@ func TestSummaryIncludesCoreSignals(t *testing.T) {
 	if len(s.Cards) == 0 || s.Cards[0].Link == "" {
 		t.Fatalf("expected dashboard deep-link cards, got %+v", s.Cards)
 	}
+
+	foundRecentlyAdded := false
+	for _, card := range s.Cards {
+		if card.Title != "Recently Added" {
+			continue
+		}
+		foundRecentlyAdded = true
+		if card.Link != "/collections" {
+			t.Fatalf("expected Recently Added card to target /collections, got %q", card.Link)
+		}
+	}
+	if !foundRecentlyAdded {
+		t.Fatalf("expected Recently Added dashboard card, got %+v", s.Cards)
+	}
 }

--- a/openspec/specs/dashboard/ui-screen-home/spec.md
+++ b/openspec/specs/dashboard/ui-screen-home/spec.md
@@ -36,9 +36,14 @@ Each quick action SHALL navigate to the correct destination with preserved conte
 - **WHEN** user clicks a Home quick action
 - **THEN** app SHALL open the expected screen/workflow context
 
+#### Scenario: Recently Added card routes to collections
+- **GIVEN** Home dashboard data includes a `Recently Added` quick-action card for recently added inventory
+- **WHEN** user opens that quick action from Home
+- **THEN** the app SHALL route to `/collections`
+- **AND** the action MUST NOT target invalid singular route `/collection`
+
 ### Requirement UI-SCREEN-HOME-004 (Deprecated): Home onboarding rail starter actions
 This requirement is deprecated. Starter setup is now a pre-auth setup wizard and MUST NOT be rendered inside authenticated Home.
-
 #### Scenario: Deprecated behavior reference
 - **GIVEN** an authenticated actor with the required role is operating an active local profile, required capability configuration is enabled, and scenario fixture data exists for execution
 - **WHEN** legacy Home onboarding panel behavior is evaluated
@@ -65,7 +70,6 @@ Authenticated Home route SHALL not include starter setup wizard cards or control
 - **GIVEN** user is authenticated and route is Home
 - **WHEN** Home renders dashboard content
 - **THEN** labels and controls `Starter Onboarding`, `Start Setup`, `Import Existing Collection`, and `Use Sample Data` MUST NOT be present
-
 ### Requirement UI-SCREEN-HOME-007: Home SHALL use `/dashboard` as the canonical route
 Authenticated Home SHALL load on `/dashboard`, while `/` SHALL redirect deterministically to `/dashboard` without route drift.
 

--- a/ui.web/cypress/e2e/dashboard/ui-screen-home/spec.cy.ts
+++ b/ui.web/cypress/e2e/dashboard/ui-screen-home/spec.cy.ts
@@ -91,7 +91,7 @@ describe("UI-SCREEN-HOME", () => {
       req.reply({
         statusCode: 200,
         body: {
-          new_discoveries: 1,
+          new_discoveries: 0,
           wishlist_hits: 0,
           price_drops: 0,
           low_stock_discoveries: 0,
@@ -100,7 +100,9 @@ describe("UI-SCREEN-HOME", () => {
           total_items: 1,
           total_instances: 1,
           estimated_value: 99,
-          cards: [{ title: "Review discoveries", value: 1, link: "/discoveries" }],
+          cards: [
+            { title: "Recently Added", value: 1, link: "/collections" },
+          ],
         },
       })
     }).as("dashboardRetry")
@@ -112,14 +114,14 @@ describe("UI-SCREEN-HOME", () => {
     cy.wait("@dashboardRetry")
     cy.contains("Dashboard unavailable").should("not.exist")
 
-    cy.contains("Review discoveries")
+    cy.contains("Recently Added")
       .parentsUntil("div.border")
       .parent()
       .within(() => {
         cy.contains("a", "Open").click()
       })
 
-    cy.location("pathname", { timeout: 15000 }).should("match", /^\/discoveries\/?$/)
+    cy.location("pathname", { timeout: 15000 }).should("match", /^\/collections\/?$/)
   })
 
   it("UI-SCREEN-HOME-003 routes dashboard action links to live Cabinet destinations", () => {


### PR DESCRIPTION
## Summary
- fix the dashboard service payload so the Recently Added quick-action card targets /collections instead of dead route /collection
- add backend proof that the dashboard summary emits the correct collections route for that card
- update Home quick-action coverage/spec so the Recently Added path is explicitly verified

## Validation
- openspec validate --all --strict --no-interactive
- go test ./internal/dashboard -count=1
- go test ./internal/app -run Dashboard -count=1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/dashboard/ui-screen-home/spec.cy.ts -Browser chrome -NoServer
- npm run build
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1

## Notes
- go test ./internal/app -count=1 still hits broader existing migration-timeout failures outside this narrow dashboard route slice, so I kept the issue proof focused on the dashboard contract/tests for this PR.