### PR TITLE
#535 feat(wishlist): add planning focus summary

### DIFF
--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -221,4 +221,124 @@ describe("ui-screen-wishlist", () => {
     cy.location("pathname", { timeout: 15000 }).should("match", /^\/inventory\/?$/);
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
   });
+
+  it("UI-SCREEN-WISHLIST-008 surfaces planning summary and persists selected focus across refresh and route return", () => {
+    cy.intercept("GET", "/api/wishlist", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "wish-1",
+            item_id: "item-collector-1",
+            priority: "medium",
+            below_target_now: false,
+            notes: "Wait for convention restock",
+          },
+          {
+            id: "wish-2",
+            item_id: "item-collector-2",
+            priority: "high",
+            below_target_now: true,
+            notes: "Buy if price drops again",
+          },
+          {
+            id: "wish-3",
+            item_id: "item-collector-3",
+            priority: "critical",
+            below_target_now: false,
+            notes: "Need before championship season",
+          },
+        ],
+      },
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "item-collector-1",
+            title: "AFX Mega-G+ Camaro Wildfire",
+            part_number: "22073",
+            status: "wishlist",
+            category: "Slot Cars",
+            priority: "medium",
+          },
+          {
+            id: "item-collector-2",
+            title: "F1 Silverline",
+            part_number: "F1002",
+            status: "wishlist",
+            category: "Formula",
+            priority: "high",
+          },
+          {
+            id: "item-collector-3",
+            title: "Team Transport Hauler",
+            part_number: "TT-88",
+            status: "wishlist",
+            category: "Haulers",
+            priority: "critical",
+          },
+        ],
+      },
+    }).as("catalogItems");
+
+    signInToWishlist({ skipStub: true });
+
+    cy.get('[data-testid="wishlist-planning-summary"]').should("be.visible");
+    cy.get('[data-testid="wishlist-planning-focus-all"]').should(
+      "contain",
+      "3"
+    );
+    cy.get('[data-testid="wishlist-planning-focus-high-priority"]').should(
+      "contain",
+      "2"
+    );
+    cy.get('[data-testid="wishlist-planning-focus-below-target"]').should(
+      "contain",
+      "1"
+    );
+    cy.get('[data-testid="wishlist-planning-focus-watchlist"]').should(
+      "contain",
+      "1"
+    );
+
+    cy.get('[data-testid="wishlist-planning-focus-below-target"]').click();
+    cy.window()
+      .its("localStorage")
+      .invoke("getItem", "cabinet.wishlistPlanningFocus")
+      .should("eq", "below-target");
+    cy.get('[data-testid="wishlist-planning-focus-below-target"]').should(
+      "have.attr",
+      "aria-pressed",
+      "true"
+    );
+    cy.contains("F1 Silverline").should("be.visible");
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+    cy.contains("Team Transport Hauler").should("not.exist");
+
+    cy.reload();
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.get('[data-testid="wishlist-planning-focus-below-target"]').should(
+      "have.attr",
+      "aria-pressed",
+      "true"
+    );
+    cy.contains("F1 Silverline").should("be.visible");
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+
+    cy.visit("/inventory/");
+    cy.location("pathname", { timeout: 15000 }).should("match", /^\/inventory\/?$/);
+    cy.visit("/wishlist/");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.get('[data-testid="wishlist-planning-focus-below-target"]').should(
+      "have.attr",
+      "aria-pressed",
+      "true"
+    );
+    cy.contains("F1 Silverline").should("be.visible");
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+  });
 });

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -19,6 +19,10 @@ const wishlistStatusLabels: Record<string, string> = {
   discovered: 'Below target',
 }
 
+function formatWishlistStatus(status: string) {
+  return wishlistStatusLabels[status] ?? status
+}
+
 export function getTasksColumns({
   routePath,
   onWishlistMarkOwned,
@@ -77,9 +81,16 @@ export function getTasksColumns({
         const label = labels.find((label) => label.value === row.original.label)
 
         return (
-          <div className='flex space-x-2'>
+          <div className='flex min-w-0 flex-col gap-1'>
             {!isInventoryRoute && !isWishlistRoute && label ? <Badge variant='outline'>{label.label}</Badge> : null}
-            <span className='truncate font-medium'>{row.getValue('title')}</span>
+            <div className='flex space-x-2'>
+              <span className='truncate font-medium'>{row.getValue('title')}</span>
+            </div>
+            {isWishlistRoute && row.original.notes ? (
+              <span className='truncate text-xs text-muted-foreground'>
+                {row.original.notes}
+              </span>
+            ) : null}
           </div>
         )
       },
@@ -105,7 +116,7 @@ export function getTasksColumns({
         if (isWishlistRoute) {
           return (
             <div className='flex min-w-[120px] items-center gap-2'>
-              <span>{wishlistStatusLabels[row.original.status] ?? row.original.status}</span>
+              <span>{formatWishlistStatus(row.original.status)}</span>
             </div>
           )
         }

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -58,6 +58,16 @@ type DataTableProps = {
 
 type ViewMode = 'rows' | 'cards'
 
+function formatWishlistStatus(status: string) {
+  if (status === 'wishlist') {
+    return 'Watching'
+  }
+  if (status === 'discovered') {
+    return 'Below target'
+  }
+  return status
+}
+
 export function TasksTable({
   data,
   routePath,
@@ -423,10 +433,20 @@ export function TasksTable({
                   />
                 </div>
                 <div className='flex flex-wrap gap-2 text-xs text-muted-foreground'>
-                  <span>Status: {row.original.status}</span>
+                  <span>
+                    Status:{' '}
+                    {routePath === '/_authenticated/wishlist/'
+                      ? formatWishlistStatus(row.original.status)
+                      : row.original.status}
+                  </span>
                   <span>Priority: {row.original.priority}</span>
                   <span>Type: {row.original.label}</span>
                 </div>
+                {routePath === '/_authenticated/wishlist/' && row.original.notes ? (
+                  <p className='text-xs text-muted-foreground'>
+                    Notes: {row.original.notes}
+                  </p>
+                ) : null}
               </div>
             ))
           ) : (
@@ -458,6 +478,11 @@ export function TasksTable({
               <p>
                 <strong>Status:</strong> {selectedRecord.status}
               </p>
+              {selectedRecord.notes ? (
+                <p>
+                  <strong>Notes:</strong> {selectedRecord.notes}
+                </p>
+              ) : null}
             </div>
           ) : null}
         </DialogContent>

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -10,6 +10,8 @@ export const taskSchema = z.object({
   status: z.string(),
   label: z.string(),
   priority: z.string(),
+  notes: z.string().optional(),
+  belowTargetNow: z.boolean().optional(),
 })
 
 export type Task = z.infer<typeof taskSchema>

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -17,7 +17,7 @@ import {
   collectionKey,
   useWorkspaceCollections,
 } from '@/features/collections/use-workspace-collections'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { TasksDialogs } from './components/tasks-dialogs'
 import { TasksProvider } from './components/tasks-provider'
@@ -29,6 +29,72 @@ type TasksProps = {
   title?: string
   description?: string
   routePath?: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+}
+
+const WISHLIST_PLANNING_FOCUS_STORAGE_KEY = 'cabinet.wishlistPlanningFocus'
+
+type WishlistPlanningFocus =
+  | 'all'
+  | 'high-priority'
+  | 'below-target'
+  | 'watchlist'
+
+const wishlistPlanningFocusConfig: Array<{
+  id: WishlistPlanningFocus
+  label: string
+  description: string
+}> = [
+  {
+    id: 'all',
+    label: 'All planned',
+    description: 'Everything currently being tracked.',
+  },
+  {
+    id: 'high-priority',
+    label: 'High priority',
+    description: 'High and critical items that need active attention.',
+  },
+  {
+    id: 'below-target',
+    label: 'Below target',
+    description: 'Items currently priced at or below target.',
+  },
+  {
+    id: 'watchlist',
+    label: 'Steady watch',
+    description: 'Items to monitor without immediate urgency.',
+  },
+]
+
+function normalizeWishlistPlanningFocus(
+  value: string | null | undefined
+): WishlistPlanningFocus {
+  switch (value) {
+    case 'high-priority':
+    case 'below-target':
+    case 'watchlist':
+      return value
+    default:
+      return 'all'
+  }
+}
+
+function matchesWishlistPlanningFocus(
+  task: Task,
+  focus: WishlistPlanningFocus
+): boolean {
+  const priority = task.priority.trim().toLowerCase()
+  const isBelowTarget = Boolean(task.belowTargetNow)
+  switch (focus) {
+    case 'high-priority':
+      return priority === 'high' || priority === 'critical'
+    case 'below-target':
+      return isBelowTarget
+    case 'watchlist':
+      return !isBelowTarget && priority !== 'high' && priority !== 'critical'
+    default:
+      return true
+  }
 }
 
 export function Tasks({
@@ -50,6 +116,15 @@ export function Tasks({
   const [wishlistActionItemID, setWishlistActionItemID] = useState<string | null>(
     null
   )
+  const [wishlistPlanningFocus, setWishlistPlanningFocus] =
+    useState<WishlistPlanningFocus>(() => {
+      if (typeof window === 'undefined') {
+        return 'all'
+      }
+      return normalizeWishlistPlanningFocus(
+        window.localStorage.getItem(WISHLIST_PLANNING_FOCUS_STORAGE_KEY)
+      )
+    })
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
 
   const loadWishlistData = useCallback(async () => {
@@ -65,6 +140,7 @@ export function Tasks({
         id?: string
         item_id?: string
         priority?: string
+        notes?: string
         below_target_now?: boolean
       }>
     }
@@ -82,6 +158,7 @@ export function Tasks({
       {
         id?: string
         priority?: string
+        notes?: string
         below_target_now?: boolean
       }
     >()
@@ -107,6 +184,8 @@ export function Tasks({
         label: item.category?.trim() || 'collection',
         priority:
           wishlistEntry?.priority?.trim() || item.priority?.trim() || 'medium',
+        notes: wishlistEntry?.notes?.trim(),
+        belowTargetNow: Boolean(wishlistEntry?.below_target_now),
       } satisfies Task
     })
   }, [])
@@ -162,6 +241,37 @@ export function Tasks({
     },
     [loadWishlistData]
   )
+
+  useEffect(() => {
+    if (!isWishlistRoute || typeof window === 'undefined') {
+      return
+    }
+    window.localStorage.setItem(
+      WISHLIST_PLANNING_FOCUS_STORAGE_KEY,
+      wishlistPlanningFocus
+    )
+  }, [isWishlistRoute, wishlistPlanningFocus])
+
+  const wishlistPlanningSummary = useMemo(() => {
+    if (!isWishlistRoute) {
+      return []
+    }
+    return wishlistPlanningFocusConfig.map((focus) => ({
+      ...focus,
+      count: tableData.filter((task) =>
+        matchesWishlistPlanningFocus(task, focus.id)
+      ).length,
+    }))
+  }, [isWishlistRoute, tableData])
+
+  const displayedData = useMemo(() => {
+    if (!isWishlistRoute) {
+      return tableData
+    }
+    return tableData.filter((task) =>
+      matchesWishlistPlanningFocus(task, wishlistPlanningFocus)
+    )
+  }, [isWishlistRoute, tableData, wishlistPlanningFocus])
 
   return (
     <TasksProvider>
@@ -224,6 +334,37 @@ export function Tasks({
             </DropdownMenu>
           </div>
         </div>
+        {isWishlistRoute ? (
+          <div
+            className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'
+            data-testid='wishlist-planning-summary'
+          >
+            {wishlistPlanningSummary.map((focus) => (
+              <button
+                key={focus.id}
+                type='button'
+                data-testid={`wishlist-planning-focus-${focus.id}`}
+                className={`rounded-lg border p-4 text-left transition-colors ${
+                  wishlistPlanningFocus === focus.id
+                    ? 'border-primary bg-primary/5'
+                    : 'hover:bg-accent/40'
+                }`}
+                aria-pressed={wishlistPlanningFocus === focus.id}
+                onClick={() => setWishlistPlanningFocus(focus.id)}
+              >
+                <div className='flex items-start justify-between gap-3'>
+                  <div>
+                    <p className='text-sm font-medium'>{focus.label}</p>
+                    <p className='mt-1 text-xs text-muted-foreground'>
+                      {focus.description}
+                    </p>
+                  </div>
+                  <span className='text-2xl font-semibold'>{focus.count}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        ) : null}
         {isWishlistRoute ? (
           <div
             className='rounded-md border p-3'
@@ -316,7 +457,7 @@ export function Tasks({
           </div>
         ) : null}
         <TasksTable
-          data={tableData}
+          data={displayedData}
           routePath={routePath}
           onWishlistMarkOwned={
             isWishlistRoute ? handleWishlistMarkOwned : undefined


### PR DESCRIPTION
## Summary
- add wishlist planning summary buttons for high-priority, below-target, and steady-watch views
- persist the selected planning focus across refresh and route return
- surface wishlist notes inside the primary planning workflow
- add focused E2E coverage for planning summary filtering and persistence

## Validation
- `npx.cmd eslint ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts ui.web/src/features/tasks/index.tsx ui.web/src/features/tasks/components/tasks-columns.tsx ui.web/src/features/tasks/components/tasks-table.tsx ui.web/src/features/tasks/data/schema.ts`
- `npm.cmd run build` in `ui.web`
- manual Playwright sanity against a temporary runtime