### PR TITLE
#555 test(cypress): make login smoke start signed out

### DIFF
--- a/ui.web/cypress/e2e/general/ui-login-session/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-login-session/spec.cy.ts
@@ -4,12 +4,10 @@ describe("ui-login-session", () => {
     cy.request("POST", "/api/test/runtime/setup-status", { state: "present" })
       .its("status")
       .should("eq", 200);
+    cy.e2eEnsureSignedOut();
   });
 
   it("UI-LOGIN-SESSION-001 redirects unauthenticated access to sign-in and returns to target after login", () => {
-    cy.clearCookies();
-    cy.clearLocalStorage();
-
     cy.visit("/inventory/");
     cy.location("pathname").should("eq", "/sign-in");
     cy.location("search").should("include", "redirect=");
@@ -26,9 +24,6 @@ describe("ui-login-session", () => {
   });
 
   it("UI-LOGIN-SESSION-002 keeps inline validation errors and allows retry without refresh", () => {
-    cy.clearCookies();
-    cy.clearLocalStorage();
-
     cy.visit("/sign-in");
     cy.get('input[name="email"]').type("invalid-email");
     cy.get('input[name="password"]').type("short");
@@ -48,9 +43,6 @@ describe("ui-login-session", () => {
   });
 
   it("UI-LOGIN-SESSION-003 switches active profile after login and uses selected profile scope for subsequent API calls", () => {
-    cy.clearCookies();
-    cy.clearLocalStorage();
-
     let activeProfile = { id: "p1", name: "Default" };
 
     cy.intercept("GET", "/api/profiles", {
@@ -125,9 +117,6 @@ describe("ui-login-session", () => {
   });
 
   it("UI-LOGIN-SESSION-005 redirects base unauthenticated entry to clean sign-in while preserving deep-link redirects", () => {
-    cy.clearCookies();
-    cy.clearLocalStorage();
-
     cy.visit("/");
     cy.location("pathname").should("eq", "/sign-in");
     cy.location("search").should("eq", "");
@@ -137,8 +126,7 @@ describe("ui-login-session", () => {
     cy.contains("button", "Sign in").click();
     cy.location("pathname", { timeout: 15000 }).should("match", /^\/dashboard\/?$/);
 
-    cy.clearCookies();
-    cy.clearLocalStorage();
+    cy.e2eEnsureSignedOut();
 
     cy.visit("/inventory/");
     cy.location("pathname").should("eq", "/sign-in");

--- a/ui.web/cypress/support/commands.ts
+++ b/ui.web/cypress/support/commands.ts
@@ -18,6 +18,7 @@ declare global {
     interface Chainable {
       e2eReset(): Chainable<void>;
       e2eBootstrap(options?: E2EBootstrapOptions): Chainable<E2EBootstrapState>;
+      e2eEnsureSignedOut(): Chainable<void>;
       e2eSetSetupState(state: E2ESetupState): Chainable<void>;
       e2eCompleteSetupHelper(overrides?: {
         instance_name?: string;
@@ -29,8 +30,36 @@ declare global {
   }
 }
 
+const AUTH_COOKIE_NAMES = ["thisisjustarandomstring", "cabinet_auth_user"] as const;
+
+function expireAuthCookies(win: Window) {
+  AUTH_COOKIE_NAMES.forEach((name) => {
+    win.document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  });
+}
+
 Cypress.Commands.add("e2eReset", () => {
   cy.request("POST", "/api/test/reset", {}).its("status").should("eq", 200);
+});
+
+Cypress.Commands.add("e2eEnsureSignedOut", () => {
+  cy.visit("/sign-out", {
+    onBeforeLoad(win) {
+      win.localStorage.clear();
+      win.sessionStorage.clear();
+      expireAuthCookies(win);
+    },
+  });
+
+  cy.clearCookies();
+  cy.clearLocalStorage();
+  cy.window({ log: false }).then((win) => {
+    win.sessionStorage.clear();
+    expireAuthCookies(win);
+  });
+  cy.getCookie("thisisjustarandomstring").should("not.exist");
+  cy.getCookie("cabinet_auth_user").should("not.exist");
+  cy.location("pathname", { timeout: 15000 }).should("eq", "/sign-in");
 });
 
 Cypress.Commands.add("e2eBootstrap", (options: E2EBootstrapOptions = {}) => {


### PR DESCRIPTION
## Summary
- add a deterministic Cypress helper that forces the app into a signed-out state
- use that helper in the login-session smoke spec before each test instead of assuming cookie clears are enough
- keep the main gate scoped to the same smoke spec, but make it reliable against persisted auth state

## Validation
- npm.cmd run build
- npx.cmd eslint cypress/support/commands.ts cypress/e2e/general/ui-login-session/spec.cy.ts

## Notes
- A direct local Cypress run is still blocked on this Windows workstation by the existing Cypress Electron startup issue (ad option: --smoke-test), so the decisive rerun is in GitHub Actions.
- A one-off TS command against Cypress files also surfaced an older pre-existing type mismatch around 2eCompleteSetupHelper; this change does not add new TS errors there.