### PR TITLE
#515 fix(settings): add profile page copy

### DIFF
--- a/openspec/specs/settings/profile/spec.md
+++ b/openspec/specs/settings/profile/spec.md
@@ -9,6 +9,7 @@ Profile screen SHALL allow editing username, display email, bio, and URL list wi
 - **GIVEN** user opens `/settings/profile`
 - **WHEN** user submits valid profile values
 - **THEN** runtime MUST persist values and UI MUST show deterministic success state
+- **AND** the screen title/description MUST resolve to user-facing copy instead of raw translation keys
 
 ### Requirement UI-SCREEN-SETTINGS-PROFILE-002: Profile screen SHALL handle deterministic error states
 

--- a/ui.web/cypress/e2e/settings/profile/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/profile/spec.cy.ts
@@ -14,6 +14,10 @@ describe('settings/profile', () => {
   })
 
   it('UI-SCREEN-SETTINGS-PROFILE-001 persists profile values through Cabinet settings API', () => {
+    cy.contains('Profile settings').should('be.visible')
+    cy.contains('Manage your account profile and public display details.').should('be.visible')
+    cy.contains('settings.profile.title').should('not.exist')
+    cy.contains('settings.profile.description').should('not.exist')
     cy.contains('button', 'Update profile').should('not.be.disabled')
     cy.get('input[name="username"]').clear().type('collector-profile')
     cy.get('[data-testid="settings-profile-email-trigger"]').click()

--- a/ui.web/src/locales/en/pages.json
+++ b/ui.web/src/locales/en/pages.json
@@ -8,5 +8,11 @@
   },
   "wishlist": {
     "title": "Wishlist"
+  },
+  "settings": {
+    "profile": {
+      "title": "Profile settings",
+      "description": "Manage your account profile and public display details."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add the missing English settings profile page-copy keys so the live screen no longer leaks raw translation identifiers
- keep the settings profile spec aligned with the requirement that user-facing copy must resolve cleanly
- add focused settings/profile proof that the visible title and description render as user-facing copy and raw keys do not appear

## Validation
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/settings/profile/spec.cy.ts -Browser electron -NoServer
- npm run build
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
