### PR TITLE
#503 fix(settings): restore profile settings content

### DIFF
--- a/ui.web/src/locales/en/pages.json
+++ b/ui.web/src/locales/en/pages.json
@@ -8,5 +8,11 @@
   },
   "wishlist": {
     "title": "Wishlist"
+  },
+  "settings": {
+    "profile": {
+      "title": "Profile settings",
+      "description": "Manage your account profile and public display details."
+    }
   }
 }


### PR DESCRIPTION
## Summary\n- preserve and complete the existing #503 settings/profile slice instead of discarding it\n- render the profile settings section with resolved page-copy headings\n- align profile spec and Cypress proof with the canonical /settings/profile route\n\n## Validation\n- openspec validate --all --strict --no-interactive\n- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/settings/profile/spec.cy.ts -Browser electron -NoServer\n- npm run build\n- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1