### PR TITLE
#535 Wishlist uses canonical item status as source-of-truth

### DIFF
--- a/internal/chat/service.go
+++ b/internal/chat/service.go
@@ -632,6 +632,14 @@ func (s *Service) applyCreateWishlistEntry(ctx context.Context, profileID string
 	if err != nil {
 		return "", "", fmt.Errorf("create wishlist entry: %w", err)
 	}
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE canonical_items
+		SET status = 'wishlist', priority = ?, updated_at = CURRENT_TIMESTAMP, updated_by = 'chat.service'
+		WHERE id = ? AND profile_id = ?
+	`, strings.TrimSpace(priority), itemID, strings.TrimSpace(profileID))
+	if err != nil {
+		return "", "", fmt.Errorf("sync wishlist item: %w", err)
+	}
 	return itemID, wishlistID, nil
 }
 

--- a/internal/collection/repository.go
+++ b/internal/collection/repository.go
@@ -89,9 +89,10 @@ var allowedStatuses = map[string]struct{}{
 }
 
 var allowedItemLifecycleStatuses = map[string]struct{}{
-	"active":  {},
-	"deleted": {},
-	"recycle": {},
+	"active":   {},
+	"wishlist": {},
+	"deleted":  {},
+	"recycle":  {},
 }
 
 func NewRepository(db *sql.DB) *Repository {

--- a/internal/discovery/service.go
+++ b/internal/discovery/service.go
@@ -153,13 +153,23 @@ func (s *Service) ApplyAction(ctx context.Context, a Action) error {
 					SET notes = ?, highlight_hit = 1, updated_at = CURRENT_TIMESTAMP
 					WHERE id = ?
 				`, mergedNotes, existingID)
+				_, _ = s.db.ExecContext(ctx, `
+					UPDATE canonical_items
+					SET status = 'wishlist', updated_at = CURRENT_TIMESTAMP, updated_by = 'discovery.service'
+					WHERE id = ? AND (? = '' OR profile_id = ?)
+				`, itemID, profileID, profileID)
 				break
 			}
 			_, _ = s.db.ExecContext(ctx, `
 				INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit)
-				VALUES (?, ?, ?, ?, 'normal', ?, 1)
+				VALUES (?, ?, ?, ?, 'medium', ?, 1)
 				ON CONFLICT(item_id) DO UPDATE SET notes = excluded.notes, highlight_hit = 1, updated_at = CURRENT_TIMESTAMP
 			`, uuid.NewString(), profileID, itemID, 0.0, metadata)
+			_, _ = s.db.ExecContext(ctx, `
+				UPDATE canonical_items
+				SET status = 'wishlist', priority = 'medium', updated_at = CURRENT_TIMESTAMP, updated_by = 'discovery.service'
+				WHERE id = ? AND (? = '' OR profile_id = ?)
+			`, itemID, profileID, profileID)
 		}
 	case ActionCreateItem:
 		var title, partNumber string

--- a/internal/wishlist/service.go
+++ b/internal/wishlist/service.go
@@ -46,9 +46,8 @@ func (s *Service) CreateForProfile(ctx context.Context, profileID string, in Ent
 	if strings.TrimSpace(in.ItemID) == "" {
 		return Entry{}, fmt.Errorf("item_id is required")
 	}
-	if strings.TrimSpace(in.Priority) == "" {
-		in.Priority = "normal"
-	}
+	trimmedProfileID := strings.TrimSpace(profileID)
+	in.Priority = normalizeWishlistPriority(in.Priority)
 	in.ID = uuid.NewString()
 	highlight := 0
 	if in.HighlightHit {
@@ -57,11 +56,14 @@ func (s *Service) CreateForProfile(ctx context.Context, profileID string, in Ent
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, in.ID, strings.TrimSpace(profileID), in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight)
+	`, in.ID, trimmedProfileID, in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight)
 	if err != nil {
 		return Entry{}, fmt.Errorf("create wishlist entry: %w", err)
 	}
-	return s.GetByIDForProfile(ctx, strings.TrimSpace(profileID), in.ID)
+	if err := s.syncItemWishlistState(ctx, trimmedProfileID, in.ItemID, "wishlist", in.Priority); err != nil {
+		return Entry{}, err
+	}
+	return s.GetByIDForProfile(ctx, trimmedProfileID, in.ID)
 }
 
 func (s *Service) Update(ctx context.Context, in Entry) error {
@@ -72,16 +74,25 @@ func (s *Service) UpdateForProfile(ctx context.Context, profileID string, in Ent
 	if strings.TrimSpace(in.ID) == "" {
 		return fmt.Errorf("id is required")
 	}
+	trimmedProfileID := strings.TrimSpace(profileID)
+	in.Priority = normalizeWishlistPriority(in.Priority)
+	itemID, err := s.itemIDForEntry(ctx, trimmedProfileID, in.ID)
+	if err != nil {
+		return err
+	}
 	highlight := 0
 	if in.HighlightHit {
 		highlight = 1
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 		UPDATE wishlist_entries
 		SET target_price = ?, priority = ?, notes = ?, highlight_hit = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, in.TargetPrice, in.Priority, in.Notes, highlight, in.ID, strings.TrimSpace(profileID), strings.TrimSpace(profileID))
-	return err
+	`, in.TargetPrice, in.Priority, in.Notes, highlight, in.ID, trimmedProfileID, trimmedProfileID)
+	if err != nil {
+		return err
+	}
+	return s.syncItemWishlistState(ctx, trimmedProfileID, itemID, "wishlist", in.Priority)
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {
@@ -89,8 +100,16 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 }
 
 func (s *Service) DeleteForProfile(ctx context.Context, profileID, id string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID))
-	return err
+	trimmedProfileID := strings.TrimSpace(profileID)
+	itemID, _ := s.itemIDForEntry(ctx, trimmedProfileID, id)
+	_, err := s.db.ExecContext(ctx, `DELETE FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)`, id, trimmedProfileID, trimmedProfileID)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(itemID) == "" {
+		return nil
+	}
+	return s.syncItemWishlistState(ctx, trimmedProfileID, itemID, "active", "")
 }
 
 func (s *Service) GetByID(ctx context.Context, id string) (Entry, error) {
@@ -186,4 +205,46 @@ func (s *Service) isBelowTarget(ctx context.Context, itemID string, target float
 		return false
 	}
 	return minPrice > 0 && minPrice <= target
+}
+
+func normalizeWishlistPriority(raw string) string {
+	priority := strings.ToLower(strings.TrimSpace(raw))
+	if priority == "" || priority == "normal" {
+		return "medium"
+	}
+	return priority
+}
+
+func (s *Service) itemIDForEntry(ctx context.Context, profileID, entryID string) (string, error) {
+	var itemID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT item_id
+		FROM wishlist_entries
+		WHERE id = ? AND (? = '' OR profile_id = ?)
+	`, entryID, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&itemID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("wishlist entry not found")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(itemID), nil
+}
+
+func (s *Service) syncItemWishlistState(ctx context.Context, profileID, itemID, status, priority string) error {
+	if strings.TrimSpace(itemID) == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE canonical_items
+		SET status = ?,
+			priority = CASE WHEN ? = '' THEN priority ELSE ? END,
+			updated_at = CURRENT_TIMESTAMP,
+			updated_by = 'wishlist.service'
+		WHERE id = ? AND (? = '' OR profile_id = ?)
+	`, strings.TrimSpace(status), strings.TrimSpace(priority), strings.TrimSpace(priority), strings.TrimSpace(itemID), strings.TrimSpace(profileID), strings.TrimSpace(profileID))
+	if err != nil {
+		return fmt.Errorf("sync wishlist item status: %w", err)
+	}
+	return nil
 }

--- a/openspec/specs/wishlist/ui-screen-wishlist/spec.md
+++ b/openspec/specs/wishlist/ui-screen-wishlist/spec.md
@@ -60,10 +60,10 @@ Wishlist detail collection picker MUST support `+ New Collection` inline create.
 - **AND** only an explicit cancel/dismiss action MAY close the inline create state without a create result
 
 ### Requirement UI-SCREEN-WISHLIST-007: Wishlist rows SHALL use collection semantics and MUST NOT leak task seed labels
-Wishlist rows/cards MUST be sourced from `/api/wishlist` + `/api/items` contracts and MUST NOT render generic task IDs or task taxonomy labels.
+Wishlist rows/cards MUST be sourced from canonical `/api/items?status=wishlist` records with `/api/wishlist` metadata overlays and MUST NOT render generic task IDs or task taxonomy labels.
 
 #### Scenario: Wishlist semantics in rows view
-- **GIVEN** `/api/wishlist` returns profile entries and `/api/items` returns canonical item metadata
+- **GIVEN** `/api/items?status=wishlist` returns canonical wishlist item records and `/api/wishlist` returns wishlist metadata overlays
 - **WHEN** user opens wishlist rows view
 - **THEN** rendered IDs MUST align to wishlist `item_id` values
 - **AND** row titles MUST align to canonical item title/part number

--- a/openspec/specs/wishlist/wishlist-items/spec.md
+++ b/openspec/specs/wishlist/wishlist-items/spec.md
@@ -3,12 +3,13 @@ Define wishlist item lifecycle behavior.
 
 ## Requirements
 ### Requirement WISHLIST-PRICING-DASHBOARD-001: Wishlist entries SHALL link to canonical items and target pricing
-Cabinet SHALL persist wishlist records with target price, priority, and notes.
+Cabinet SHALL treat the canonical item record as the source-of-truth for wishlist membership, using item lifecycle status plus attached wishlist metadata for target price, priority, and notes.
 
 #### Scenario: Create wishlist entry
 - **GIVEN** an authenticated user has an active profile and a canonical item exists with `item_id`
 - **WHEN** the user submits `POST /api/wishlist` with `item_id`, `target_price`, `priority`, and `notes`
-- **THEN** API MUST return `201` and persisted record MUST include:
+- **THEN** API MUST return `201`, persist wishlist metadata, and mark the canonical item lifecycle status as `wishlist`
+- **AND** the persisted record MUST include:
   - `wishlist_id` (string)
   - `item_id` matching request
   - `target_price` (number)

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -19,7 +19,7 @@ describe("ui-screen-wishlist", () => {
         ],
       },
     }).as("wishlistItems");
-    cy.intercept("GET", "/api/items", {
+    cy.intercept("GET", "/api/items?status=wishlist", {
       statusCode: 200,
       body: {
         items: [
@@ -27,11 +27,17 @@ describe("ui-screen-wishlist", () => {
             id: "item-collector-1",
             title: "AFX Mega-G+ Camaro Wildfire",
             part_number: "22073",
+            status: "wishlist",
+            category: "Slot Cars",
+            priority: "medium",
           },
           {
             id: "item-collector-2",
             title: "F1 Silverline",
             part_number: "F1002",
+            status: "wishlist",
+            category: "Formula",
+            priority: "high",
           },
         ],
       },

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -59,14 +59,13 @@ export function Tasks({
       try {
         const [wishlistResponse, itemsResponse] = await Promise.all([
           fetch('/api/wishlist'),
-          fetch('/api/items'),
+          fetch('/api/items?status=wishlist'),
         ])
         if (!wishlistResponse.ok || !itemsResponse.ok) {
           throw new Error('wishlist_bootstrap_failed')
         }
         const wishlistPayload = (await wishlistResponse.json()) as {
           items?: Array<{
-            id?: string
             item_id?: string
             priority?: string
             below_target_now?: boolean
@@ -77,25 +76,35 @@ export function Tasks({
             id?: string
             title?: string
             part_number?: string
+            category?: string
+            priority?: string
           }>
         }
-        const itemTitleByID = new Map<string, string>()
-        ;(itemsPayload.items ?? []).forEach((item) => {
-          const itemID = item.id?.trim()
+        const wishlistByItemID = new Map<
+          string,
+          {
+            priority?: string
+            below_target_now?: boolean
+          }
+        >()
+        ;(wishlistPayload.items ?? []).forEach((entry) => {
+          const itemID = entry.item_id?.trim()
           if (!itemID) {
             return
           }
-          const label = item.title?.trim() || item.part_number?.trim() || itemID
-          itemTitleByID.set(itemID, label)
+          wishlistByItemID.set(itemID, entry)
         })
-        const mapped: Task[] = (wishlistPayload.items ?? []).map((entry, index) => {
-          const itemID = entry.item_id?.trim() || `wishlist-item-${index + 1}`
+        const mapped: Task[] = (itemsPayload.items ?? []).map((item, index) => {
+          const itemID = item.id?.trim() || `wishlist-item-${index + 1}`
+          const wishlistEntry = wishlistByItemID.get(itemID)
           return {
             id: itemID,
-            title: itemTitleByID.get(itemID) || `Wishlist item ${index + 1}`,
-            status: entry.below_target_now ? 'discovered' : 'wishlist',
-            label: 'collection',
-            priority: entry.priority?.trim() || 'medium',
+            title:
+              item.title?.trim() || item.part_number?.trim() || `Wishlist item ${index + 1}`,
+            status: wishlistEntry?.below_target_now ? 'discovered' : 'wishlist',
+            label: item.category?.trim() || 'collection',
+            priority:
+              wishlistEntry?.priority?.trim() || item.priority?.trim() || 'medium',
           }
         })
         if (!cancelled) {


### PR DESCRIPTION
## Summary\n- treat canonical item lifecycle status (wishlist) as the source-of-truth for wishlist membership\n- keep wishlist entries for metadata overlays (target price/notes/highlight hit)\n- sync item status/priority when wishlist create/update/delete, discovery add-to-wishlist, and chat create_wishlist_entry paths run\n- load wishlist UI rows from /api/items?status=wishlist with /api/wishlist metadata overlay\n- update wishlist specs + Cypress contract to reflect canonical-item-source model\n\n## Validation\n- openspec validate --all --strict --no-interactive\n- go test ./internal/wishlist ./internal/discovery -count=1\n- go test ./internal/app -run TestWishlistAndPricingEndpoints -count=1\n- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser chrome -RequireE2EHooks\n\n## Notes\n- a broad baseline run of unrelated suites still shows existing failures in this branch baseline (chat schema/commerce/onboarding paths); this PR keeps scope focused to #535 wishlist contract behavior.