### PR TITLE
#547 Align UI journeys runner to existing Cypress specs

### DIFF
--- a/ui.web/cypress.config.runtime.cjs
+++ b/ui.web/cypress.config.runtime.cjs
@@ -1,0 +1,21 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://127.0.0.1:17880',
+    specPattern: 'cypress/e2e/**/*.cy.ts',
+    supportFile: 'cypress/support/e2e.ts',
+    defaultCommandTimeout: 10000,
+    requestTimeout: 10000,
+    responseTimeout: 20000,
+    retries: {
+      runMode: 2,
+      openMode: 0,
+    },
+  },
+  video: false,
+  screenshotOnRunFailure: true,
+  screenshotsFolder: 'cypress/artifacts/screenshots',
+  videosFolder: 'cypress/artifacts/videos',
+  fixturesFolder: 'cypress/fixtures',
+})

--- a/ui.web/package.json
+++ b/ui.web/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "serve:go": "go run ../cmd/cabinet",
     "e2e": "cypress run --browser electron",
-    "e2e:journeys": "cypress run --browser electron --spec cypress/e2e/journeys/**/*.cy.ts",
+    "e2e:journeys": "cypress run --browser electron --config-file cypress.config.runtime.cjs --spec \"cypress/e2e/**/*.cy.ts\"",
     "e2e:foundation": "pwsh -NoLogo -NoProfile -File ../cypress.ps1 -Spec cypress/e2e/general/ui-login-session/spec.cy.ts -Browser chrome",
     "e2e:run-smoke": "pwsh -NoLogo -NoProfile -File ../cypress.ps1 -Spec cypress/e2e/general/ui-login-session/spec.cy.ts -Browser chrome",
     "e2e:run-inventory": "pwsh -NoLogo -NoProfile -File ../cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser chrome",


### PR DESCRIPTION
## Summary
- update `ui.web` `e2e:journeys` script to target existing spec tree (`cypress/e2e/**/*.cy.ts`)
- remove stale hardcoded `cypress/e2e/journeys/**/*.cy.ts` reference
- add `ui.web/cypress.config.runtime.cjs` and run journeys script via that config for stable runtime bootstrap

## Validation
- `npm run e2e:journeys -- --spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts`
  - command resolves + executes Cypress against existing spec paths

## Notes
- This PR addresses blocker scope #547 (runner path/config drift).
- Test assertions may still be red for unrelated baseline behavior in individual specs; this change is focused on making the canonical full-regression command executable and aligned with repository paths.
