### PR TITLE
#537 feat(collections): convert collections to shared table surface

### DIFF
--- a/openspec/specs/collections/ui-screen-collections/spec.md
+++ b/openspec/specs/collections/ui-screen-collections/spec.md
@@ -1,88 +1,78 @@
 ## Purpose
-Define top-level Collections screen behavior and create workflows.
+Define top-level Collections screen behavior as a shared Cabinet table management surface.
 
 ## Requirements
-### Requirement UI-SCREEN-COLLECTIONS-001: Collections SHALL be a top-level managed section with dedicated create flow
-Collections management SHALL exist as a first-class section and support list + create operations.
+### Requirement UI-SCREEN-COLLECTIONS-001: Collections SHALL use the shared table management pattern
+Collections SHALL render as a practical row-based table surface using the shared Cabinet table pattern instead of a custom mixed create/list layout.
 
-#### Scenario: Open collections section
-- **GIVEN** authenticated user navigates to Collections section
-- **WHEN** section renders
-- **THEN** UI MUST show collection list and dedicated `New` create action for collection entries
+#### Scenario: Collections table renders
+- **GIVEN** an authenticated user opens `/collections`
+- **WHEN** the screen loads
+- **THEN** the primary collections surface MUST render as a shared table
+- **AND** the table MUST show collection rows with management-oriented columns
+- **AND** the screen MUST expose one primary create action for adding a collection row
 
-### Requirement UI-SCREEN-COLLECTIONS-002: Collections screen SHALL expose New and Create-menu actions
-Collections screen SHALL provide a dedicated `New` button for primary entity creation and adjacent `Create` menu for quick create actions.
+### Requirement UI-SCREEN-COLLECTIONS-002: Collections SHALL support row selection with visible management context
+The screen SHALL keep row selection and the current collection management context visible while the user works from the table.
 
-#### Scenario: New + Create menu behavior
-- **GIVEN** collections section is open
-- **WHEN** user clicks `New`
-- **THEN** primary create-collection flow MUST open
-- **WHEN** user clicks adjacent `Create` menu
-- **THEN** menu MUST show configured quick-create actions
+#### Scenario: Select collection row
+- **GIVEN** collection rows are visible in the table
+- **WHEN** the user selects a collection row
+- **THEN** the row MUST become the active collection context
+- **AND** a visible selected-collection panel MUST reflect the selected row details
 
-### Requirement UI-SCREEN-COLLECTIONS-003: Collection picker SHALL support inline quick-create
-Where collection picker is used (inventory/wishlist detail forms), picker SHALL allow inline create without leaving current workflow.
+### Requirement UI-SCREEN-COLLECTIONS-003: Collections SHALL support create from the table workflow
+The shared table surface SHALL support creating a collection through a single explicit create flow.
 
-#### Scenario: Quick-create from collection picker
-- **GIVEN** user opens collection picker in item/wishlist details
-- **WHEN** user selects `+ New Collection` and submits valid name
-- **THEN** new collection MUST be created and auto-selected in the current picker context
+#### Scenario: Create collection from table surface
+- **GIVEN** the user is on `/collections`
+- **WHEN** the user triggers the primary create action and submits a valid collection name
+- **THEN** the collection MUST be added to the table
+- **AND** the new collection MUST become the active management context
+- **AND** the result MUST persist across refresh
 
-### Requirement UI-SCREEN-COLLECTIONS-004: Collections screen SHALL show and confirm active collection context changes
-The dedicated Collections screen SHALL let users understand which collection is currently active and confirm the effect of switching to another collection.
+### Requirement UI-SCREEN-COLLECTIONS-004: Collections SHALL support row edit workflow
+The shared table surface SHALL support editing a collection row through the standard row-management workflow.
 
-#### Scenario: Switch active collection from Collections screen
-- **GIVEN** collections section is open and at least two collections exist
-- **WHEN** user selects a different collection entry
-- **THEN** the newly active collection MUST be visually distinguished on the page
-- **AND** the active context change MUST be communicated with explicit on-screen state and persistence semantics
-- **AND** returning to the screen MUST reflect the persisted active collection without requiring reselection
+#### Scenario: Rename collection from row workflow
+- **GIVEN** a collection row exists in the table
+- **WHEN** the user edits the row and saves a valid new name
+- **THEN** the table MUST update to show the new collection name
+- **AND** the updated name MUST persist across refresh
 
-### Requirement UI-SCREEN-COLLECTIONS-005: Collections screen SHALL support rename and remove management actions
-The dedicated Collections screen SHALL provide direct management actions for existing collections beyond creation and activation.
+### Requirement UI-SCREEN-COLLECTIONS-005: Collections SHALL support row delete workflow
+The shared table surface SHALL support removing collection rows through an explicit delete confirmation flow.
 
-#### Scenario: Rename or remove an existing collection
-- **GIVEN** collections section is open and a non-default collection exists
-- **WHEN** user chooses rename or remove for that collection
-- **THEN** the screen MUST expose the corresponding action
-- **AND** the action MUST complete through a clear confirmation/edit flow with deterministic transient result messaging
-- **AND** short-lived success/info/cancel outcomes for rename/remove flows MUST surface as toasts rather than only inline helper text
-- **AND** protected/default collections MUST not expose destructive completion for removal
+#### Scenario: Delete collection from row workflow
+- **GIVEN** a collection row exists in the table
+- **WHEN** the user confirms deletion
+- **THEN** the row MUST be removed from the table
+- **AND** the active management context MUST update deterministically
 
-### Requirement UI-SCREEN-COLLECTIONS-006: Collections screen SHALL expose collection details and metadata summaries
-Users SHALL be able to understand what a collection represents before choosing it.
+### Requirement UI-SCREEN-COLLECTIONS-006: Collections table SHALL support deterministic filtering
+The shared table surface SHALL support simple filtering without leaving the table workflow.
 
-#### Scenario: Review collection details from list
-- **GIVEN** collections section is open
-- **WHEN** user scans or opens a collection entry
-- **THEN** the UI MUST expose useful metadata for that collection such as summary/details/counts/status as defined by the product contract
-- **AND** each visible collection entry MUST surface enough detail to distinguish broad workspace scope, active operational lanes, and storage/archive groupings before selection
+#### Scenario: Filter collections
+- **GIVEN** multiple collections exist
+- **WHEN** the user filters the table
+- **THEN** only matching collection rows MUST remain visible
+- **AND** the filtered count summary MUST update deterministically
 
-### Requirement UI-SCREEN-COLLECTIONS-007: Collections screen SHALL support search, filtering, and ordering tools for collection management
-When multiple collections exist, the dedicated management surface SHALL help users find and organize them efficiently.
+## Acceptance Criteria
+- Collections no longer depends on a custom mixed create/list layout.
+- The shared table pattern drives create, edit, delete, selection, and filtering behaviors.
+- Refresh-persistence evidence exists for create and rename flows.
 
-#### Scenario: Locate and organize a collection
-- **GIVEN** collections section contains many entries
-- **WHEN** user needs to find or organize a specific collection
-- **THEN** the screen MUST provide supported search/filtering and ordering controls for collection management workflows
-- **AND** visible result counts/state MUST make the current search/filter/order effect obvious to the user
+## Success Criteria
+- Collections behaves like a practical management surface, not a one-off custom page.
+- The next collections issue can build assignment/move behavior on top of this table base cleanly.
 
-### Requirement UI-SCREEN-COLLECTIONS-008: Collections screen SHALL communicate create-action outcomes and available create paths clearly
-Collection creation entry points SHALL make their behavior obvious and communicate whether creation succeeded, failed, or requires additional input.
-
-#### Scenario: Use visible create actions on Collections screen
-- **GIVEN** collections section is open
-- **WHEN** user uses `New` or `Create`
-- **THEN** the resulting workflow/options MUST be obvious from the page state
-- **AND** success and informational/cancel outcomes for create flows MUST be communicated with visible toast feedback while validation failures remain explicit and actionable
-- **AND** the page MUST explain the difference between the primary `New` flow and alternate `Create` actions before mutation occurs
-
-### Requirement UI-SCREEN-COLLECTIONS-009: Collections affordances SHALL use tag iconography consistently
-Cabinet SHALL use a tag icon for the primary Collections affordance so sidebar navigation and dedicated Collections screen entry reinforce the same metaphor.
-
-#### Scenario: Open collections from authenticated navigation
-- **GIVEN** an authenticated user views the sidebar and the dedicated Collections screen
-- **WHEN** the Collections affordance renders in navigation and page context
-- **THEN** the sidebar Collections entry MUST use a tag icon
-- **AND** the dedicated Collections screen header MUST use matching tag iconography
-- **AND** icon sizing/alignment MUST remain visually consistent with surrounding controls and headings
+## Use-Case IDs and E2E Mapping
+| UC ID | Flow | Expected Result | E2E Mapping |
+| --- | --- | --- | --- |
+| UC-COL-01 | Open collections table | Shared table surface renders | `ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts` `renders collections as shared management table` |
+| UC-COL-02 | Select row | Selected collection panel updates | `ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts` `selects a collection row and updates management context` |
+| UC-COL-03 | Create collection | New row appears and survives refresh | `ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts` `creates a collection from the table workflow and persists after refresh` |
+| UC-COL-04 | Rename collection | Updated row survives refresh | `ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts` `renames a collection from the row workflow and persists after refresh` |
+| UC-COL-05 | Delete collection | Row removed from table | `ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts` `deletes a collection from the row workflow` |
+| UC-COL-06 | Filter collections | Matching rows remain visible | `ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts` `filters collections within the shared table surface` |

--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -1,175 +1,88 @@
-describe("ui-screen-collections", () => {
+describe('ui-screen-collections', () => {
   function signInToCollections() {
-    cy.visit("/sign-in?redirect=%2Fcollections%2F");
-    cy.get('input[name="email"]').clear().type("e2e-collections@example.com");
-    cy.get('input[name="password"]').clear().type("password123");
-    cy.contains("button", "Sign in").click();
-    cy.location("pathname", { timeout: 15000 }).should(
-      "match",
-      /^\/collections\/?$/
-    );
+    cy.visit('/sign-in?redirect=%2Fcollections%2F')
+    cy.get('input[name="email"]').clear().type('e2e-collections@example.com')
+    cy.get('input[name="password"]').clear().type('password123')
+    cy.contains('button', 'Sign in').click()
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/collections\/?$/)
   }
 
-  it("UI-SCREEN-COLLECTIONS-001 renders top-level collections section with list and New action", () => {
-    signInToCollections();
+  beforeEach(() => {
+    cy.visit('/sign-in')
+    cy.window().then((win) => {
+      win.localStorage.clear()
+    })
+  })
 
-    cy.get('[data-testid="collections-section"]').should("be.visible");
-    cy.get('[data-testid="collections-item-all-items"]').should("be.visible");
-    cy.get('[data-testid="collections-new-action"]').should("be.visible");
-  });
+  it('renders collections as shared management table', () => {
+    signInToCollections()
 
-  it("UI-SCREEN-COLLECTIONS-002 exposes New flow and adjacent Create menu quick actions", () => {
-    signInToCollections();
+    cy.get('[data-testid="collections-shared-table"]').should('be.visible')
+    cy.contains('Collection management table').should('be.visible')
+    cy.contains('th', 'Collection').should('be.visible')
+    cy.contains('th', 'Items').should('be.visible')
+    cy.contains('th', 'Scope').should('be.visible')
+    cy.contains('th', 'Status').should('be.visible')
+    cy.get('[data-testid="collections-row-all-items"]').should('be.visible')
+    cy.get('[data-testid="collections-new-action"]').should('be.visible')
+  })
 
-    cy.get('[data-testid="collections-create-guidance"]').should("be.visible");
-    cy.get('[data-testid="collections-new-action"]').click();
-    cy.get('[data-testid="collections-create-panel"]').should("be.visible");
-    cy.get('[data-testid="collections-create-panel-description"]')
-      .should("contain.text", "Saving creates the collection immediately")
-    cy.contains("New opens the primary create flow for a named collection.")
-      .should("be.visible")
-    cy.get('[data-testid="collections-create-outcome"]').should("not.exist")
+  it('selects a collection row and updates management context', () => {
+    signInToCollections()
 
-    cy.get('[data-testid="collections-create-menu-trigger"]').click();
-    cy.get('[data-testid="collections-create-menu-new"]').should("be.visible");
-    cy.get('[data-testid="collections-create-menu-starter"]').should("be.visible");
-  });
+    cy.get('[data-testid="collections-row-store-1"]').click()
+    cy.get('[data-testid="collections-selected-name"]').should('contain', 'Store 1')
+    cy.get('[data-testid="collections-selected-count"]').should('not.be.empty')
+    cy.get('[data-testid="collections-row-store-1"]').should('have.attr', 'data-state', 'selected')
+  })
 
-  it("UI-SCREEN-COLLECTIONS-003 supports inline-style quick create and auto-activates new collection", () => {
-    signInToCollections();
+  it('creates a collection from the table workflow and persists after refresh', () => {
+    signInToCollections()
 
-    cy.get('[data-testid="collections-new-action"]').click();
-    cy.get('[data-testid="collections-new-input"]').type("Collections Inline Alpha");
-    cy.get('[data-testid="collections-new-save"]').click();
+    cy.get('[data-testid="collections-new-action"]').click()
+    cy.get('[data-testid="collections-create-input"]').type('Cabinet Alpha')
+    cy.get('[data-testid="collections-create-submit"]').click()
 
-    cy.contains("Collections Inline Alpha created and set as the active collection.")
-      .should("be.visible")
-    cy.get('[data-testid="collections-create-outcome"]').should("not.exist")
-    cy.get('[data-testid="collections-item-collections-inline-alpha"]')
-      .should("be.visible")
-      .and("have.attr", "data-state", "active");
-  });
+    cy.get('[data-testid="collections-row-cabinet-alpha"]').should('be.visible')
+    cy.get('[data-testid="collections-selected-name"]').should('contain', 'Cabinet Alpha')
 
-  it("UI-SCREEN-COLLECTIONS-008 makes create outcomes and validation visible", () => {
-    signInToCollections();
+    cy.reload()
+    cy.get('[data-testid="collections-row-cabinet-alpha"]').should('be.visible')
+    cy.get('[data-testid="collections-selected-name"]').should('contain', 'Cabinet Alpha')
+  })
 
-    cy.get('[data-testid="collections-new-action"]').click();
-    cy.get('[data-testid="collections-new-save"]').click();
-    cy.get('[data-testid="collections-create-error"]')
-      .should("contain.text", "Enter a collection name before saving.")
+  it('renames a collection from the row workflow and persists after refresh', () => {
+    signInToCollections()
 
-    cy.get('[data-testid="collections-new-input"]').type("Collections Visible Beta");
-    cy.get('[data-testid="collections-new-save"]').click();
-    cy.get('[data-testid="collections-create-error"]').should("not.exist");
-    cy.contains("Collections Visible Beta created and set as the active collection.")
-      .should("be.visible")
-    cy.get('[data-testid="collections-create-outcome"]').should("not.exist")
+    cy.get('[data-testid="collections-row-store-2"]').click()
+    cy.get('[data-testid="collections-row-edit-store-2"]').click()
+    cy.get('[data-testid="collections-edit-input"]').clear().type('Store 2 Updated')
+    cy.get('[data-testid="collections-edit-submit"]').click()
 
-    cy.get('[data-testid="collections-create-menu-trigger"]').click();
-    cy.get('[data-testid="collections-create-menu-starter"]').click();
-    cy.contains("Starter collections added.").should("be.visible")
-    cy.get('[data-testid="collections-create-outcome"]').should("not.exist")
-  });
+    cy.get('[data-testid="collections-row-store-2-updated"]').should('be.visible')
+    cy.get('[data-testid="collections-selected-name"]').should('contain', 'Store 2 Updated')
 
-  it("UI-SCREEN-COLLECTIONS-006 exposes collection details and metadata summaries before selection", () => {
-    signInToCollections();
+    cy.reload()
+    cy.get('[data-testid="collections-row-store-2-updated"]').should('be.visible')
+    cy.get('[data-testid="collections-selected-name"]').should('contain', 'Store 2 Updated')
+  })
 
-    cy.get('[data-testid="collections-item-title-all-items"]')
-      .should("contain.text", "All Items")
-    cy.get('[data-testid="collections-item-description-all-items"]')
-      .should("contain.text", "Everything currently tracked")
-    cy.get('[data-testid="collections-item-metadata-all-items"]')
-      .should("contain.text", "248 items")
-      .and("contain.text", "Workspace default")
-      .and("contain.text", "Updated 5m ago")
-    cy.get('[data-testid="collections-item-status-all-items"]')
-      .should("contain.text", "Broadest scope")
+  it('deletes a collection from the row workflow', () => {
+    signInToCollections()
 
-    cy.get('[data-testid="collections-item-description-watch-list"]')
-      .should("contain.text", "Fast-moving")
-    cy.get('[data-testid="collections-item-status-watch-list"]')
-      .should("contain.text", "Needs review")
-  });
+    cy.get('[data-testid="collections-row-warehouse-1"]').click()
+    cy.get('[data-testid="collections-selected-delete"]').click()
+    cy.get('[data-testid="collections-delete-submit"]').click()
 
-  it("UI-SCREEN-COLLECTIONS-007 supports search, filtering, and ordering tools", () => {
-    signInToCollections();
+    cy.get('[data-testid="collections-row-warehouse-1"]').should('not.exist')
+  })
 
-    cy.get('[data-testid="collections-management-tools"]').should("be.visible");
-    cy.get('[data-testid="collections-management-summary"]')
-      .should("contain.text", "Showing 6 of 6 collections.")
+  it('filters collections within the shared table surface', () => {
+    signInToCollections()
 
-    cy.get('[data-testid="collections-search-input"]').type("watch");
-    cy.get('[data-testid="collections-item-watch-list"]').should("be.visible");
-    cy.get('[data-testid="collections-item-all-items"]').should("not.exist");
-    cy.get('[data-testid="collections-management-summary"]')
-      .should("contain.text", "Showing 1 of 6 collections.")
-
-    cy.get('[data-testid="collections-search-input"]').clear();
-    cy.get('[data-testid="collections-filter-storage"]').click();
-    cy.get('[data-testid="collections-item-warehouse-1"]').should("be.visible");
-    cy.get('[data-testid="collections-item-store-1"]').should("not.exist");
-
-    cy.get('[data-testid="collections-filter-all"]').click();
-    cy.get('[data-testid="collections-sort-items-desc"]').click();
-    cy.get('[data-testid^="collections-item-"]').then(($items) => {
-      const first = $items.first().attr('data-testid');
-      expect(first).to.eq('collections-item-all-items');
-    });
-  });
-
-  it("UI-SCREEN-COLLECTIONS-005 supports rename and remove actions with visible outcomes", () => {
-    signInToCollections();
-
-    cy.get('[data-testid="collections-rename-trigger-store-2"]').click();
-    cy.get('[data-testid="collections-rename-panel"]').should("be.visible");
-    cy.get('[data-testid="collections-rename-input"]').clear().type("Store 2 Prime");
-    cy.get('[data-testid="collections-rename-save"]').click();
-    cy.contains("Store 2 renamed to Store 2 Prime.").should("be.visible")
-    cy.get('[data-testid="collections-create-outcome"]').should("not.exist")
-    cy.get('[data-testid="collections-item-store-2-prime"]').should("be.visible");
-    cy.get('[data-testid="collections-item-store-2"]').should("not.exist");
-
-    cy.get('[data-testid="collections-remove-trigger-store-2-prime"]').click();
-    cy.get('[data-testid="collections-remove-panel"]').should("be.visible");
-    cy.get('[data-testid="collections-remove-confirm"]').click();
-    cy.contains("Store 2 Prime removed from workspace collections.").should("be.visible")
-    cy.get('[data-testid="collections-create-outcome"]').should("not.exist")
-    cy.get('[data-testid="collections-item-store-2-prime"]').should("not.exist");
-  });
-
-  it("UI-SCREEN-COLLECTIONS-004 shows active collection context changes and persistence semantics", () => {
-    signInToCollections();
-
-    cy.get('[data-testid="collections-active-context-panel"]').should("be.visible");
-    cy.get('[data-testid="collections-active-context-name"]')
-      .should("contain.text", "All Items");
-    cy.get('[data-testid="collections-active-context-persistence"]')
-      .should("contain.text", "Persists for this signed-in profile");
-
-    cy.get('[data-testid="collections-item-watch-list"] button').first().click();
-    cy.get('[data-testid="collections-item-watch-list"]')
-      .should("have.attr", "data-state", "active");
-    cy.get('[data-testid="collections-active-context-name"]')
-      .should("contain.text", "Watch List");
-    cy.get('[data-testid="collections-active-context-message"]')
-      .should("contain.text", "Active collection is Watch List")
-
-    cy.reload();
-    cy.get('[data-testid="collections-active-context-name"]')
-      .should("contain.text", "Watch List");
-    cy.get('[data-testid="collections-item-watch-list"]')
-      .should("have.attr", "data-state", "active");
-  });
-
-  it("UI-SCREEN-COLLECTIONS-009 uses tag iconography for collections navigation and page identity", () => {
-    signInToCollections();
-
-    cy.get('[data-testid="sidebar-nav-link-collections"]').should("be.visible");
-    cy.get('[data-testid="collections-page-icon"]').should("be.visible");
-
-    cy.get('[data-testid="sidebar-nav-link-collections"] svg')
-      .should("have.attr", "data-lucide", "tag");
-    cy.get('[data-testid="collections-page-icon"]')
-      .should("have.attr", "data-lucide", "tag");
-  });
-});
+    cy.get('input[placeholder="Filter collections..."]').type('watch')
+    cy.get('[data-testid="collections-row-watch-list"]').should('be.visible')
+    cy.get('[data-testid="collections-row-all-items"]').should('not.exist')
+    cy.get('[data-testid="collections-filtered-count"]').should('contain', '1')
+  })
+})

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -1,6 +1,17 @@
 import { useMemo, useState } from 'react'
-import { ArrowDownAZ, ArrowUpAZ, Pencil, Tag, Trash2 } from 'lucide-react'
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -9,135 +20,276 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { Input } from '@/components/ui/input'
 import { ConfigDrawer } from '@/components/config-drawer'
-import { LanguageSwitch } from '@/components/language-switch'
+import { DataTableColumnHeader, DataTablePagination, DataTableToolbar } from '@/components/data-table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Header } from '@/components/layout/header'
+import { Input } from '@/components/ui/input'
+import { LanguageSwitch } from '@/components/language-switch'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { ThemeSwitch } from '@/components/theme-switch'
-import { useWorkspaceCollections } from '@/features/collections/use-workspace-collections'
+import { useWorkspaceCollections } from './use-workspace-collections'
 
-type CollectionFilterMode = 'all' | 'active-lanes' | 'storage' | 'custom'
-type CollectionSortMode = 'name-asc' | 'name-desc' | 'items-desc'
+type CollectionRow = {
+  id: string
+  name: string
+  itemCount: number
+  scopeLabel: string
+  statusLabel: string
+  updatedLabel: string
+  description: string
+}
 
-function isSystemCollection(collection: { name: string; scopeLabel: string }) {
-  return (
-    collection.name === 'All Items' ||
-    collection.scopeLabel === 'Monitoring set' ||
-    collection.scopeLabel === 'Intent shortlist' ||
-    collection.scopeLabel === 'Storage location' ||
-    collection.scopeLabel === 'Retail lane'
-  )
+function buildCollectionColumns({
+  onEdit,
+  onDelete,
+}: {
+  onEdit: (row: CollectionRow) => void
+  onDelete: (row: CollectionRow) => void
+}): ColumnDef<CollectionRow>[] {
+  return [
+    {
+      accessorKey: 'name',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Collection' />
+      ),
+      cell: ({ row }) => (
+        <div className='space-y-1'>
+          <div className='font-medium' data-testid={`collections-row-name-${row.original.id}`}>
+            {row.original.name}
+          </div>
+          <div className='text-xs text-muted-foreground'>
+            {row.original.description}
+          </div>
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'itemCount',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Items' />
+      ),
+      cell: ({ row }) => (
+        <span data-testid={`collections-row-count-${row.original.id}`}>
+          {row.original.itemCount}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'scopeLabel',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Scope' />
+      ),
+      cell: ({ row }) => <Badge variant='secondary'>{row.original.scopeLabel}</Badge>,
+    },
+    {
+      accessorKey: 'statusLabel',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Status' />
+      ),
+      cell: ({ row }) => <Badge variant='outline'>{row.original.statusLabel}</Badge>,
+    },
+    {
+      accessorKey: 'updatedLabel',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Updated' />
+      ),
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      enableSorting: false,
+      enableHiding: false,
+      cell: ({ row }) => (
+        <div className='flex items-center justify-end gap-2'>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            data-testid={`collections-row-edit-${row.original.id}`}
+            onClick={(event) => {
+              event.stopPropagation()
+              onEdit(row.original)
+            }}
+          >
+            <Pencil className='mr-2 h-4 w-4' />
+            Edit
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            data-testid={`collections-row-delete-${row.original.id}`}
+            onClick={(event) => {
+              event.stopPropagation()
+              onDelete(row.original)
+            }}
+          >
+            <Trash2 className='mr-2 h-4 w-4' />
+            Delete
+          </Button>
+        </div>
+      ),
+    },
+  ]
 }
 
 export function Collections() {
   const {
-    collectionSummaries,
+    workspaceCollections,
     activeWorkspaceCollection,
     setActiveWorkspaceCollection,
     addCollection,
     renameCollection,
     removeCollection,
+    collectionSummaries,
   } = useWorkspaceCollections()
-  const [newCollectionName, setNewCollectionName] = useState('')
-  const [createPanelOpen, setCreatePanelOpen] = useState(false)
-  const [createError, setCreateError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [filterMode, setFilterMode] = useState<CollectionFilterMode>('all')
-  const [sortMode, setSortMode] = useState<CollectionSortMode>('name-asc')
-  const [editingCollectionName, setEditingCollectionName] = useState<
-    string | null
-  >(null)
-  const [renameValue, setRenameValue] = useState('')
-  const [pendingRemoveName, setPendingRemoveName] = useState<string | null>(
-    null
-  )
+  const [globalFilter, setGlobalFilter] = useState('')
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'name', desc: false },
+  ])
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [createValue, setCreateValue] = useState('')
+  const [editValue, setEditValue] = useState('')
+  const [selectedCollectionID, setSelectedCollectionID] = useState<string | null>(null)
 
-  const availableCreateActions = useMemo(
-    () => [
-      {
-        id: 'new-collection',
-        label: 'New Collection',
-        description:
-          'Open the primary create flow and name a collection explicitly.',
-      },
-      {
-        id: 'starter-collections',
-        label: 'Add Starter Collections',
-        description:
-          'Seed a couple of ready-to-use collections for quick workspace setup.',
-      },
-    ],
+  const rows = useMemo<CollectionRow[]>(() => {
+    return collectionSummaries.map((summary) => ({
+      id: summary.key,
+      name: summary.name,
+      itemCount: summary.itemCount,
+      scopeLabel: summary.scopeLabel,
+      statusLabel: summary.statusLabel,
+      updatedLabel: summary.updatedLabel,
+      description: summary.description,
+    }))
+  }, [collectionSummaries])
+
+  const selectedRow = useMemo(() => {
+    return (
+      rows.find((row) => row.id === selectedCollectionID) ??
+      rows.find((row) => row.name === activeWorkspaceCollection) ??
+      rows[0] ??
+      null
+    )
+  }, [activeWorkspaceCollection, rows, selectedCollectionID])
+
+  const columns = useMemo(
+    () =>
+      buildCollectionColumns({
+        onEdit: (row) => {
+          setSelectedCollectionID(row.id)
+          setEditValue(row.name)
+          setEditOpen(true)
+        },
+        onDelete: (row) => {
+          setSelectedCollectionID(row.id)
+          setDeleteOpen(true)
+        },
+      }),
     []
   )
 
-  const activeCollectionSummary = useMemo(
-    () =>
-      collectionSummaries.find(
-        (collection) => collection.name === activeWorkspaceCollection
-      ) ?? collectionSummaries[0],
-    [activeWorkspaceCollection, collectionSummaries]
-  )
-
-  const activeContextMessage = activeCollectionSummary
-    ? `Active collection is ${activeCollectionSummary.name}. This choice persists for the current signed-in profile.`
-    : ''
-
-  const filteredCollections = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase()
-
-    const visible = collectionSummaries
-      .filter((collection) => {
-        if (!normalizedSearch) {
-          return true
-        }
-        return [
-          collection.name,
-          collection.description,
-          collection.scopeLabel,
-          collection.statusLabel,
-        ]
-          .join(' ')
-          .toLowerCase()
-          .includes(normalizedSearch)
-      })
-      .filter((collection) => {
-        if (filterMode === 'all') {
-          return true
-        }
-        if (filterMode === 'active-lanes') {
-          return (
-            collection.scopeLabel === 'Retail lane' ||
-            collection.scopeLabel === 'Monitoring set'
-          )
-        }
-        if (filterMode === 'storage') {
-          return collection.scopeLabel === 'Storage location'
-        }
-        return !isSystemCollection(collection)
-      })
-
-    return [...visible].sort((left, right) => {
-      if (sortMode === 'items-desc') {
-        return (
-          right.itemCount - left.itemCount ||
-          left.name.localeCompare(right.name)
-        )
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: {
+      globalFilter,
+      sorting,
+    },
+    onGlobalFilterChange: setGlobalFilter,
+    onSortingChange: setSorting,
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const searchValue = String(filterValue).trim().toLowerCase()
+      if (!searchValue) {
+        return true
       }
-      if (sortMode === 'name-desc') {
-        return right.name.localeCompare(left.name)
-      }
-      return left.name.localeCompare(right.name)
-    })
-  }, [collectionSummaries, filterMode, searchTerm, sortMode])
+      return [
+        row.original.name,
+        row.original.description,
+        row.original.scopeLabel,
+        row.original.statusLabel,
+        String(row.original.itemCount),
+      ].some((value) => value.toLowerCase().includes(searchValue))
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  const handleSelectRow = (row: CollectionRow) => {
+    setSelectedCollectionID(row.id)
+    setActiveWorkspaceCollection(row.name)
+  }
+
+  const handleCreateCollection = () => {
+    const created = addCollection(createValue)
+    if (!created) {
+      toast.error('Collection name must be unique and non-empty.')
+      return
+    }
+    setActiveWorkspaceCollection(created)
+    setSelectedCollectionID(
+      collectionSummaries.find((summary) => summary.name === created)?.key ?? null
+    )
+    setCreateValue('')
+    setCreateOpen(false)
+    toast.success(`Created collection ${created}.`)
+  }
+
+  const handleRenameCollection = () => {
+    if (!selectedRow) {
+      return
+    }
+    const renamed = renameCollection(selectedRow.name, editValue)
+    if (!renamed) {
+      toast.error('Rename failed. Use a unique non-empty collection name.')
+      return
+    }
+    setActiveWorkspaceCollection(renamed)
+    setSelectedCollectionID(
+      collectionSummaries.find((summary) => summary.name === renamed)?.key ?? selectedRow.id
+    )
+    setEditOpen(false)
+    setEditValue('')
+    toast.success(`Renamed collection to ${renamed}.`)
+  }
+
+  const handleDeleteCollection = () => {
+    if (!selectedRow) {
+      return
+    }
+    const deleted = removeCollection(selectedRow.name)
+    if (!deleted) {
+      toast.error('Collection could not be deleted.')
+      return
+    }
+    setDeleteOpen(false)
+    setSelectedCollectionID(null)
+    toast.success(`Deleted collection ${selectedRow.name}.`)
+  }
+
+  const filteredCount = table.getFilteredRowModel().rows.length
 
   return (
     <>
@@ -151,553 +303,246 @@ export function Collections() {
         </div>
       </Header>
 
-      <Main className='space-y-4'>
-        <div className='space-y-1'>
-          <div className='flex items-center gap-2'>
-            <Tag
-              data-testid='collections-page-icon'
-              className='h-5 w-5 text-muted-foreground'
-            />
+      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
+        <div className='flex flex-wrap items-end justify-between gap-3'>
+          <div>
             <h1 className='text-2xl font-bold tracking-tight'>Collections</h1>
+            <p className='text-muted-foreground'>
+              Manage collection rows through the shared Cabinet table surface.
+            </p>
           </div>
-          <p className='text-muted-foreground'>
-            Manage workspace collections outside of sidebar chrome.
-          </p>
+          <Button
+            type='button'
+            data-testid='collections-new-action'
+            onClick={() => setCreateOpen(true)}
+          >
+            <Plus className='mr-2 h-4 w-4' />
+            New Collection
+          </Button>
         </div>
-        <Card data-testid='collections-section'>
-          <CardHeader>
-            <div className='flex flex-wrap items-center justify-between gap-2'>
-              <CardTitle>Workspace Collections</CardTitle>
-              <div className='flex items-center gap-2'>
-                <Button
-                  type='button'
-                  data-testid='collections-new-action'
-                  onClick={() => {
-                    setCreatePanelOpen(true)
-                    setCreateError(null)
-                    toast.message(
-                      'New opens the primary create flow for a named collection.'
-                    )
-                  }}
-                >
-                  New
-                </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type='button'
-                      variant='outline'
-                      data-testid='collections-create-menu-trigger'
-                    >
-                      Create
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align='end'>
-                    <DropdownMenuItem
-                      data-testid='collections-create-menu-new'
-                      onClick={() => {
-                        setCreatePanelOpen(true)
-                        setCreateError(null)
-                        toast.message(
-                          'Create → New Collection opens the full naming flow on this page.'
+
+        <div className='grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Collection management table</CardTitle>
+              <CardDescription>
+                Browse, create, and edit collection rows from the standard table workflow.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-4'>
+              <DataTableToolbar
+                table={table}
+                searchPlaceholder='Filter collections...'
+                filters={[]}
+              />
+              <div className='rounded-md border' data-testid='collections-shared-table'>
+                <Table>
+                  <TableHeader>
+                    {table.getHeaderGroups().map((headerGroup) => (
+                      <TableRow key={headerGroup.id}>
+                        {headerGroup.headers.map((header) => (
+                          <TableHead key={header.id}>
+                            {header.isPlaceholder
+                              ? null
+                              : flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext()
+                                )}
+                          </TableHead>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableHeader>
+                  <TableBody>
+                    {table.getRowModel().rows.length > 0 ? (
+                      table.getRowModel().rows.map((row) => {
+                        const isActive = selectedRow?.id === row.original.id
+                        return (
+                          <TableRow
+                            key={row.id}
+                            data-testid={`collections-row-${row.original.id}`}
+                            data-state={isActive ? 'selected' : undefined}
+                            className='cursor-pointer'
+                            onClick={() => handleSelectRow(row.original)}
+                          >
+                            {row.getVisibleCells().map((cell) => (
+                              <TableCell key={cell.id}>
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              </TableCell>
+                            ))}
+                          </TableRow>
                         )
-                      }}
-                    >
-                      New Collection
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      data-testid='collections-create-menu-starter'
-                      onClick={() => {
-                        addCollection('New Arrivals')
-                        addCollection('Recently Graded')
-                        setCreatePanelOpen(false)
-                        setCreateError(null)
-                        toast.success(
-                          'Starter collections added. New Arrivals is now available as an active collection choice.'
-                        )
-                      }}
-                    >
-                      Add Starter Collections
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                      })
+                    ) : (
+                      <TableRow>
+                        <TableCell colSpan={columns.length} className='h-24 text-center'>
+                          No collections match the current filter.
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
               </div>
-            </div>
-            <CardDescription>
-              Create, list, and switch active collection context.
-            </CardDescription>
-            <div
-              className='rounded-md border border-border/60 bg-muted/20 p-3 text-sm'
-              data-testid='collections-create-guidance'
-            >
-              <p className='font-medium'>How creation works here</p>
-              <ul className='mt-2 space-y-1 text-muted-foreground'>
-                {availableCreateActions.map((action) => (
-                  <li
-                    key={action.id}
-                    data-testid={`collections-create-guidance-${action.id}`}
-                  >
-                    <span className='font-medium text-foreground'>
-                      {action.label}:
-                    </span>{' '}
-                    {action.description}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </CardHeader>
-          <CardContent className='space-y-3'>
-            <div
-              className='rounded-md border border-border/60 bg-muted/10 p-3'
-              data-testid='collections-management-tools'
-            >
-              <div className='flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between'>
-                <div className='flex flex-1 flex-col gap-3 md:flex-row'>
-                  <div className='flex-1'>
-                    <p className='mb-1 text-sm font-medium'>
-                      Find a collection
-                    </p>
-                    <Input
-                      data-testid='collections-search-input'
-                      placeholder='Search collections...'
-                      value={searchTerm}
-                      onChange={(event) => setSearchTerm(event.target.value)}
-                    />
-                  </div>
-                  <div>
-                    <p className='mb-1 text-sm font-medium'>Filter</p>
-                    <div className='flex flex-wrap gap-2'>
-                      <Button
-                        type='button'
-                        size='sm'
-                        variant={filterMode === 'all' ? 'default' : 'outline'}
-                        data-testid='collections-filter-all'
-                        onClick={() => setFilterMode('all')}
-                      >
-                        All
-                      </Button>
-                      <Button
-                        type='button'
-                        size='sm'
-                        variant={
-                          filterMode === 'active-lanes' ? 'default' : 'outline'
-                        }
-                        data-testid='collections-filter-active-lanes'
-                        onClick={() => setFilterMode('active-lanes')}
-                      >
-                        Active lanes
-                      </Button>
-                      <Button
-                        type='button'
-                        size='sm'
-                        variant={
-                          filterMode === 'storage' ? 'default' : 'outline'
-                        }
-                        data-testid='collections-filter-storage'
-                        onClick={() => setFilterMode('storage')}
-                      >
-                        Storage
-                      </Button>
-                      <Button
-                        type='button'
-                        size='sm'
-                        variant={
-                          filterMode === 'custom' ? 'default' : 'outline'
-                        }
-                        data-testid='collections-filter-custom'
-                        onClick={() => setFilterMode('custom')}
-                      >
-                        Custom
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-                <div>
-                  <p className='mb-1 text-sm font-medium'>Order</p>
-                  <div className='flex flex-wrap gap-2'>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant={sortMode === 'name-asc' ? 'default' : 'outline'}
-                      data-testid='collections-sort-name-asc'
-                      onClick={() => setSortMode('name-asc')}
-                    >
-                      <ArrowUpAZ className='mr-1 size-4' /> A–Z
-                    </Button>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant={sortMode === 'name-desc' ? 'default' : 'outline'}
-                      data-testid='collections-sort-name-desc'
-                      onClick={() => setSortMode('name-desc')}
-                    >
-                      <ArrowDownAZ className='mr-1 size-4' /> Z–A
-                    </Button>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant={
-                        sortMode === 'items-desc' ? 'default' : 'outline'
-                      }
-                      data-testid='collections-sort-items-desc'
-                      onClick={() => setSortMode('items-desc')}
-                    >
-                      Largest first
-                    </Button>
-                  </div>
-                </div>
-              </div>
-              <p
-                className='mt-3 text-xs text-muted-foreground'
-                data-testid='collections-management-summary'
-              >
-                Showing {filteredCollections.length} of{' '}
-                {collectionSummaries.length} collections.
+              <DataTablePagination table={table} />
+              <p className='text-xs text-muted-foreground' data-testid='collections-filtered-count'>
+                Showing {filteredCount} of {workspaceCollections.length} collections.
               </p>
-            </div>
-            {activeCollectionSummary ? (
-              <div
-                className='rounded-md border border-primary/30 bg-primary/5 px-3 py-3 text-sm'
-                data-testid='collections-active-context-panel'
-              >
-                <div className='flex flex-wrap items-start justify-between gap-3'>
+            </CardContent>
+          </Card>
+
+          <Card data-testid='collections-selected-panel'>
+            <CardHeader>
+              <CardTitle>Selected collection</CardTitle>
+              <CardDescription>
+                Keep the current management context visible while working the table.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-3'>
+              {selectedRow ? (
+                <>
                   <div>
-                    <p className='font-medium'>Current active collection</p>
-                    <p
-                      className='mt-1 text-base font-semibold text-foreground'
-                      data-testid='collections-active-context-name'
-                    >
-                      {activeCollectionSummary.name}
-                    </p>
-                    <p
-                      className='mt-1 text-muted-foreground'
-                      data-testid='collections-active-context-message'
-                    >
-                      {activeContextMessage}
-                    </p>
-                  </div>
-                  <div
-                    className='rounded-full border border-primary/30 px-2 py-1 text-xs text-primary'
-                    data-testid='collections-active-context-persistence'
-                  >
-                    Persists for this signed-in profile
-                  </div>
-                </div>
-              </div>
-            ) : null}
-            {createError ? (
-              <div
-                className='rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive'
-                data-testid='collections-create-error'
-              >
-                {createError}
-              </div>
-            ) : null}
-            {createPanelOpen ? (
-              <div
-                className='rounded-md border bg-muted/20 p-3'
-                data-testid='collections-create-panel'
-              >
-                <div className='space-y-3'>
-                  <div>
-                    <p
-                      className='font-medium'
-                      data-testid='collections-create-panel-title'
-                    >
-                      Create a collection
-                    </p>
-                    <p
-                      className='text-sm text-muted-foreground'
-                      data-testid='collections-create-panel-description'
-                    >
-                      Saving creates the collection immediately, closes this
-                      panel, and makes the new collection active.
-                    </p>
-                  </div>
-                  <div className='flex flex-wrap gap-2'>
-                    <Input
-                      data-testid='collections-new-input'
-                      placeholder='Collection name'
-                      value={newCollectionName}
-                      onChange={(event) => {
-                        setNewCollectionName(event.target.value)
-                        if (createError) {
-                          setCreateError(null)
-                        }
-                      }}
-                    />
-                    <Button
-                      data-testid='collections-new-save'
-                      onClick={() => {
-                        const trimmedName = newCollectionName.trim()
-                        if (!trimmedName) {
-                          setCreateError(
-                            'Enter a collection name before saving.'
-                          )
-                          return
-                        }
-                        addCollection(trimmedName)
-                        setNewCollectionName('')
-                        setCreatePanelOpen(false)
-                        setEditingCollectionName(null)
-                        setPendingRemoveName(null)
-                        setCreateError(null)
-                        toast.success(
-                          `${trimmedName} created and set as the active collection.`
-                        )
-                      }}
-                    >
-                      Save
-                    </Button>
-                    <Button
-                      variant='outline'
-                      data-testid='collections-new-cancel'
-                      onClick={() => {
-                        setCreatePanelOpen(false)
-                        setNewCollectionName('')
-                        setCreateError(null)
-                        toast.message(
-                          'Collection creation cancelled. No collection was added.'
-                        )
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-            {editingCollectionName ? (
-              <div
-                className='rounded-md border bg-muted/20 p-3'
-                data-testid='collections-rename-panel'
-              >
-                <div className='space-y-3'>
-                  <div>
-                    <p className='font-medium'>Rename collection</p>
-                    <p className='text-sm text-muted-foreground'>
-                      Rename updates the collection label in place and preserves
-                      active context when applicable.
-                    </p>
-                  </div>
-                  <div className='flex flex-wrap gap-2'>
-                    <Input
-                      data-testid='collections-rename-input'
-                      value={renameValue}
-                      onChange={(event) => {
-                        setRenameValue(event.target.value)
-                        if (createError) {
-                          setCreateError(null)
-                        }
-                      }}
-                    />
-                    <Button
-                      data-testid='collections-rename-save'
-                      onClick={() => {
-                        const renamed = renameCollection(
-                          editingCollectionName,
-                          renameValue
-                        )
-                        if (!renamed) {
-                          setCreateError(
-                            'Enter a new collection name before saving rename.'
-                          )
-                          return
-                        }
-                        setEditingCollectionName(null)
-                        setRenameValue('')
-                        setCreateError(null)
-                        toast.success(
-                          `${editingCollectionName} renamed to ${renamed}.`
-                        )
-                      }}
-                    >
-                      Save rename
-                    </Button>
-                    <Button
-                      variant='outline'
-                      data-testid='collections-rename-cancel'
-                      onClick={() => {
-                        setEditingCollectionName(null)
-                        setRenameValue('')
-                        setCreateError(null)
-                        toast.message(
-                          'Collection rename cancelled. No changes were made.'
-                        )
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-            {pendingRemoveName ? (
-              <div
-                className='rounded-md border bg-muted/20 p-3'
-                data-testid='collections-remove-panel'
-              >
-                <div className='space-y-3'>
-                  <div>
-                    <p className='font-medium'>Remove collection</p>
-                    <p className='text-sm text-muted-foreground'>
-                      Confirm removal of {pendingRemoveName}. Active context
-                      falls back to All Items if needed.
-                    </p>
-                  </div>
-                  <div className='flex flex-wrap gap-2'>
-                    <Button
-                      variant='destructive'
-                      data-testid='collections-remove-confirm'
-                      onClick={() => {
-                        const removed = removeCollection(pendingRemoveName)
-                        if (!removed) {
-                          setCreateError(
-                            'Collection removal could not be completed.'
-                          )
-                          return
-                        }
-                        const removedName = pendingRemoveName
-                        setPendingRemoveName(null)
-                        setEditingCollectionName(null)
-                        setRenameValue('')
-                        setCreateError(null)
-                        toast.success(
-                          `${removedName} removed from workspace collections.`
-                        )
-                      }}
-                    >
-                      Confirm remove
-                    </Button>
-                    <Button
-                      variant='outline'
-                      data-testid='collections-remove-cancel'
-                      onClick={() => {
-                        setPendingRemoveName(null)
-                        toast.message(
-                          'Collection removal cancelled. No collection was removed.'
-                        )
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-            <div className='grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3'>
-              {filteredCollections.length ? (
-                filteredCollections.map((collection) => {
-                  const isActive = activeWorkspaceCollection === collection.name
-                  const isProtected = collection.name === 'All Items'
-                  return (
-                    <div
-                      key={collection.name}
-                      className={
-                        isActive
-                          ? 'rounded-md border-2 border-primary bg-primary/5 px-3 py-3'
-                          : 'rounded-md border px-3 py-3'
-                      }
-                      data-testid={`collections-item-${collection.key}`}
-                      data-state={isActive ? 'active' : 'inactive'}
-                    >
-                      <button
-                        type='button'
-                        className='w-full text-left hover:bg-muted/40'
-                        onClick={() => {
-                          setActiveWorkspaceCollection(collection.name)
-                        }}
-                      >
-                        <div className='flex items-start justify-between gap-3'>
-                          <div className='min-w-0'>
-                            <div
-                              className='font-medium'
-                              data-testid={`collections-item-title-${collection.key}`}
-                            >
-                              {collection.name}
-                            </div>
-                            <div
-                              className='mt-1 text-sm text-muted-foreground'
-                              data-testid={`collections-item-description-${collection.key}`}
-                            >
-                              {collection.description}
-                            </div>
-                          </div>
-                          <div
-                            className='rounded-full border px-2 py-1 text-xs text-muted-foreground'
-                            data-testid={`collections-item-status-${collection.key}`}
-                          >
-                            {collection.statusLabel}
-                          </div>
-                        </div>
-                        <div
-                          className='mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground'
-                          data-testid={`collections-item-metadata-${collection.key}`}
-                        >
-                          <span
-                            data-testid={`collections-item-count-${collection.key}`}
-                          >
-                            {collection.itemCount} items
-                          </span>
-                          <span
-                            data-testid={`collections-item-scope-${collection.key}`}
-                          >
-                            {collection.scopeLabel}
-                          </span>
-                          <span
-                            data-testid={`collections-item-updated-${collection.key}`}
-                          >
-                            {collection.updatedLabel}
-                          </span>
-                        </div>
-                      </button>
-                      <div className='mt-3 flex flex-wrap gap-2'>
-                        <Button
-                          type='button'
-                          size='sm'
-                          variant='outline'
-                          data-testid={`collections-rename-trigger-${collection.key}`}
-                          disabled={isProtected}
-                          onClick={() => {
-                            setEditingCollectionName(collection.name)
-                            setRenameValue(collection.name)
-                            setPendingRemoveName(null)
-                            setCreateError(null)
-                          }}
-                        >
-                          <Pencil className='mr-1 size-4' /> Rename
-                        </Button>
-                        <Button
-                          type='button'
-                          size='sm'
-                          variant='outline'
-                          data-testid={`collections-remove-trigger-${collection.key}`}
-                          disabled={isProtected}
-                          onClick={() => {
-                            setPendingRemoveName(collection.name)
-                            setEditingCollectionName(null)
-                            setRenameValue('')
-                            setCreateError(null)
-                          }}
-                        >
-                          <Trash2 className='mr-1 size-4' /> Remove
-                        </Button>
-                      </div>
+                    <div className='text-sm text-muted-foreground'>Name</div>
+                    <div className='font-medium' data-testid='collections-selected-name'>
+                      {selectedRow.name}
                     </div>
-                  )
-                })
+                  </div>
+                  <div className='grid grid-cols-2 gap-3 text-sm'>
+                    <div>
+                      <div className='text-muted-foreground'>Items</div>
+                      <div data-testid='collections-selected-count'>{selectedRow.itemCount}</div>
+                    </div>
+                    <div>
+                      <div className='text-muted-foreground'>Updated</div>
+                      <div>{selectedRow.updatedLabel}</div>
+                    </div>
+                  </div>
+                  <div className='flex flex-wrap gap-2'>
+                    <Badge variant='secondary'>{selectedRow.scopeLabel}</Badge>
+                    <Badge variant='outline'>{selectedRow.statusLabel}</Badge>
+                  </div>
+                  <p className='text-sm text-muted-foreground'>
+                    {selectedRow.description}
+                  </p>
+                  <div className='flex gap-2'>
+                    <Button
+                      type='button'
+                      variant='outline'
+                      data-testid='collections-selected-edit'
+                      onClick={() => {
+                        setEditValue(selectedRow.name)
+                        setEditOpen(true)
+                      }}
+                    >
+                      <Pencil className='mr-2 h-4 w-4' />
+                      Edit
+                    </Button>
+                    <Button
+                      type='button'
+                      variant='outline'
+                      data-testid='collections-selected-delete'
+                      onClick={() => setDeleteOpen(true)}
+                    >
+                      <Trash2 className='mr-2 h-4 w-4' />
+                      Delete
+                    </Button>
+                  </div>
+                </>
               ) : (
-                <div
-                  className='rounded-md border border-dashed px-3 py-6 text-sm text-muted-foreground'
-                  data-testid='collections-empty-state'
-                >
-                  No collections match the current search/filter combination.
-                </div>
+                <p className='text-sm text-muted-foreground'>
+                  Select a collection row to manage it here.
+                </p>
               )}
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        </div>
       </Main>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent data-testid='collections-create-dialog'>
+          <DialogHeader>
+            <DialogTitle>Create collection</DialogTitle>
+            <DialogDescription>
+              Add a new collection row to the management table.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            data-testid='collections-create-input'
+            placeholder='Collection name'
+            value={createValue}
+            onChange={(event) => setCreateValue(event.target.value)}
+          />
+          <DialogFooter>
+            <Button type='button' variant='outline' onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type='button'
+              data-testid='collections-create-submit'
+              onClick={handleCreateCollection}
+            >
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent data-testid='collections-edit-dialog'>
+          <DialogHeader>
+            <DialogTitle>Edit collection</DialogTitle>
+            <DialogDescription>
+              Rename the selected collection through the row management workflow.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            data-testid='collections-edit-input'
+            placeholder='Collection name'
+            value={editValue}
+            onChange={(event) => setEditValue(event.target.value)}
+          />
+          <DialogFooter>
+            <Button type='button' variant='outline' onClick={() => setEditOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type='button'
+              data-testid='collections-edit-submit'
+              onClick={handleRenameCollection}
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent data-testid='collections-delete-dialog'>
+          <DialogHeader>
+            <DialogTitle>Delete collection</DialogTitle>
+            <DialogDescription>
+              Remove the selected collection row from the shared table surface.
+            </DialogDescription>
+          </DialogHeader>
+          <p className='text-sm text-muted-foreground'>
+            {selectedRow
+              ? `Delete ${selectedRow.name}? This should immediately remove it from the collections table.`
+              : 'No collection is selected.'}
+          </p>
+          <DialogFooter>
+            <Button type='button' variant='outline' onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type='button'
+              variant='destructive'
+              data-testid='collections-delete-submit'
+              onClick={handleDeleteCollection}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -43,7 +43,7 @@ import {
 import { priorities, statuses } from '../data/data'
 import { type Task } from '../data/schema'
 import { DataTableBulkActions } from './data-table-bulk-actions'
-import { tasksColumns as columns } from './tasks-columns'
+import { getTasksColumns } from './tasks-columns'
 
 type TasksRoutePath = '/_authenticated/inventory/' | '/_authenticated/wishlist/'
 
@@ -62,6 +62,8 @@ export function TasksTable({
   currentRecordID,
   onRecordFocus,
 }: DataTableProps) {
+  const columns = useMemo(() => getTasksColumns({ routePath }), [routePath])
+
   const route =
     routePath === '/_authenticated/inventory/'
       ? getRouteApi('/_authenticated/inventory/')


### PR DESCRIPTION
## Summary
- convert Collections from the custom mixed UI into a shared table management surface
- add explicit row-based create, select, edit, delete, and filter workflows
- update the focused collections spec and Cypress coverage for the table workflow

## Validation
- `openspec validate --all --strict --no-interactive`
- `cd ui.web && npm run build`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser chrome -RequireE2EHooks`

## Notes
- includes the small `tasks-table.tsx` import fix needed for this worktree to build cleanly against the current code state
