### PR TITLE
#536 feat(wishlist): support moving wishlist items into inventory

### DIFF
--- a/internal/app/discovery_wishlist_pricing_api_test.go
+++ b/internal/app/discovery_wishlist_pricing_api_test.go
@@ -88,6 +88,22 @@ func TestWishlistAndPricingEndpoints(t *testing.T) {
 	if wid == "" {
 		t.Fatal("expected wishlist id")
 	}
+	itemsWishlist := doRequest(t, a, http.MethodGet, "/api/items?status=wishlist", nil, nil)
+	if itemsWishlist.Code != http.StatusOK {
+		t.Fatalf("wishlist items status=%d body=%s", itemsWishlist.Code, itemsWishlist.Body.String())
+	}
+	var wishlistItemsPayload struct {
+		Items []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(itemsWishlist.Body).Decode(&wishlistItemsPayload); err != nil {
+		t.Fatalf("decode wishlist items payload: %v", err)
+	}
+	if len(wishlistItemsPayload.Items) != 1 || wishlistItemsPayload.Items[0].ID != "i1" || wishlistItemsPayload.Items[0].Status != "wishlist" {
+		t.Fatalf("expected i1 in wishlist item listing, got %+v", wishlistItemsPayload.Items)
+	}
 	listWish := doRequest(t, a, http.MethodGet, "/api/wishlist", nil, nil)
 	if listWish.Code != http.StatusOK {
 		t.Fatalf("list wishlist status=%d body=%s", listWish.Code, listWish.Body.String())
@@ -145,5 +161,36 @@ func TestWishlistAndPricingEndpoints(t *testing.T) {
 	delWish := doRequest(t, a, http.MethodDelete, "/api/wishlist?id="+wid, nil, nil)
 	if delWish.Code != http.StatusNoContent {
 		t.Fatalf("delete wishlist status=%d body=%s", delWish.Code, delWish.Body.String())
+	}
+	itemsActive := doRequest(t, a, http.MethodGet, "/api/items", nil, nil)
+	if itemsActive.Code != http.StatusOK {
+		t.Fatalf("active items status=%d body=%s", itemsActive.Code, itemsActive.Body.String())
+	}
+	var activeItemsPayload struct {
+		Items []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(itemsActive.Body).Decode(&activeItemsPayload); err != nil {
+		t.Fatalf("decode active items payload: %v", err)
+	}
+	if len(activeItemsPayload.Items) != 1 || activeItemsPayload.Items[0].ID != "i1" || activeItemsPayload.Items[0].Status != "active" {
+		t.Fatalf("expected i1 restored to active item listing after wishlist delete, got %+v", activeItemsPayload.Items)
+	}
+	itemsWishlistAfterDelete := doRequest(t, a, http.MethodGet, "/api/items?status=wishlist", nil, nil)
+	if itemsWishlistAfterDelete.Code != http.StatusOK {
+		t.Fatalf("wishlist items after delete status=%d body=%s", itemsWishlistAfterDelete.Code, itemsWishlistAfterDelete.Body.String())
+	}
+	var wishlistItemsAfterDeletePayload struct {
+		Items []struct {
+			ID string `json:"id"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(itemsWishlistAfterDelete.Body).Decode(&wishlistItemsAfterDeletePayload); err != nil {
+		t.Fatalf("decode wishlist items after delete payload: %v", err)
+	}
+	if len(wishlistItemsAfterDeletePayload.Items) != 0 {
+		t.Fatalf("expected wishlist item listing empty after delete, got %+v", wishlistItemsAfterDeletePayload.Items)
 	}
 }

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -44,8 +44,10 @@ describe("ui-screen-wishlist", () => {
     }).as("catalogItems");
   }
 
-  function signInToWishlist() {
-    stubWishlistData();
+  function signInToWishlist(options?: { skipStub?: boolean }) {
+    if (!options?.skipStub) {
+      stubWishlistData();
+    }
     cy.visit("/sign-in?redirect=%2Fwishlist%2F");
     cy.get('input[name="email"]').clear().type("e2e-wishlist@example.com");
     cy.get('input[name="password"]').clear().type("password123");
@@ -149,5 +151,74 @@ describe("ui-screen-wishlist", () => {
     cy.contains("Below target").should("be.visible");
     cy.contains(/TASK-\d+/).should("not.exist");
     cy.contains("Backlog").should("not.exist");
+  });
+
+  it("UI-SCREEN-WISHLIST-006 moves acquired item into inventory and keeps it out of wishlist after refresh", () => {
+    let wishlistEntries = [
+      {
+        id: "wish-1",
+        item_id: "item-collector-1",
+        priority: "high",
+        below_target_now: false,
+      },
+    ];
+    let wishlistItems = [
+      {
+        id: "item-collector-1",
+        title: "AFX Mega-G+ Camaro Wildfire",
+        part_number: "22073",
+        status: "wishlist",
+        category: "Slot Cars",
+        priority: "high",
+      },
+    ];
+    const inventoryItems = [
+      {
+        id: "item-collector-1",
+        title: "AFX Mega-G+ Camaro Wildfire",
+        part_number: "22073",
+        status: "active",
+        category: "Slot Cars",
+        priority: "high",
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistItems } });
+    }).as("catalogItems");
+    cy.intercept("DELETE", "/api/wishlist?id=wish-1", (req) => {
+      wishlistEntries = [];
+      wishlistItems = [];
+      req.reply({ statusCode: 204, body: "" });
+    }).as("moveWishlistItemToOwned");
+    cy.intercept("GET", "/api/items", {
+      statusCode: 200,
+      body: { items: inventoryItems },
+    }).as("inventoryItems");
+
+    signInToWishlist({ skipStub: true });
+
+    cy.contains("tr", "AFX Mega-G+ Camaro Wildfire").within(() => {
+      cy.get('[data-testid="task-row-actions-trigger"]').click();
+    });
+    cy.get('[data-testid="wishlist-mark-owned-action"]').click();
+
+    cy.wait("@moveWishlistItemToOwned");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+
+    cy.reload();
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+
+    cy.visit("/inventory/");
+    cy.wait("@inventoryItems");
+    cy.location("pathname", { timeout: 15000 }).should("match", /^\/inventory\/?$/);
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
   });
 });

--- a/ui.web/src/features/tasks/components/data-table-row-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-row-actions.tsx
@@ -16,17 +16,25 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { labels } from '../data/data'
-import { taskSchema } from '../data/schema'
+import { type Task, taskSchema } from '../data/schema'
 import { useTasks } from './tasks-provider'
 
 type DataTableRowActionsProps<TData> = {
   row: Row<TData>
+  routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+  onWishlistMarkOwned?: (task: Task) => Promise<void>
+  wishlistActionItemID?: string | null
 }
 
 export function DataTableRowActions<TData>({
   row,
+  routePath,
+  onWishlistMarkOwned,
+  wishlistActionItemID,
 }: DataTableRowActionsProps<TData>) {
   const task = taskSchema.parse(row.original)
+  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
+  const isWishlistActionPending = wishlistActionItemID === task.id
 
   const { setOpen, setCurrentRow } = useTasks()
 
@@ -36,12 +44,29 @@ export function DataTableRowActions<TData>({
         <Button
           variant='ghost'
           className='flex h-8 w-8 p-0 data-[state=open]:bg-muted'
+          data-testid='task-row-actions-trigger'
         >
           <DotsHorizontalIcon className='h-4 w-4' />
           <span className='sr-only'>Open menu</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end' className='w-[160px]'>
+        {isWishlistRoute ? (
+          <>
+            <DropdownMenuItem
+              data-testid='wishlist-mark-owned-action'
+              disabled={!task.wishlistEntryID || isWishlistActionPending}
+              onClick={() => {
+                if (onWishlistMarkOwned) {
+                  void onWishlistMarkOwned(task)
+                }
+              }}
+            >
+              {isWishlistActionPending ? 'Moving...' : 'Mark owned'}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
         <DropdownMenuItem
           onClick={() => {
             setCurrentRow(task)

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -10,6 +10,8 @@ export type TasksRoutePath = '/_authenticated/inventory/' | '/_authenticated/wis
 
 type TasksColumnsOptions = {
   routePath: TasksRoutePath
+  onWishlistMarkOwned?: (task: Task) => Promise<void>
+  wishlistActionItemID?: string | null
 }
 
 const wishlistStatusLabels: Record<string, string> = {
@@ -17,7 +19,11 @@ const wishlistStatusLabels: Record<string, string> = {
   discovered: 'Below target',
 }
 
-export function getTasksColumns({ routePath }: TasksColumnsOptions): ColumnDef<Task>[] {
+export function getTasksColumns({
+  routePath,
+  onWishlistMarkOwned,
+  wishlistActionItemID,
+}: TasksColumnsOptions): ColumnDef<Task>[] {
   const isInventoryRoute = routePath === '/_authenticated/inventory/'
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
 
@@ -165,7 +171,14 @@ export function getTasksColumns({ routePath }: TasksColumnsOptions): ColumnDef<T
     },
     {
       id: 'actions',
-      cell: ({ row }) => <DataTableRowActions row={row} />,
+      cell: ({ row }) => (
+        <DataTableRowActions
+          row={row}
+          routePath={routePath}
+          onWishlistMarkOwned={onWishlistMarkOwned}
+          wishlistActionItemID={wishlistActionItemID}
+        />
+      ),
     },
   ]
 }

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -52,6 +52,8 @@ type DataTableProps = {
   routePath: TasksRoutePath
   currentRecordID?: string
   onRecordFocus?: (itemID: string, recordID: string, title: string) => void
+  onWishlistMarkOwned?: (task: Task) => Promise<void>
+  wishlistActionItemID?: string | null
 }
 
 type ViewMode = 'rows' | 'cards'
@@ -61,8 +63,18 @@ export function TasksTable({
   routePath,
   currentRecordID,
   onRecordFocus,
+  onWishlistMarkOwned,
+  wishlistActionItemID,
 }: DataTableProps) {
-  const columns = useMemo(() => getTasksColumns({ routePath }), [routePath])
+  const columns = useMemo(
+    () =>
+      getTasksColumns({
+        routePath,
+        onWishlistMarkOwned,
+        wishlistActionItemID,
+      }),
+    [routePath, onWishlistMarkOwned, wishlistActionItemID]
+  )
 
   const route =
     routePath === '/_authenticated/inventory/'
@@ -108,7 +120,6 @@ export function TasksTable({
     ],
   })
 
-  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data,
     columns,
@@ -168,7 +179,7 @@ export function TasksTable({
 
   const visibleRecordIDs = useMemo(
     () => table.getRowModel().rows.map((row) => row.original.id),
-    [table, data, rowSelection, columnFilters, globalFilter, pagination, sorting]
+    [table]
   )
 
   const selectedVisibleIndex = selectedRecordID

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 export const taskSchema = z.object({
   id: z.string(),
   itemID: z.string().optional(),
+  wishlistEntryID: z.string().optional(),
   title: z.string(),
   status: z.string(),
   label: z.string(),

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -17,7 +17,8 @@ import {
   collectionKey,
   useWorkspaceCollections,
 } from '@/features/collections/use-workspace-collections'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
 import { TasksDialogs } from './components/tasks-dialogs'
 import { TasksProvider } from './components/tasks-provider'
 import { TasksTable } from './components/tasks-table'
@@ -46,7 +47,69 @@ export function Tasks({
   const [inlineCollectionValidationMessage, setInlineCollectionValidationMessage] =
     useState('')
   const [tableData, setTableData] = useState<Task[]>(tasks)
+  const [wishlistActionItemID, setWishlistActionItemID] = useState<string | null>(
+    null
+  )
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
+
+  const loadWishlistData = useCallback(async () => {
+    const [wishlistResponse, itemsResponse] = await Promise.all([
+      fetch('/api/wishlist'),
+      fetch('/api/items?status=wishlist'),
+    ])
+    if (!wishlistResponse.ok || !itemsResponse.ok) {
+      throw new Error('wishlist_bootstrap_failed')
+    }
+    const wishlistPayload = (await wishlistResponse.json()) as {
+      items?: Array<{
+        id?: string
+        item_id?: string
+        priority?: string
+        below_target_now?: boolean
+      }>
+    }
+    const itemsPayload = (await itemsResponse.json()) as {
+      items?: Array<{
+        id?: string
+        title?: string
+        part_number?: string
+        category?: string
+        priority?: string
+      }>
+    }
+    const wishlistByItemID = new Map<
+      string,
+      {
+        id?: string
+        priority?: string
+        below_target_now?: boolean
+      }
+    >()
+    ;(wishlistPayload.items ?? []).forEach((entry) => {
+      const itemID = entry.item_id?.trim()
+      if (!itemID) {
+        return
+      }
+      wishlistByItemID.set(itemID, entry)
+    })
+    return (itemsPayload.items ?? []).map((item, index) => {
+      const itemID = item.id?.trim() || `wishlist-item-${index + 1}`
+      const wishlistEntry = wishlistByItemID.get(itemID)
+      return {
+        id: itemID,
+        itemID: itemID,
+        wishlistEntryID: wishlistEntry?.id?.trim(),
+        title:
+          item.title?.trim() ||
+          item.part_number?.trim() ||
+          `Wishlist item ${index + 1}`,
+        status: wishlistEntry?.below_target_now ? 'discovered' : 'wishlist',
+        label: item.category?.trim() || 'collection',
+        priority:
+          wishlistEntry?.priority?.trim() || item.priority?.trim() || 'medium',
+      } satisfies Task
+    })
+  }, [])
 
   useEffect(() => {
     if (!isWishlistRoute) {
@@ -55,73 +118,50 @@ export function Tasks({
     }
 
     let cancelled = false
-    const loadWishlistData = async () => {
-      try {
-        const [wishlistResponse, itemsResponse] = await Promise.all([
-          fetch('/api/wishlist'),
-          fetch('/api/items?status=wishlist'),
-        ])
-        if (!wishlistResponse.ok || !itemsResponse.ok) {
-          throw new Error('wishlist_bootstrap_failed')
-        }
-        const wishlistPayload = (await wishlistResponse.json()) as {
-          items?: Array<{
-            item_id?: string
-            priority?: string
-            below_target_now?: boolean
-          }>
-        }
-        const itemsPayload = (await itemsResponse.json()) as {
-          items?: Array<{
-            id?: string
-            title?: string
-            part_number?: string
-            category?: string
-            priority?: string
-          }>
-        }
-        const wishlistByItemID = new Map<
-          string,
-          {
-            priority?: string
-            below_target_now?: boolean
-          }
-        >()
-        ;(wishlistPayload.items ?? []).forEach((entry) => {
-          const itemID = entry.item_id?.trim()
-          if (!itemID) {
-            return
-          }
-          wishlistByItemID.set(itemID, entry)
-        })
-        const mapped: Task[] = (itemsPayload.items ?? []).map((item, index) => {
-          const itemID = item.id?.trim() || `wishlist-item-${index + 1}`
-          const wishlistEntry = wishlistByItemID.get(itemID)
-          return {
-            id: itemID,
-            title:
-              item.title?.trim() || item.part_number?.trim() || `Wishlist item ${index + 1}`,
-            status: wishlistEntry?.below_target_now ? 'discovered' : 'wishlist',
-            label: item.category?.trim() || 'collection',
-            priority:
-              wishlistEntry?.priority?.trim() || item.priority?.trim() || 'medium',
-          }
-        })
+    void loadWishlistData()
+      .then((mapped) => {
         if (!cancelled) {
           setTableData(mapped)
         }
-      } catch {
+      })
+      .catch(() => {
         if (!cancelled) {
           setTableData([])
         }
-      }
-    }
+      })
 
-    void loadWishlistData()
     return () => {
       cancelled = true
     }
-  }, [isWishlistRoute])
+  }, [isWishlistRoute, loadWishlistData])
+
+  const handleWishlistMarkOwned = useCallback(
+    async (task: Task) => {
+      const wishlistEntryID = task.wishlistEntryID?.trim()
+      if (!wishlistEntryID) {
+        toast.error('Wishlist entry is missing transition metadata.')
+        return
+      }
+      setWishlistActionItemID(task.id)
+      try {
+        const response = await fetch(
+          `/api/wishlist?id=${encodeURIComponent(wishlistEntryID)}`,
+          { method: 'DELETE' }
+        )
+        if (!response.ok) {
+          throw new Error('failed_to_move_wishlist_item_to_owned')
+        }
+        const mapped = await loadWishlistData()
+        setTableData(mapped)
+        toast.success(`${task.title} moved to inventory.`)
+      } catch {
+        toast.error('Move to inventory failed. Try again.')
+      } finally {
+        setWishlistActionItemID(null)
+      }
+    },
+    [loadWishlistData]
+  )
 
   return (
     <TasksProvider>
@@ -275,7 +315,14 @@ export function Tasks({
             ) : null}
           </div>
         ) : null}
-        <TasksTable data={tableData} routePath={routePath} />
+        <TasksTable
+          data={tableData}
+          routePath={routePath}
+          onWishlistMarkOwned={
+            isWishlistRoute ? handleWishlistMarkOwned : undefined
+          }
+          wishlistActionItemID={wishlistActionItemID}
+        />
       </Main>
 
       <TasksDialogs />


### PR DESCRIPTION
## Summary
- add explicit wishlist row action to move acquired items into owned inventory
- reload wishlist data after transition and keep per-row pending state visible
- add API and Cypress coverage for wishlist-to-owned persistence

## Validation
- `go test ./internal/app -run TestWishlistAndPricingEndpoints -count=1`
- `npx.cmd eslint ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts ui.web/src/features/tasks/index.tsx ui.web/src/features/tasks/components/tasks-table.tsx ui.web/src/features/tasks/components/tasks-columns.tsx ui.web/src/features/tasks/components/data-table-row-actions.tsx ui.web/src/features/tasks/data/schema.ts`
- `npm.cmd run build` in `ui.web`
- manual Playwright sanity against disposable local runtime with E2E hooks enabled