### PR TITLE
#535 feat(wishlist): wire real wishlist actions

### DIFF
--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -48,14 +48,13 @@ describe("ui-screen-wishlist", () => {
     if (!options?.skipStub) {
       stubWishlistData();
     }
-    cy.visit("/sign-in?redirect=%2Fwishlist%2F");
-    cy.get('input[name="email"]').clear().type("e2e-wishlist@example.com");
-    cy.get('input[name="password"]').clear().type("password123");
-    cy.contains("button", "Sign in").click();
-    cy.location("pathname", { timeout: 15000 }).should(
-      "match",
-      /^\/wishlist\/?$/
-    );
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: "/wishlist/",
+      });
+    });
     cy.wait("@wishlistItems");
     cy.wait("@catalogItems");
   }
@@ -85,8 +84,8 @@ describe("ui-screen-wishlist", () => {
     cy.contains(/selected/i).should("be.visible");
     cy.get('button[aria-label="Update status"]').should("be.visible");
     cy.get('button[aria-label="Update priority"]').should("be.visible");
-    cy.get('button[aria-label="Export tasks"]').should("be.visible");
-    cy.get('button[aria-label="Delete selected tasks"]').should("be.visible");
+    cy.get('button[aria-label="Export wishlist entries"]').should("be.visible");
+    cy.get('button[aria-label="Delete selected wishlist entries"]').should("be.visible");
   });
 
   it("UI-SCREEN-WISHLIST-002 opens create and import actions from Create menu", () => {
@@ -340,5 +339,128 @@ describe("ui-screen-wishlist", () => {
     );
     cy.contains("F1 Silverline").should("be.visible");
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+  });
+
+  it("UI-SCREEN-WISHLIST-009 wires New and Create actions into real wishlist dialogs", () => {
+    signInToWishlist();
+
+    cy.get('[data-testid="wishlist-new-action"]').click();
+    cy.contains("Create Wishlist Entry").should("be.visible");
+
+    cy.contains("button", "Close").click();
+
+    cy.get('[data-testid="wishlist-create-menu-trigger"]').click();
+    cy.get('[data-testid="wishlist-create-menu-entry"]').click();
+    cy.contains("Create Wishlist Entry").should("be.visible");
+
+    cy.contains("button", "Close").click();
+
+    cy.get('[data-testid="wishlist-create-menu-trigger"]').click();
+    cy.get('[data-testid="wishlist-create-menu-import"]').click();
+    cy.contains("Import Wishlist Entries").should("be.visible");
+  });
+
+  it("UI-SCREEN-WISHLIST-010 persists wishlist edit and delete actions", () => {
+    let wishlistEntries = [
+      {
+        id: "wish-edit-1",
+        item_id: "item-collector-1",
+        priority: "medium",
+        below_target_now: false,
+        notes: "Original watch note",
+        target_price: 20,
+      },
+    ];
+    let wishlistItems = [
+      {
+        id: "item-collector-1",
+        title: "AFX Mega-G+ Camaro Wildfire",
+        part_number: "22073",
+        status: "wishlist",
+        category: "Slot Cars",
+        priority: "medium",
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistItems } });
+    }).as("catalogItems");
+    cy.intercept("PUT", "/api/wishlist", (req) => {
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === req.body.id
+          ? {
+              ...entry,
+              priority: req.body.priority,
+              notes: req.body.notes,
+              target_price: req.body.target_price,
+            }
+          : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("updateWishlistEntry");
+    cy.intercept("PUT", "/api/items/item-collector-1", (req) => {
+      wishlistItems = wishlistItems.map((item) =>
+        item.id === "item-collector-1"
+          ? {
+              ...item,
+              title: req.body.title,
+              category: req.body.category,
+            }
+          : item
+      );
+      req.reply({
+        statusCode: 200,
+        body: {
+          ...wishlistItems[0],
+          title: req.body.title,
+          category: req.body.category,
+        },
+      });
+    }).as("updateWishlistItem");
+    cy.intercept("DELETE", "/api/wishlist?id=wish-edit-1", (req) => {
+      wishlistEntries = [];
+      wishlistItems = [];
+      req.reply({ statusCode: 204, body: "" });
+    }).as("deleteWishlistEntry");
+
+    signInToWishlist({ skipStub: true });
+
+    cy.contains("tr", "AFX Mega-G+ Camaro Wildfire").within(() => {
+      cy.get('[data-testid="task-row-actions-trigger"]').click();
+    });
+    cy.contains('[role="menuitem"]', "Edit").click();
+
+    cy.contains("Edit Wishlist Entry").should("be.visible");
+    cy.get('input[name="title"]').clear().type("AFX Mega-G+ Camaro Updated");
+    cy.get('textarea[name="notes"]').clear().type("Updated watch note");
+    cy.contains("button", "Save changes").click();
+
+    cy.wait("@updateWishlistItem");
+    cy.wait("@updateWishlistEntry");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("AFX Mega-G+ Camaro Updated").should("be.visible");
+    cy.contains("Updated watch note").should("be.visible");
+
+    cy.contains("tr", "AFX Mega-G+ Camaro Updated").within(() => {
+      cy.get('[data-testid="task-row-actions-trigger"]').click();
+    });
+    cy.get('[role="menu"]')
+      .should("be.visible")
+      .within(() => {
+        cy.contains('[role="menuitem"]', /^Delete$/)
+          .should("be.visible")
+          .click({ force: true });
+      });
+    cy.contains("Delete this wishlist entry").should("be.visible");
+    cy.contains("button", "Delete").click();
+
+    cy.wait("@deleteWishlistEntry");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("AFX Mega-G+ Camaro Updated").should("not.exist");
   });
 });

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -47,7 +47,10 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { TasksTable } from '@/features/tasks/components/tasks-table'
-import { TasksDialogs } from '@/features/tasks/components/tasks-dialogs'
+import {
+  TasksDialogs,
+  type TasksDialogType,
+} from '@/features/tasks/components/tasks-dialogs'
 import { TasksProvider } from '@/features/tasks/components/tasks-provider'
 import { tasks } from '@/features/tasks/data/tasks'
 import { type Task } from '@/features/tasks/data/schema'
@@ -749,6 +752,9 @@ export function Collection({
   const [itemSaveBusy, setItemSaveBusy] = useState(false)
   const [itemSaveError, setItemSaveError] = useState<string | null>(null)
   const [itemSaveSuccess, setItemSaveSuccess] = useState<string | null>(null)
+  const [tasksDialogOpen, setTasksDialogOpen] =
+    useState<TasksDialogType | null>(null)
+  const [tasksDialogRow, setTasksDialogRow] = useState<Task | null>(null)
   const [barcodeAddInput, setBarcodeAddInput] = useState('')
   const [barcodeLookupInput, setBarcodeLookupInput] = useState('')
   const [barcodeAddBusy, setBarcodeAddBusy] = useState(false)
@@ -3126,7 +3132,13 @@ export function Collection({
           </DialogContent>
         </Dialog>
       </Main>
-      <TasksDialogs />
+      <TasksDialogs
+        routePath='/_authenticated/inventory/'
+        open={tasksDialogOpen}
+        setOpen={setTasksDialogOpen}
+        currentRow={tasksDialogRow}
+        setCurrentRow={setTasksDialogRow}
+      />
     </TasksProvider>
   )
 }

--- a/ui.web/src/features/tasks/components/data-table-bulk-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-bulk-actions.tsx
@@ -1,9 +1,15 @@
-import { useState } from 'react'
+import { type ComponentType, useState } from 'react'
 import { type Table } from '@tanstack/react-table'
-import { Trash2, CircleArrowUp, ArrowUpDown, Download } from 'lucide-react'
+import {
+  ArrowUpDown,
+  CircleArrowUp,
+  Download,
+  Trash2,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import { sleep } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { DataTableBulkActions as BulkActionsToolbar } from '@/components/data-table'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,23 +21,44 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { DataTableBulkActions as BulkActionsToolbar } from '@/components/data-table'
 import { priorities, statuses } from '../data/data'
 import { type Task } from '../data/schema'
 import { TasksMultiDeleteDialog } from './tasks-multi-delete-dialog'
 
-type DataTableBulkActionsProps<TData> = {
+interface DataTableBulkActionsProps<TData> {
   table: Table<TData>
+  routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+  onWishlistBulkStatusChange?: (tasks: Task[], status: string) => Promise<void>
+  onWishlistBulkPriorityChange?: (tasks: Task[], priority: string) => Promise<void>
+  onWishlistBulkDelete?: (tasks: Task[]) => Promise<void>
+  onWishlistExport?: (tasks: Task[]) => void
+  isWishlistMutating?: boolean
 }
 
 export function DataTableBulkActions<TData>({
   table,
+  routePath,
+  onWishlistBulkStatusChange,
+  onWishlistBulkPriorityChange,
+  onWishlistBulkDelete,
+  onWishlistExport,
+  isWishlistMutating = false,
 }: DataTableBulkActionsProps<TData>) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const selectedRows = table.getFilteredSelectedRowModel().rows
+  const selectedTasks = selectedRows.map((row) => row.original as Task)
+  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
+  const wishlistStatusOptions = [
+    { label: 'Watching', value: 'wishlist' },
+    { label: 'Below target', value: 'discovered' },
+  ]
 
   const handleBulkStatusChange = (status: string) => {
-    const selectedTasks = selectedRows.map((row) => row.original as Task)
+    if (isWishlistRoute && onWishlistBulkStatusChange) {
+      void onWishlistBulkStatusChange(selectedTasks, status)
+      return
+    }
+
     toast.promise(sleep(2000), {
       loading: 'Updating status...',
       success: () => {
@@ -44,7 +71,11 @@ export function DataTableBulkActions<TData>({
   }
 
   const handleBulkPriorityChange = (priority: string) => {
-    const selectedTasks = selectedRows.map((row) => row.original as Task)
+    if (isWishlistRoute && onWishlistBulkPriorityChange) {
+      void onWishlistBulkPriorityChange(selectedTasks, priority)
+      return
+    }
+
     toast.promise(sleep(2000), {
       loading: 'Updating priority...',
       success: () => {
@@ -57,7 +88,12 @@ export function DataTableBulkActions<TData>({
   }
 
   const handleBulkExport = () => {
-    const selectedTasks = selectedRows.map((row) => row.original as Task)
+    if (isWishlistRoute && onWishlistExport) {
+      onWishlistExport(selectedTasks)
+      table.resetRowSelection()
+      return
+    }
+
     toast.promise(sleep(2000), {
       loading: 'Exporting tasks...',
       success: () => {
@@ -71,7 +107,10 @@ export function DataTableBulkActions<TData>({
 
   return (
     <>
-      <BulkActionsToolbar table={table} entityName='task'>
+      <BulkActionsToolbar
+        table={table}
+        entityName={isWishlistRoute ? 'wishlist entry' : 'task'}
+      >
         <DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -82,6 +121,7 @@ export function DataTableBulkActions<TData>({
                   className='size-8'
                   aria-label='Update status'
                   title='Update status'
+                  disabled={isWishlistMutating}
                 >
                   <CircleArrowUp />
                   <span className='sr-only'>Update status</span>
@@ -93,18 +133,23 @@ export function DataTableBulkActions<TData>({
             </TooltipContent>
           </Tooltip>
           <DropdownMenuContent sideOffset={14}>
-            {statuses.map((status) => (
-              <DropdownMenuItem
-                key={status.value}
-                defaultValue={status.value}
-                onClick={() => handleBulkStatusChange(status.value)}
-              >
-                {status.icon && (
-                  <status.icon className='size-4 text-muted-foreground' />
-                )}
-                {status.label}
-              </DropdownMenuItem>
-            ))}
+            {(isWishlistRoute ? wishlistStatusOptions : statuses).map((status) => {
+              const StatusIcon =
+                'icon' in status ? (status.icon as ComponentType<{ className?: string }>) : null
+
+              return (
+                <DropdownMenuItem
+                  key={status.value}
+                  defaultValue={status.value}
+                  onClick={() => handleBulkStatusChange(status.value)}
+                >
+                  {StatusIcon ? (
+                    <StatusIcon className='size-4 text-muted-foreground' />
+                  ) : null}
+                  {status.label}
+                </DropdownMenuItem>
+              )
+            })}
           </DropdownMenuContent>
         </DropdownMenu>
 
@@ -118,6 +163,7 @@ export function DataTableBulkActions<TData>({
                   className='size-8'
                   aria-label='Update priority'
                   title='Update priority'
+                  disabled={isWishlistMutating}
                 >
                   <ArrowUpDown />
                   <span className='sr-only'>Update priority</span>
@@ -151,15 +197,20 @@ export function DataTableBulkActions<TData>({
               size='icon'
               onClick={() => handleBulkExport()}
               className='size-8'
-              aria-label='Export tasks'
-              title='Export tasks'
+              aria-label={
+                isWishlistRoute ? 'Export wishlist entries' : 'Export tasks'
+              }
+              title={isWishlistRoute ? 'Export wishlist entries' : 'Export tasks'}
+              disabled={isWishlistMutating}
             >
               <Download />
-              <span className='sr-only'>Export tasks</span>
+              <span className='sr-only'>
+                {isWishlistRoute ? 'Export wishlist entries' : 'Export tasks'}
+              </span>
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Export tasks</p>
+            <p>{isWishlistRoute ? 'Export wishlist entries' : 'Export tasks'}</p>
           </TooltipContent>
         </Tooltip>
 
@@ -170,15 +221,32 @@ export function DataTableBulkActions<TData>({
               size='icon'
               onClick={() => setShowDeleteConfirm(true)}
               className='size-8'
-              aria-label='Delete selected tasks'
-              title='Delete selected tasks'
+              aria-label={
+                isWishlistRoute
+                  ? 'Delete selected wishlist entries'
+                  : 'Delete selected tasks'
+              }
+              title={
+                isWishlistRoute
+                  ? 'Delete selected wishlist entries'
+                  : 'Delete selected tasks'
+              }
+              disabled={isWishlistMutating}
             >
               <Trash2 />
-              <span className='sr-only'>Delete selected tasks</span>
+              <span className='sr-only'>
+                {isWishlistRoute
+                  ? 'Delete selected wishlist entries'
+                  : 'Delete selected tasks'}
+              </span>
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Delete selected tasks</p>
+            <p>
+              {isWishlistRoute
+                ? 'Delete selected wishlist entries'
+                : 'Delete selected tasks'}
+            </p>
           </TooltipContent>
         </Tooltip>
       </BulkActionsToolbar>
@@ -187,6 +255,9 @@ export function DataTableBulkActions<TData>({
         open={showDeleteConfirm}
         onOpenChange={setShowDeleteConfirm}
         table={table}
+        routePath={routePath}
+        onWishlistBulkDelete={onWishlistBulkDelete}
+        isLoading={isWishlistMutating}
       />
     </>
   )

--- a/ui.web/src/features/tasks/components/data-table-row-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-row-actions.tsx
@@ -6,22 +6,17 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { labels } from '../data/data'
 import { type Task, taskSchema } from '../data/schema'
-import { useTasks } from './tasks-provider'
 
 type DataTableRowActionsProps<TData> = {
   row: Row<TData>
   routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+  onEditRow?: (task: Task) => void
+  onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   wishlistActionItemID?: string | null
 }
@@ -29,14 +24,14 @@ type DataTableRowActionsProps<TData> = {
 export function DataTableRowActions<TData>({
   row,
   routePath,
+  onEditRow,
+  onDeleteRow,
   onWishlistMarkOwned,
   wishlistActionItemID,
 }: DataTableRowActionsProps<TData>) {
   const task = taskSchema.parse(row.original)
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
   const isWishlistActionPending = wishlistActionItemID === task.id
-
-  const { setOpen, setCurrentRow } = useTasks()
 
   return (
     <DropdownMenu modal={false}>
@@ -45,18 +40,31 @@ export function DataTableRowActions<TData>({
           variant='ghost'
           className='flex h-8 w-8 p-0 data-[state=open]:bg-muted'
           data-testid='task-row-actions-trigger'
+          onClick={(event) => {
+            event.stopPropagation()
+          }}
+          onPointerDown={(event) => {
+            event.stopPropagation()
+          }}
         >
           <DotsHorizontalIcon className='h-4 w-4' />
           <span className='sr-only'>Open menu</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align='end' className='w-[160px]'>
+      <DropdownMenuContent
+        align='end'
+        className='w-[160px]'
+        onClick={(event) => {
+          event.stopPropagation()
+        }}
+      >
         {isWishlistRoute ? (
           <>
             <DropdownMenuItem
               data-testid='wishlist-mark-owned-action'
               disabled={!task.wishlistEntryID || isWishlistActionPending}
-              onClick={() => {
+              onSelect={(event) => {
+                event.stopPropagation()
                 if (onWishlistMarkOwned) {
                   void onWishlistMarkOwned(task)
                 }
@@ -68,33 +76,24 @@ export function DataTableRowActions<TData>({
           </>
         ) : null}
         <DropdownMenuItem
-          onClick={() => {
-            setCurrentRow(task)
-            setOpen('update')
+          onSelect={(event) => {
+            event.stopPropagation()
+            onEditRow?.(task)
           }}
         >
           Edit
         </DropdownMenuItem>
-        <DropdownMenuItem disabled>Make a copy</DropdownMenuItem>
-        <DropdownMenuItem disabled>Favorite</DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>Labels</DropdownMenuSubTrigger>
-          <DropdownMenuSubContent>
-            <DropdownMenuRadioGroup value={task.label}>
-              {labels.map((label) => (
-                <DropdownMenuRadioItem key={label.value} value={label.value}>
-                  {label.label}
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-        <DropdownMenuSeparator />
+        {!isWishlistRoute ? (
+          <>
+            <DropdownMenuItem disabled>Make a copy</DropdownMenuItem>
+            <DropdownMenuItem disabled>Favorite</DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
         <DropdownMenuItem
-          onClick={() => {
-            setCurrentRow(task)
-            setOpen('delete')
+          onSelect={(event) => {
+            event.stopPropagation()
+            onDeleteRow?.(task)
           }}
         >
           Delete

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -10,6 +10,8 @@ export type TasksRoutePath = '/_authenticated/inventory/' | '/_authenticated/wis
 
 type TasksColumnsOptions = {
   routePath: TasksRoutePath
+  onEditRow?: (task: Task) => void
+  onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   wishlistActionItemID?: string | null
 }
@@ -25,6 +27,8 @@ function formatWishlistStatus(status: string) {
 
 export function getTasksColumns({
   routePath,
+  onEditRow,
+  onDeleteRow,
   onWishlistMarkOwned,
   wishlistActionItemID,
 }: TasksColumnsOptions): ColumnDef<Task>[] {
@@ -186,6 +190,8 @@ export function getTasksColumns({
         <DataTableRowActions
           row={row}
           routePath={routePath}
+          onEditRow={onEditRow}
+          onDeleteRow={onDeleteRow}
           onWishlistMarkOwned={onWishlistMarkOwned}
           wishlistActionItemID={wishlistActionItemID}
         />

--- a/ui.web/src/features/tasks/components/tasks-dialogs.tsx
+++ b/ui.web/src/features/tasks/components/tasks-dialogs.tsx
@@ -1,23 +1,95 @@
+import { useEffect, useRef } from 'react'
 import { showSubmittedData } from '@/lib/show-submitted-data'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { TasksImportDialog } from './tasks-import-dialog'
-import { TasksMutateDrawer } from './tasks-mutate-drawer'
-import { useTasks } from './tasks-provider'
+import {
+  TasksMutateDrawer,
+  type WishlistEntryDraft,
+} from './tasks-mutate-drawer'
+import { type Task } from '../data/schema'
 
-export function TasksDialogs() {
-  const { open, setOpen, currentRow, setCurrentRow } = useTasks()
+export type TasksDialogType = 'create' | 'update' | 'delete' | 'import'
+
+type TasksDialogsProps = {
+  routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+  open: TasksDialogType | null
+  setOpen: (open: TasksDialogType | null) => void
+  currentRow: Task | null
+  setCurrentRow: (task: Task | null) => void
+  onWishlistSubmit?: (
+    draft: WishlistEntryDraft,
+    currentRow?: Task
+  ) => Promise<void>
+  onWishlistDelete?: (currentRow: Task) => Promise<void>
+  onWishlistImport?: (entries: WishlistEntryDraft[]) => Promise<void>
+  isWishlistMutating?: boolean
+}
+
+export function TasksDialogs({
+  routePath,
+  open,
+  setOpen,
+  currentRow,
+  setCurrentRow,
+  onWishlistSubmit,
+  onWishlistDelete,
+  onWishlistImport,
+  isWishlistMutating = false,
+}: TasksDialogsProps) {
+  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
+  const clearCurrentRowTimerRef = useRef<number | null>(null)
+
+  const cancelPendingClearCurrentRow = () => {
+    if (clearCurrentRowTimerRef.current !== null) {
+      window.clearTimeout(clearCurrentRowTimerRef.current)
+      clearCurrentRowTimerRef.current = null
+    }
+  }
+
+  const clearCurrentRow = () => {
+    cancelPendingClearCurrentRow()
+    clearCurrentRowTimerRef.current = window.setTimeout(() => {
+      setCurrentRow(null)
+      clearCurrentRowTimerRef.current = null
+    }, 500)
+  }
+
+  useEffect(() => {
+    if (open !== null) {
+      cancelPendingClearCurrentRow()
+    }
+  }, [open])
+
+  useEffect(() => cancelPendingClearCurrentRow, [])
+
   return (
     <>
       <TasksMutateDrawer
         key='task-create'
         open={open === 'create'}
-        onOpenChange={() => setOpen('create')}
+        onOpenChange={(isOpen) => {
+          if (isOpen) {
+            cancelPendingClearCurrentRow()
+          }
+          setOpen(isOpen ? 'create' : null)
+        }}
+        routePath={routePath}
+        onWishlistSubmit={onWishlistSubmit}
+        isLoading={isWishlistMutating}
       />
 
       <TasksImportDialog
         key='tasks-import'
         open={open === 'import'}
-        onOpenChange={() => setOpen('import')}
+        onOpenChange={(isOpen) => {
+          if (isOpen) {
+            cancelPendingClearCurrentRow()
+          }
+          setOpen(isOpen ? 'import' : null)
+        }}
+        routePath={routePath}
+        onWishlistImport={onWishlistImport}
+        isLoading={isWishlistMutating}
       />
 
       {currentRow && (
@@ -25,43 +97,70 @@ export function TasksDialogs() {
           <TasksMutateDrawer
             key={`task-update-${currentRow.id}`}
             open={open === 'update'}
-            onOpenChange={() => {
-              setOpen('update')
-              setTimeout(() => {
-                setCurrentRow(null)
-              }, 500)
+            onOpenChange={(isOpen) => {
+              if (isOpen) {
+                cancelPendingClearCurrentRow()
+              }
+              setOpen(isOpen ? 'update' : null)
+              if (!isOpen) {
+                clearCurrentRow()
+              }
             }}
             currentRow={currentRow}
+            routePath={routePath}
+            onWishlistSubmit={onWishlistSubmit}
+            isLoading={isWishlistMutating}
           />
 
           <ConfirmDialog
             key='task-delete'
             destructive
             open={open === 'delete'}
-            onOpenChange={() => {
-              setOpen('delete')
-              setTimeout(() => {
-                setCurrentRow(null)
-              }, 500)
+            onOpenChange={(isOpen) => {
+              if (isOpen) {
+                cancelPendingClearCurrentRow()
+              }
+              setOpen(isOpen ? 'delete' : null)
+              if (!isOpen) {
+                clearCurrentRow()
+              }
             }}
             handleConfirm={() => {
+              if (isWishlistRoute && onWishlistDelete) {
+                void onWishlistDelete(currentRow).then(() => {
+                  setOpen(null)
+                  clearCurrentRow()
+                })
+                return
+              }
               setOpen(null)
-              setTimeout(() => {
-                setCurrentRow(null)
-              }, 500)
+              clearCurrentRow()
               showSubmittedData(
                 currentRow,
                 'The following task has been deleted:'
               )
             }}
+            isLoading={isWishlistMutating}
             className='max-w-md'
-            title={`Delete this task: ${currentRow.id} ?`}
+            title={
+              isWishlistRoute
+                ? `Delete this wishlist entry: ${currentRow.title} ?`
+                : `Delete this task: ${currentRow.id} ?`
+            }
             desc={
-              <>
-                You are about to delete a task with the ID{' '}
-                <strong>{currentRow.id}</strong>. <br />
-                This action cannot be undone.
-              </>
+              isWishlistRoute ? (
+                <>
+                  You are about to delete the wishlist entry for{' '}
+                  <strong>{currentRow.title}</strong>. <br />
+                  This action cannot be undone.
+                </>
+              ) : (
+                <>
+                  You are about to delete a task with the ID{' '}
+                  <strong>{currentRow.id}</strong>. <br />
+                  This action cannot be undone.
+                </>
+              )
             }
             confirmText='Delete'
           />

--- a/ui.web/src/features/tasks/components/tasks-import-dialog.tsx
+++ b/ui.web/src/features/tasks/components/tasks-import-dialog.tsx
@@ -1,6 +1,6 @@
-import { z } from 'zod'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { showSubmittedData } from '@/lib/show-submitted-data'
 import { Button } from '@/components/ui/button'
 import {
@@ -21,6 +21,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { type WishlistEntryDraft } from './tasks-mutate-drawer'
 
 const formSchema = z.object({
   file: z
@@ -29,7 +30,7 @@ const formSchema = z.object({
       message: 'Please upload a file',
     })
     .refine(
-      (files) => ['text/csv'].includes(files?.[0]?.type),
+      (files) => ['text/csv', 'application/vnd.ms-excel', ''].includes(files?.[0]?.type),
       'Please upload csv format.'
     ),
 })
@@ -37,12 +38,82 @@ const formSchema = z.object({
 type TaskImportDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
+  routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+  onWishlistImport?: (entries: WishlistEntryDraft[]) => Promise<void>
+  isLoading?: boolean
+}
+
+function parseCsvLine(line: string) {
+  const out: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i]
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"'
+        i += 1
+      } else {
+        inQuotes = !inQuotes
+      }
+      continue
+    }
+    if (char === ',' && !inQuotes) {
+      out.push(current.trim())
+      current = ''
+      continue
+    }
+    current += char
+  }
+  out.push(current.trim())
+  return out
+}
+
+function parseWishlistImportCsv(text: string): WishlistEntryDraft[] {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  if (lines.length < 2) {
+    throw new Error('Import file must include a header row and at least one entry.')
+  }
+
+  const headers = parseCsvLine(lines[0]).map((header) =>
+    header.trim().toLowerCase()
+  )
+
+  const columnIndex = (name: string) => headers.indexOf(name)
+  const titleIndex = columnIndex('title')
+  if (titleIndex < 0) {
+    throw new Error('Import file must include a title column.')
+  }
+
+  return lines.slice(1).map((line, index) => {
+    const cells = parseCsvLine(line)
+    const title = cells[titleIndex]?.trim() ?? ''
+    if (!title) {
+      throw new Error(`Row ${index + 2} is missing a title.`)
+    }
+    return {
+      title,
+      partNumber: cells[columnIndex('part_number')]?.trim() ?? '',
+      category: cells[columnIndex('category')]?.trim() ?? '',
+      priority: cells[columnIndex('priority')]?.trim() || 'medium',
+      notes: cells[columnIndex('notes')]?.trim() ?? '',
+      targetPrice: cells[columnIndex('target_price')]?.trim() ?? '',
+    }
+  })
 }
 
 export function TasksImportDialog({
   open,
   onOpenChange,
+  routePath,
+  onWishlistImport,
+  isLoading = false,
 }: TaskImportDialogProps) {
+  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: { file: undefined },
@@ -50,16 +121,22 @@ export function TasksImportDialog({
 
   const fileRef = form.register('file')
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     const file = form.getValues('file')
 
     if (file && file[0]) {
-      const fileDetails = {
-        name: file[0].name,
-        size: file[0].size,
-        type: file[0].type,
+      if (isWishlistRoute && onWishlistImport) {
+        const text = await file[0].text()
+        const entries = parseWishlistImportCsv(text)
+        await onWishlistImport(entries)
+      } else {
+        const fileDetails = {
+          name: file[0].name,
+          size: file[0].size,
+          type: file[0].type,
+        }
+        showSubmittedData(fileDetails, 'You have imported the following file:')
       }
-      showSubmittedData(fileDetails, 'You have imported the following file:')
     }
     onOpenChange(false)
   }
@@ -74,9 +151,13 @@ export function TasksImportDialog({
     >
       <DialogContent className='gap-2 sm:max-w-sm'>
         <DialogHeader className='text-start'>
-          <DialogTitle>Import Tasks</DialogTitle>
+          <DialogTitle>
+            {isWishlistRoute ? 'Import Wishlist Entries' : 'Import Tasks'}
+          </DialogTitle>
           <DialogDescription>
-            Import tasks quickly from a CSV file.
+            {isWishlistRoute
+              ? 'Import wishlist entries from CSV. Supported columns: title, part_number, category, priority, notes, target_price.'
+              : 'Import tasks quickly from a CSV file.'}
           </DialogDescription>
         </DialogHeader>
         <Form {...form}>
@@ -98,10 +179,12 @@ export function TasksImportDialog({
         </Form>
         <DialogFooter className='gap-2'>
           <DialogClose asChild>
-            <Button variant='outline'>Close</Button>
+            <Button variant='outline' disabled={isLoading}>
+              Close
+            </Button>
           </DialogClose>
-          <Button type='submit' form='task-import-form'>
-            Import
+          <Button type='submit' form='task-import-form' disabled={isLoading}>
+            {isLoading ? 'Importing...' : 'Import'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/ui.web/src/features/tasks/components/tasks-multi-delete-dialog.tsx
+++ b/ui.web/src/features/tasks/components/tasks-multi-delete-dialog.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useState } from 'react'
 import { type Table } from '@tanstack/react-table'
 import { AlertTriangle } from 'lucide-react'
@@ -9,11 +7,15 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ConfirmDialog } from '@/components/confirm-dialog'
+import { type Task } from '../data/schema'
 
 type TaskMultiDeleteDialogProps<TData> = {
   open: boolean
   onOpenChange: (open: boolean) => void
   table: Table<TData>
+  routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+  onWishlistBulkDelete?: (tasks: Task[]) => Promise<void>
+  isLoading?: boolean
 }
 
 const CONFIRM_WORD = 'DELETE'
@@ -22,14 +24,26 @@ export function TasksMultiDeleteDialog<TData>({
   open,
   onOpenChange,
   table,
+  routePath,
+  onWishlistBulkDelete,
+  isLoading = false,
 }: TaskMultiDeleteDialogProps<TData>) {
   const [value, setValue] = useState('')
+  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
 
   const selectedRows = table.getFilteredSelectedRowModel().rows
+  const selectedTasks = selectedRows.map((row) => row.original as Task)
 
   const handleDelete = () => {
     if (value.trim() !== CONFIRM_WORD) {
       toast.error(`Please type "${CONFIRM_WORD}" to confirm.`)
+      return
+    }
+
+    if (isWishlistRoute && onWishlistBulkDelete) {
+      void onWishlistBulkDelete(selectedTasks)
+      setValue('')
+      onOpenChange(false)
       return
     }
 
@@ -54,6 +68,7 @@ export function TasksMultiDeleteDialog<TData>({
       onOpenChange={onOpenChange}
       handleConfirm={handleDelete}
       disabled={value.trim() !== CONFIRM_WORD}
+      isLoading={isLoading}
       title={
         <span className='text-destructive'>
           <AlertTriangle
@@ -61,18 +76,27 @@ export function TasksMultiDeleteDialog<TData>({
             size={18}
           />{' '}
           Delete {selectedRows.length}{' '}
-          {selectedRows.length > 1 ? 'tasks' : 'task'}
+          {selectedRows.length > 1
+            ? isWishlistRoute
+              ? 'wishlist entries'
+              : 'tasks'
+            : isWishlistRoute
+              ? 'wishlist entry'
+              : 'task'}
         </span>
       }
       desc={
         <div className='space-y-4'>
           <p className='mb-2'>
-            Are you sure you want to delete the selected tasks? <br />
+            {isWishlistRoute
+              ? 'Are you sure you want to delete the selected wishlist entries?'
+              : 'Are you sure you want to delete the selected tasks?'}{' '}
+            <br />
             This action cannot be undone.
           </p>
 
           <Label className='my-4 flex flex-col items-start gap-1.5'>
-            <span className=''>Confirm by typing "{CONFIRM_WORD}":</span>
+            <span>Confirm by typing "{CONFIRM_WORD}":</span>
             <Input
               value={value}
               onChange={(e) => setValue(e.target.value)}

--- a/ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx
+++ b/ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx
@@ -1,6 +1,7 @@
-import { z } from 'zod'
+import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 import { showSubmittedData } from '@/lib/show-submitted-data'
 import { Button } from '@/components/ui/button'
 import {
@@ -12,7 +13,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Sheet,
   SheetClose,
@@ -23,31 +24,81 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { SelectDropdown } from '@/components/select-dropdown'
+import { priorities } from '../data/data'
 import { type Task } from '../data/schema'
+
+export type WishlistEntryDraft = {
+  title: string
+  partNumber: string
+  category: string
+  priority: string
+  notes: string
+  targetPrice: string
+}
 
 type TaskMutateDrawerProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   currentRow?: Task
+  routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+  onWishlistSubmit?: (
+    draft: WishlistEntryDraft,
+    currentRow?: Task
+  ) => Promise<void>
+  isLoading?: boolean
 }
 
-const formSchema = z.object({
+const taskFormSchema = z.object({
   title: z.string().min(1, 'Title is required.'),
   status: z.string().min(1, 'Please select a status.'),
   label: z.string().min(1, 'Please select a label.'),
   priority: z.string().min(1, 'Please choose a priority.'),
 })
-type TaskForm = z.infer<typeof formSchema>
+
+const wishlistFormSchema = z.object({
+  title: z.string().trim().min(1, 'Title is required.'),
+  partNumber: z.string(),
+  category: z.string(),
+  priority: z.string().trim().min(1, 'Please choose a priority.'),
+  notes: z.string(),
+  targetPrice: z.string().refine((value) => {
+      if (value.trim() === '') {
+        return true
+      }
+      return !Number.isNaN(Number(value)) && Number(value) >= 0
+    }, 'Target price must be a positive number.'),
+})
+
+type TaskForm = z.infer<typeof taskFormSchema>
+type WishlistForm = z.infer<typeof wishlistFormSchema>
+
+function wishlistDefaults(currentRow?: Task): WishlistForm {
+  return {
+    title: currentRow?.title ?? '',
+    partNumber: currentRow?.partNumber ?? '',
+    category: currentRow?.label ?? '',
+    priority: currentRow?.priority ?? 'medium',
+    notes: currentRow?.notes ?? '',
+    targetPrice:
+      typeof currentRow?.targetPrice === 'number' && currentRow.targetPrice > 0
+        ? String(currentRow.targetPrice)
+        : '',
+  }
+}
 
 export function TasksMutateDrawer({
   open,
   onOpenChange,
   currentRow,
+  routePath,
+  onWishlistSubmit,
+  isLoading = false,
 }: TaskMutateDrawerProps) {
   const isUpdate = !!currentRow
+  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
 
-  const form = useForm<TaskForm>({
-    resolver: zodResolver(formSchema),
+  const taskForm = useForm<TaskForm>({
+    resolver: zodResolver(taskFormSchema),
     defaultValues: currentRow ?? {
       title: '',
       status: '',
@@ -56,21 +107,186 @@ export function TasksMutateDrawer({
     },
   })
 
-  const onSubmit = (data: TaskForm) => {
-    // do something with the form data
+  const wishlistForm = useForm<WishlistForm>({
+    resolver: zodResolver(wishlistFormSchema),
+    defaultValues: wishlistDefaults(currentRow),
+  })
+
+  useEffect(() => {
+    if (!isWishlistRoute) {
+      return
+    }
+    wishlistForm.reset(wishlistDefaults(currentRow))
+  }, [currentRow, isWishlistRoute, wishlistForm])
+
+  const handleClose = (nextOpen: boolean) => {
+    onOpenChange(nextOpen)
+    taskForm.reset()
+    wishlistForm.reset(wishlistDefaults(currentRow))
+  }
+
+  const onTaskSubmit = (data: TaskForm) => {
     onOpenChange(false)
-    form.reset()
+    taskForm.reset()
     showSubmittedData(data)
   }
 
+  const onWishlistFormSubmit = async (data: WishlistForm) => {
+    if (!onWishlistSubmit) {
+      return
+    }
+    await onWishlistSubmit(
+      {
+        title: data.title.trim(),
+        partNumber: data.partNumber.trim(),
+        category: data.category.trim(),
+        priority: data.priority.trim(),
+        notes: data.notes.trim(),
+        targetPrice: data.targetPrice.trim(),
+      },
+      currentRow
+    )
+    onOpenChange(false)
+    wishlistForm.reset(wishlistDefaults(undefined))
+  }
+
+  if (isWishlistRoute) {
+    return (
+      <Sheet open={open} onOpenChange={handleClose}>
+        <SheetContent className='flex flex-col'>
+          <SheetHeader className='text-start'>
+            <SheetTitle>
+              {isUpdate ? 'Edit Wishlist Entry' : 'Create Wishlist Entry'}
+            </SheetTitle>
+            <SheetDescription>
+              {isUpdate
+                ? 'Update the selected wishlist entry and keep planning details in sync.'
+                : 'Create a new wishlist entry with the details you want to track.'}
+            </SheetDescription>
+          </SheetHeader>
+          <Form {...wishlistForm}>
+            <form
+              id='wishlist-form'
+              onSubmit={wishlistForm.handleSubmit(onWishlistFormSubmit)}
+              className='flex-1 space-y-6 overflow-y-auto px-4'
+            >
+              <FormField
+                control={wishlistForm.control}
+                name='title'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Title</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='Enter a title' />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={wishlistForm.control}
+                name='partNumber'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Part Number</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='Optional part number' />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={wishlistForm.control}
+                name='category'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Category</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='Optional category' />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={wishlistForm.control}
+                name='priority'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Priority</FormLabel>
+                    <SelectDropdown
+                      defaultValue={field.value}
+                      onValueChange={field.onChange}
+                      placeholder='Select priority'
+                      items={priorities.map((priority) => ({
+                        label: priority.label,
+                        value: priority.value,
+                      }))}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={wishlistForm.control}
+                name='targetPrice'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Target Price</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type='number'
+                        min='0'
+                        step='0.01'
+                        placeholder='Optional target price'
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={wishlistForm.control}
+                name='notes'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Notes</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder='Add planning notes'
+                        className='min-h-24'
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </form>
+          </Form>
+          <SheetFooter className='gap-2'>
+            <SheetClose asChild>
+              <Button variant='outline' disabled={isLoading}>
+                Close
+              </Button>
+            </SheetClose>
+            <Button form='wishlist-form' type='submit' disabled={isLoading}>
+              {isLoading
+                ? isUpdate
+                  ? 'Saving...'
+                  : 'Creating...'
+                : 'Save changes'}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
   return (
-    <Sheet
-      open={open}
-      onOpenChange={(v) => {
-        onOpenChange(v)
-        form.reset()
-      }}
-    >
+    <Sheet open={open} onOpenChange={handleClose}>
       <SheetContent className='flex flex-col'>
         <SheetHeader className='text-start'>
           <SheetTitle>{isUpdate ? 'Update' : 'Create'} Task</SheetTitle>
@@ -81,14 +297,14 @@ export function TasksMutateDrawer({
             Click save when you&apos;re done.
           </SheetDescription>
         </SheetHeader>
-        <Form {...form}>
+        <Form {...taskForm}>
           <form
             id='tasks-form'
-            onSubmit={form.handleSubmit(onSubmit)}
+            onSubmit={taskForm.handleSubmit(onTaskSubmit)}
             className='flex-1 space-y-6 overflow-y-auto px-4'
           >
             <FormField
-              control={form.control}
+              control={taskForm.control}
               name='title'
               render={({ field }) => (
                 <FormItem>
@@ -101,7 +317,7 @@ export function TasksMutateDrawer({
               )}
             />
             <FormField
-              control={form.control}
+              control={taskForm.control}
               name='status'
               render={({ field }) => (
                 <FormItem>
@@ -123,75 +339,33 @@ export function TasksMutateDrawer({
               )}
             />
             <FormField
-              control={form.control}
+              control={taskForm.control}
               name='label'
               render={({ field }) => (
-                <FormItem className='relative'>
+                <FormItem>
                   <FormLabel>Label</FormLabel>
                   <FormControl>
-                    <RadioGroup
-                      onValueChange={field.onChange}
-                      defaultValue={field.value}
-                      className='flex flex-col space-y-1'
-                    >
-                      <FormItem className='flex items-center'>
-                        <FormControl>
-                          <RadioGroupItem value='documentation' />
-                        </FormControl>
-                        <FormLabel className='font-normal'>
-                          Documentation
-                        </FormLabel>
-                      </FormItem>
-                      <FormItem className='flex items-center'>
-                        <FormControl>
-                          <RadioGroupItem value='feature' />
-                        </FormControl>
-                        <FormLabel className='font-normal'>Feature</FormLabel>
-                      </FormItem>
-                      <FormItem className='flex items-center'>
-                        <FormControl>
-                          <RadioGroupItem value='bug' />
-                        </FormControl>
-                        <FormLabel className='font-normal'>Bug</FormLabel>
-                      </FormItem>
-                    </RadioGroup>
+                    <Input {...field} placeholder='Enter a label' />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
             <FormField
-              control={form.control}
+              control={taskForm.control}
               name='priority'
               render={({ field }) => (
-                <FormItem className='relative'>
+                <FormItem>
                   <FormLabel>Priority</FormLabel>
-                  <FormControl>
-                    <RadioGroup
-                      onValueChange={field.onChange}
-                      defaultValue={field.value}
-                      className='flex flex-col space-y-1'
-                    >
-                      <FormItem className='flex items-center'>
-                        <FormControl>
-                          <RadioGroupItem value='high' />
-                        </FormControl>
-                        <FormLabel className='font-normal'>High</FormLabel>
-                      </FormItem>
-                      <FormItem className='flex items-center'>
-                        <FormControl>
-                          <RadioGroupItem value='medium' />
-                        </FormControl>
-                        <FormLabel className='font-normal'>Medium</FormLabel>
-                      </FormItem>
-                      <FormItem className='flex items-center'>
-                        <FormControl>
-                          <RadioGroupItem value='low' />
-                        </FormControl>
-                        <FormLabel className='font-normal'>Low</FormLabel>
-                      </FormItem>
-                    </RadioGroup>
-                  </FormControl>
+                  <SelectDropdown
+                    defaultValue={field.value}
+                    onValueChange={field.onChange}
+                    placeholder='Select priority'
+                    items={priorities.map((priority) => ({
+                      label: priority.label,
+                      value: priority.value,
+                    }))}
+                  />
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui.web/src/features/tasks/components/tasks-provider.tsx
+++ b/ui.web/src/features/tasks/components/tasks-provider.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import useDialogState from '@/hooks/use-dialog-state'
 import { type Task } from '../data/schema'
 
 type TasksDialogType = 'create' | 'update' | 'delete' | 'import'
@@ -14,13 +13,13 @@ type TasksContextType = {
 const TasksContext = React.createContext<TasksContextType | null>(null)
 
 export function TasksProvider({ children }: { children: React.ReactNode }) {
-  const [open, setOpen] = useDialogState<TasksDialogType>(null)
+  const [open, setOpen] = useState<TasksDialogType | null>(null)
   const [currentRow, setCurrentRow] = useState<Task | null>(null)
 
   return (
-    <TasksContext value={{ open, setOpen, currentRow, setCurrentRow }}>
+    <TasksContext.Provider value={{ open, setOpen, currentRow, setCurrentRow }}>
       {children}
-    </TasksContext>
+    </TasksContext.Provider>
   )
 }
 

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -52,8 +52,15 @@ type DataTableProps = {
   routePath: TasksRoutePath
   currentRecordID?: string
   onRecordFocus?: (itemID: string, recordID: string, title: string) => void
+  onEditRow?: (task: Task) => void
+  onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
+  onWishlistBulkStatusChange?: (tasks: Task[], status: string) => Promise<void>
+  onWishlistBulkPriorityChange?: (tasks: Task[], priority: string) => Promise<void>
+  onWishlistBulkDelete?: (tasks: Task[]) => Promise<void>
+  onWishlistExport?: (tasks: Task[]) => void
   wishlistActionItemID?: string | null
+  isWishlistMutating?: boolean
 }
 
 type ViewMode = 'rows' | 'cards'
@@ -73,17 +80,26 @@ export function TasksTable({
   routePath,
   currentRecordID,
   onRecordFocus,
+  onEditRow,
+  onDeleteRow,
   onWishlistMarkOwned,
+  onWishlistBulkStatusChange,
+  onWishlistBulkPriorityChange,
+  onWishlistBulkDelete,
+  onWishlistExport,
   wishlistActionItemID,
+  isWishlistMutating,
 }: DataTableProps) {
   const columns = useMemo(
     () =>
       getTasksColumns({
         routePath,
+        onEditRow,
+        onDeleteRow,
         onWishlistMarkOwned,
         wishlistActionItemID,
       }),
-    [routePath, onWishlistMarkOwned, wishlistActionItemID]
+    [routePath, onEditRow, onDeleteRow, onWishlistMarkOwned, wishlistActionItemID]
   )
 
   const route =
@@ -281,6 +297,13 @@ export function TasksTable({
     setSelectedRecordContext(visibleRecordIDs[nextIndex] ?? selectedRecordID ?? '')
   }
 
+  const statusFilterOptions = routePath === '/_authenticated/wishlist/'
+    ? [
+        { label: 'Watching', value: 'wishlist' },
+        { label: 'Below target', value: 'discovered' },
+      ]
+    : statuses
+
   return (
     <div
       className={cn(
@@ -295,7 +318,7 @@ export function TasksTable({
           {
             columnId: 'status',
             title: 'Status',
-            options: statuses,
+            options: statusFilterOptions,
           },
           {
             columnId: 'priority',
@@ -458,7 +481,15 @@ export function TasksTable({
       )}
 
       <DataTablePagination table={table} className='mt-auto' />
-      <DataTableBulkActions table={table} />
+      <DataTableBulkActions
+        table={table}
+        routePath={routePath}
+        onWishlistBulkStatusChange={onWishlistBulkStatusChange}
+        onWishlistBulkPriorityChange={onWishlistBulkPriorityChange}
+        onWishlistBulkDelete={onWishlistBulkDelete}
+        onWishlistExport={onWishlistExport}
+        isWishlistMutating={isWishlistMutating}
+      />
       <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
         <DialogContent data-testid='row-details-modal'>
           <DialogHeader>

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -7,11 +7,14 @@ export const taskSchema = z.object({
   itemID: z.string().optional(),
   wishlistEntryID: z.string().optional(),
   title: z.string(),
+  partNumber: z.string().optional(),
   status: z.string(),
   label: z.string(),
   priority: z.string(),
   notes: z.string().optional(),
   belowTargetNow: z.boolean().optional(),
+  targetPrice: z.number().optional(),
+  highlightHit: z.boolean().optional(),
 })
 
 export type Task = z.infer<typeof taskSchema>

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -19,9 +19,9 @@ import {
 } from '@/features/collections/use-workspace-collections'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
-import { TasksDialogs } from './components/tasks-dialogs'
-import { TasksProvider } from './components/tasks-provider'
+import { TasksDialogs, type TasksDialogType } from './components/tasks-dialogs'
 import { TasksTable } from './components/tasks-table'
+import { type WishlistEntryDraft } from './components/tasks-mutate-drawer'
 import { tasks } from './data/tasks'
 import { type Task } from './data/schema'
 
@@ -97,6 +97,121 @@ function matchesWishlistPlanningFocus(
   }
 }
 
+type WishlistItemPayload = {
+  id?: string
+  title?: string
+  part_number?: string
+  category?: string
+  priority?: string
+}
+
+type WishlistEntryPayload = {
+  id?: string
+  item_id?: string
+  priority?: string
+  notes?: string
+  below_target_now?: boolean
+  target_price?: number
+  highlight_hit?: boolean
+}
+
+function normalizeWishlistPriority(raw: string) {
+  const trimmed = raw.trim().toLowerCase()
+  return trimmed || 'medium'
+}
+
+function normalizeTargetPrice(raw: string) {
+  if (raw.trim() === '') {
+    return 0
+  }
+  const parsed = Number(raw)
+  if (Number.isNaN(parsed) || parsed < 0) {
+    throw new Error('invalid_target_price')
+  }
+  return parsed
+}
+
+function buildWishlistCsv(tasksToExport: Task[]) {
+  const escapeCell = (value: string | number | undefined) => {
+    const text = String(value ?? '')
+    if (/[",\n]/.test(text)) {
+      return `"${text.split('"').join('""')}"`
+    }
+    return text
+  }
+
+  return [
+    ['title', 'part_number', 'category', 'priority', 'notes', 'target_price'].join(','),
+    ...tasksToExport.map((task) =>
+      [
+        escapeCell(task.title),
+        escapeCell(task.partNumber),
+        escapeCell(task.label),
+        escapeCell(task.priority),
+        escapeCell(task.notes),
+        escapeCell(task.targetPrice ?? ''),
+      ].join(',')
+    ),
+  ].join('\n')
+}
+
+function TasksHeaderActions({
+  isWishlistRoute,
+  onOpenCollectionCreate,
+  onCreate,
+  onImport,
+}: {
+  isWishlistRoute: boolean
+  onOpenCollectionCreate: () => void
+  onCreate: () => void
+  onImport: () => void
+}) {
+  return (
+    <div className='flex items-center gap-2'>
+      <Button
+        type='button'
+        data-testid='wishlist-new-action'
+        onClick={onCreate}
+      >
+        New
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type='button'
+            variant='outline'
+            data-testid='wishlist-create-menu-trigger'
+          >
+            Create
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='end'>
+          <DropdownMenuItem
+            data-testid='wishlist-create-menu-entry'
+            onClick={onCreate}
+          >
+            New Wishlist Entry
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            data-testid='wishlist-create-menu-import'
+            onClick={onImport}
+          >
+            Import Wishlist
+          </DropdownMenuItem>
+          {isWishlistRoute ? (
+            <DropdownMenuItem
+              data-testid='wishlist-create-menu-collection'
+              onClick={onOpenCollectionCreate}
+            >
+              New Collection
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}
+
 export function Tasks({
   title = 'Tasks',
   description = "Here's a list of your tasks for this month!",
@@ -113,9 +228,12 @@ export function Tasks({
   const [inlineCollectionValidationMessage, setInlineCollectionValidationMessage] =
     useState('')
   const [tableData, setTableData] = useState<Task[]>(tasks)
+  const [dialogOpen, setDialogOpen] = useState<TasksDialogType | null>(null)
+  const [currentDialogRow, setCurrentDialogRow] = useState<Task | null>(null)
   const [wishlistActionItemID, setWishlistActionItemID] = useState<string | null>(
     null
   )
+  const [isWishlistMutating, setIsWishlistMutating] = useState(false)
   const [wishlistPlanningFocus, setWishlistPlanningFocus] =
     useState<WishlistPlanningFocus>(() => {
       if (typeof window === 'undefined') {
@@ -136,32 +254,12 @@ export function Tasks({
       throw new Error('wishlist_bootstrap_failed')
     }
     const wishlistPayload = (await wishlistResponse.json()) as {
-      items?: Array<{
-        id?: string
-        item_id?: string
-        priority?: string
-        notes?: string
-        below_target_now?: boolean
-      }>
+      items?: WishlistEntryPayload[]
     }
     const itemsPayload = (await itemsResponse.json()) as {
-      items?: Array<{
-        id?: string
-        title?: string
-        part_number?: string
-        category?: string
-        priority?: string
-      }>
+      items?: WishlistItemPayload[]
     }
-    const wishlistByItemID = new Map<
-      string,
-      {
-        id?: string
-        priority?: string
-        notes?: string
-        below_target_now?: boolean
-      }
-    >()
+    const wishlistByItemID = new Map<string, WishlistEntryPayload>()
     ;(wishlistPayload.items ?? []).forEach((entry) => {
       const itemID = entry.item_id?.trim()
       if (!itemID) {
@@ -180,12 +278,18 @@ export function Tasks({
           item.title?.trim() ||
           item.part_number?.trim() ||
           `Wishlist item ${index + 1}`,
+        partNumber: item.part_number?.trim(),
         status: wishlistEntry?.below_target_now ? 'discovered' : 'wishlist',
         label: item.category?.trim() || 'collection',
         priority:
           wishlistEntry?.priority?.trim() || item.priority?.trim() || 'medium',
         notes: wishlistEntry?.notes?.trim(),
         belowTargetNow: Boolean(wishlistEntry?.below_target_now),
+        targetPrice:
+          typeof wishlistEntry?.target_price === 'number'
+            ? wishlistEntry.target_price
+            : undefined,
+        highlightHit: Boolean(wishlistEntry?.highlight_hit),
       } satisfies Task
     })
   }, [])
@@ -242,6 +346,260 @@ export function Tasks({
     [loadWishlistData]
   )
 
+  const refreshWishlistTable = useCallback(async () => {
+    const mapped = await loadWishlistData()
+    setTableData(mapped)
+  }, [loadWishlistData])
+
+  const saveWishlistDraft = useCallback(
+    async (draft: WishlistEntryDraft, currentRow?: Task) => {
+      const itemResponse = currentRow?.itemID
+        ? await fetch(`/api/items/${encodeURIComponent(currentRow.itemID)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              title: draft.title,
+              part_number: draft.partNumber,
+              category: draft.category,
+            }),
+          })
+        : await fetch('/api/items', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              title: draft.title,
+              part_number: draft.partNumber,
+              category: draft.category,
+              priority: normalizeWishlistPriority(draft.priority),
+            }),
+          })
+
+      if (!itemResponse.ok) {
+        throw new Error('wishlist_item_save_failed')
+      }
+
+      const savedItem = (await itemResponse.json()) as { id?: string }
+      const itemID = currentRow?.itemID ?? savedItem.id?.trim()
+      if (!itemID) {
+        throw new Error('wishlist_item_id_missing')
+      }
+
+      const wishlistResponse = await fetch('/api/wishlist', {
+        method: currentRow?.wishlistEntryID ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: currentRow?.wishlistEntryID ?? undefined,
+          item_id: itemID,
+          priority: normalizeWishlistPriority(draft.priority),
+          notes: draft.notes,
+          target_price: normalizeTargetPrice(draft.targetPrice),
+          highlight_hit: currentRow?.highlightHit ?? false,
+        }),
+      })
+
+      if (!wishlistResponse.ok) {
+        throw new Error('wishlist_entry_save_failed')
+      }
+    },
+    []
+  )
+
+  const handleWishlistSubmit = useCallback(
+    async (draft: WishlistEntryDraft, currentRow?: Task) => {
+      setIsWishlistMutating(true)
+      try {
+        await saveWishlistDraft(draft, currentRow)
+        await refreshWishlistTable()
+        toast.success(
+          currentRow ? `${draft.title} updated.` : `${draft.title} added to wishlist.`
+        )
+      } catch (error) {
+        if (error instanceof Error && error.message === 'invalid_target_price') {
+          toast.error('Target price must be a positive number.')
+        } else {
+          toast.error('Wishlist save failed. Try again.')
+        }
+        throw error
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable, saveWishlistDraft]
+  )
+
+  const handleWishlistDelete = useCallback(
+    async (task: Task) => {
+      const wishlistEntryID = task.wishlistEntryID?.trim()
+      if (!wishlistEntryID) {
+        toast.error('Wishlist entry is missing delete metadata.')
+        return
+      }
+
+      setIsWishlistMutating(true)
+      try {
+        const response = await fetch(
+          `/api/wishlist?id=${encodeURIComponent(wishlistEntryID)}`,
+          { method: 'DELETE' }
+        )
+        if (!response.ok) {
+          throw new Error('wishlist_delete_failed')
+        }
+        await refreshWishlistTable()
+        toast.success(`${task.title} removed from wishlist.`)
+      } catch {
+        toast.error('Wishlist delete failed. Try again.')
+        throw new Error('wishlist_delete_failed')
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable]
+  )
+
+  const handleWishlistImport = useCallback(
+    async (entries: WishlistEntryDraft[]) => {
+      setIsWishlistMutating(true)
+      try {
+        for (const entry of entries) {
+          await saveWishlistDraft(entry)
+        }
+        await refreshWishlistTable()
+        toast.success(`Imported ${entries.length} wishlist entr${entries.length === 1 ? 'y' : 'ies'}.`)
+      } catch (error) {
+        if (error instanceof Error && error.message === 'invalid_target_price') {
+          toast.error('Target price must be a positive number.')
+        } else {
+          toast.error('Wishlist import failed. Try again.')
+        }
+        throw error
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable, saveWishlistDraft]
+  )
+
+  const handleWishlistBulkPriorityChange = useCallback(
+    async (selectedTasks: Task[], priority: string) => {
+      setIsWishlistMutating(true)
+      try {
+        for (const task of selectedTasks) {
+          const wishlistEntryID = task.wishlistEntryID?.trim()
+          if (!wishlistEntryID) {
+            continue
+          }
+          const response = await fetch('/api/wishlist', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              id: wishlistEntryID,
+              item_id: task.itemID,
+              priority: normalizeWishlistPriority(priority),
+              notes: task.notes ?? '',
+              target_price: task.targetPrice ?? 0,
+              highlight_hit: task.highlightHit ?? false,
+            }),
+          })
+          if (!response.ok) {
+            throw new Error('wishlist_bulk_priority_failed')
+          }
+        }
+        await refreshWishlistTable()
+        toast.success(`Updated priority for ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`)
+      } catch {
+        toast.error('Bulk priority update failed. Try again.')
+        throw new Error('wishlist_bulk_priority_failed')
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable]
+  )
+
+  const handleWishlistBulkStatusChange = useCallback(
+    async (selectedTasks: Task[], status: string) => {
+      const belowTargetNow = status === 'discovered'
+      setIsWishlistMutating(true)
+      try {
+        for (const task of selectedTasks) {
+          const wishlistEntryID = task.wishlistEntryID?.trim()
+          if (!wishlistEntryID) {
+            continue
+          }
+          const response = await fetch('/api/wishlist', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              id: wishlistEntryID,
+              item_id: task.itemID,
+              priority: normalizeWishlistPriority(task.priority),
+              notes: task.notes ?? '',
+              target_price: task.targetPrice ?? 0,
+              highlight_hit: task.highlightHit ?? false,
+              below_target_now: belowTargetNow,
+            }),
+          })
+          if (!response.ok) {
+            throw new Error('wishlist_bulk_status_failed')
+          }
+        }
+        await refreshWishlistTable()
+        toast.success(
+          `Updated watch status for ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`
+        )
+      } catch {
+        toast.error('Bulk watch status update failed. Try again.')
+        throw new Error('wishlist_bulk_status_failed')
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable]
+  )
+
+  const handleWishlistBulkDelete = useCallback(
+    async (selectedTasks: Task[]) => {
+      setIsWishlistMutating(true)
+      try {
+        for (const task of selectedTasks) {
+          const wishlistEntryID = task.wishlistEntryID?.trim()
+          if (!wishlistEntryID) {
+            continue
+          }
+          const response = await fetch(
+            `/api/wishlist?id=${encodeURIComponent(wishlistEntryID)}`,
+            { method: 'DELETE' }
+          )
+          if (!response.ok) {
+            throw new Error('wishlist_bulk_delete_failed')
+          }
+        }
+        await refreshWishlistTable()
+        toast.success(`Deleted ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`)
+      } catch {
+        toast.error('Bulk delete failed. Try again.')
+        throw new Error('wishlist_bulk_delete_failed')
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable]
+  )
+
+  const handleWishlistExport = useCallback((selectedTasks: Task[]) => {
+    const csv = buildWishlistCsv(selectedTasks)
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+    const url = window.URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = 'wishlist-export.csv'
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    window.URL.revokeObjectURL(url)
+    toast.success(`Exported ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`)
+  }, [])
+
   useEffect(() => {
     if (!isWishlistRoute || typeof window === 'undefined') {
       return
@@ -274,7 +632,7 @@ export function Tasks({
   }, [isWishlistRoute, tableData, wishlistPlanningFocus])
 
   return (
-    <TasksProvider>
+    <>
       <Header fixed>
         <Search />
         <div className='ms-auto flex items-center space-x-4'>
@@ -291,48 +649,21 @@ export function Tasks({
             <h2 className='text-2xl font-bold tracking-tight'>{title}</h2>
             <p className='text-muted-foreground'>{description}</p>
           </div>
-          <div className='flex items-center gap-2'>
-            <Button
-              type='button'
-              data-testid='wishlist-new-action'
-            >
-              New
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type='button'
-                  variant='outline'
-                  data-testid='wishlist-create-menu-trigger'
-                >
-                  Create
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='end'>
-                <DropdownMenuItem
-                  data-testid='wishlist-create-menu-entry'
-                >
-                  New Wishlist Entry
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  data-testid='wishlist-create-menu-import'
-                >
-                  Import Wishlist
-                </DropdownMenuItem>
-                {isWishlistRoute ? (
-                  <DropdownMenuItem
-                    data-testid='wishlist-create-menu-collection'
-                    onClick={() => {
-                      setInlineCollectionValidationMessage('')
-                      setInlineCollectionInputOpen(true)
-                    }}
-                  >
-                    New Collection
-                  </DropdownMenuItem>
-                ) : null}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          <TasksHeaderActions
+            isWishlistRoute={isWishlistRoute}
+            onOpenCollectionCreate={() => {
+              setInlineCollectionValidationMessage('')
+              setInlineCollectionInputOpen(true)
+            }}
+            onCreate={() => {
+              setCurrentDialogRow(null)
+              setDialogOpen('create')
+            }}
+            onImport={() => {
+              setCurrentDialogRow(null)
+              setDialogOpen('import')
+            }}
+          />
         </div>
         {isWishlistRoute ? (
           <div
@@ -459,14 +790,43 @@ export function Tasks({
         <TasksTable
           data={displayedData}
           routePath={routePath}
+          onEditRow={(task) => {
+            setCurrentDialogRow(task)
+            setDialogOpen('update')
+          }}
+          onDeleteRow={(task) => {
+            setCurrentDialogRow(task)
+            setDialogOpen('delete')
+          }}
           onWishlistMarkOwned={
             isWishlistRoute ? handleWishlistMarkOwned : undefined
           }
+          onWishlistBulkStatusChange={
+            isWishlistRoute ? handleWishlistBulkStatusChange : undefined
+          }
+          onWishlistBulkPriorityChange={
+            isWishlistRoute ? handleWishlistBulkPriorityChange : undefined
+          }
+          onWishlistBulkDelete={
+            isWishlistRoute ? handleWishlistBulkDelete : undefined
+          }
+          onWishlistExport={isWishlistRoute ? handleWishlistExport : undefined}
           wishlistActionItemID={wishlistActionItemID}
+          isWishlistMutating={isWishlistMutating}
         />
       </Main>
 
-      <TasksDialogs />
-    </TasksProvider>
+      <TasksDialogs
+        routePath={routePath}
+        open={dialogOpen}
+        setOpen={setDialogOpen}
+        currentRow={currentDialogRow}
+        setCurrentRow={setCurrentDialogRow}
+        onWishlistSubmit={isWishlistRoute ? handleWishlistSubmit : undefined}
+        onWishlistDelete={isWishlistRoute ? handleWishlistDelete : undefined}
+        onWishlistImport={isWishlistRoute ? handleWishlistImport : undefined}
+        isWishlistMutating={isWishlistMutating}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- wire Wishlist create, import, edit, delete, and bulk actions to real persistence instead of demo toasts
- make Wishlist dialogs, forms, and copy route-specific, including import CSV handling and row action flows
- add focused Cypress coverage for the real Wishlist action paths and fix the dialog timer race affecting delete after edit

## Validation
- `npm.cmd run build` in `ui.web`
- `npx.cmd eslint ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts ui.web/src/features/collection/index.tsx ui.web/src/features/tasks/components/data-table-bulk-actions.tsx ui.web/src/features/tasks/components/data-table-row-actions.tsx ui.web/src/features/tasks/components/tasks-columns.tsx ui.web/src/features/tasks/components/tasks-dialogs.tsx ui.web/src/features/tasks/components/tasks-import-dialog.tsx ui.web/src/features/tasks/components/tasks-multi-delete-dialog.tsx ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx ui.web/src/features/tasks/components/tasks-provider.tsx ui.web/src/features/tasks/components/tasks-table.tsx ui.web/src/features/tasks/data/schema.ts ui.web/src/features/tasks/index.tsx`
- `git diff --check`
- `./scripts/build-cabinet.ps1`
- `npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts`

## Notes
- ESLint still reports a pre-existing `react-hooks/exhaustive-deps` warning in `ui.web/src/features/collection/index.tsx` that is outside this Wishlist slice.
