### PR TITLE
#570 feat(collections): persist collection state in profile settings

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -1,10 +1,24 @@
 describe('ui-screen-collections', () => {
+  const collectionsSettingsKey = 'collections.workspace.v1'
+
   function signInToCollections() {
-    cy.visit('/sign-in?redirect=%2Fcollections%2F')
-    cy.get('input[name="email"]').clear().type('e2e-collections@example.com')
-    cy.get('input[name="password"]').clear().type('password123')
-    cy.contains('button', 'Sign in').click()
-    cy.location('pathname', { timeout: 15000 }).should('match', /^\/collections\/?$/)
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/profiles/*/settings').as('loadCollectionSettings')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path: '/collections/' })
+    })
+    cy.wait('@loadCollectionSettings')
+  }
+
+  function bootstrapCollectionsProfile(path = '/collections/') {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/profiles/*/settings').as('loadCollectionSettings')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path })
+    })
+    cy.wait('@loadCollectionSettings')
   }
 
   it('UI-SCREEN-COLLECTIONS-001 renders shared collections management table', () => {
@@ -18,8 +32,10 @@ describe('ui-screen-collections', () => {
 
   it('UI-SCREEN-COLLECTIONS-002 selects a row and persists active context across refresh', () => {
     signInToCollections()
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSelection')
 
     cy.get('[data-testid="collections-row-watch-list"]').click()
+    cy.wait('@saveCollectionSelection')
     cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Watch List')
     cy.get('[data-testid="collections-active-context-message"]').should(
       'contain.text',
@@ -52,7 +68,7 @@ describe('ui-screen-collections', () => {
     signInToCollections()
 
     cy.get('[data-testid="collections-row-store-2"]').click()
-    cy.get('[data-testid="collections-row-edit-store-2"]').click()
+    cy.get('[data-testid="collections-row-edit-store-2"]').scrollIntoView().click({ force: true })
     cy.get('[data-testid="collections-edit-input"]').clear().type('Store 2 Prime')
     cy.get('[data-testid="collections-edit-submit"]').click()
 
@@ -67,7 +83,7 @@ describe('ui-screen-collections', () => {
 
     cy.get('[data-testid="collections-row-store-1"]').click()
     cy.get('[data-testid="collections-member-shadowless-pikachu"]').should('be.visible')
-    cy.get('[data-testid="collections-row-delete-store-1"]').click()
+    cy.get('[data-testid="collections-row-delete-store-1"]').scrollIntoView().click({ force: true })
     cy.get('[data-testid="collections-delete-submit"]').click()
 
     cy.contains('Store 1 removed from workspace collections.').should('be.visible')
@@ -90,11 +106,14 @@ describe('ui-screen-collections', () => {
 
   it('UI-SCREEN-COLLECTIONS-007 assigns an item into the selected collection and persists after refresh', () => {
     signInToCollections()
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
 
     cy.get('[data-testid="collections-row-warehouse-1"]').click()
+    cy.wait('@saveCollectionSettings')
     cy.get('[data-testid="collections-assignment-select"]').click()
     cy.contains('Base Set Charizard (Unassigned)').click()
     cy.get('[data-testid="collections-assignment-submit"]').click()
+    cy.wait('@saveCollectionSettings')
 
     cy.contains('Base Set Charizard assigned to Warehouse 1.').should('be.visible')
     cy.get('[data-testid="collections-member-base-set-charizard"]').should('be.visible')
@@ -127,7 +146,100 @@ describe('ui-screen-collections', () => {
 
     cy.get('[data-testid="sidebar-nav-link-collections"]').should('be.visible')
     cy.get('[data-testid="collections-page-icon"]').should('be.visible')
-    cy.get('[data-testid="sidebar-nav-link-collections"] svg').should('have.attr', 'data-lucide', 'tag')
-    cy.get('[data-testid="collections-page-icon"]').should('have.attr', 'data-lucide', 'tag')
+    cy.get('[data-testid="sidebar-nav-link-collections"] svg').should('have.class', 'lucide-tag')
+    cy.get('[data-testid="collections-page-icon"]').should('have.class', 'lucide-tag')
+  })
+
+  it('UI-SCREEN-COLLECTIONS-010 persists collection state through profile settings and across refresh', () => {
+    bootstrapCollectionsProfile()
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
+
+    cy.get('[data-testid="collections-new-action"]').click()
+    cy.get('[data-testid="collections-create-input"]').type('Profile Persisted Vault')
+    cy.get('[data-testid="collections-create-submit"]').click()
+    cy.wait('@saveCollectionSettings')
+
+    cy.get('[data-testid="collections-row-profile-persisted-vault"]').click()
+    cy.get('[data-testid="collections-assignment-select"]').click()
+    cy.contains('Base Set Charizard (Unassigned)').click()
+    cy.get('[data-testid="collections-assignment-submit"]').click()
+    cy.wait('@saveCollectionSettings')
+
+    cy.request('/api/profiles/e2e-profile-001/settings').then((response) => {
+      const settings = (response.body.settings ?? {}) as Record<string, string>
+      const persisted = JSON.parse(settings[collectionsSettingsKey] ?? '{}') as {
+        collections?: string[]
+        activeCollection?: string
+        items?: Array<{ id?: string; collectionName?: string | null }>
+      }
+
+      expect(persisted.collections).to.include('Profile Persisted Vault')
+      expect(persisted.activeCollection).to.equal('Profile Persisted Vault')
+      expect(persisted.items).to.satisfy(
+        (items?: Array<{ id?: string; collectionName?: string | null }>) =>
+          Array.isArray(items) &&
+          items.some(
+            (item) =>
+              item.id === 'inventory-item-charizard-base' &&
+              item.collectionName === 'Profile Persisted Vault'
+          )
+      )
+    })
+
+    cy.reload()
+    cy.get('[data-testid="collections-selected-name"]').should(
+      'contain.text',
+      'Profile Persisted Vault'
+    )
+    cy.get('[data-testid="collections-member-base-set-charizard"]').should('be.visible')
+  })
+
+  it('UI-SCREEN-COLLECTIONS-011 switches collection state with the active profile', () => {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.request('POST', '/api/profiles', { name: 'Collections Profile Two' }).then(
+        (createResponse) => {
+          expect(createResponse.status).to.be.oneOf([200, 201])
+          const secondProfileId = createResponse.body.id as string
+
+          const secondProfileSettings = {
+            [collectionsSettingsKey]: JSON.stringify({
+              collections: ['All Items', 'Profile Two Vault'],
+              activeCollection: 'Profile Two Vault',
+              items: [
+                {
+                  id: 'inventory-item-kobe-rookie',
+                  name: '1996 Topps Kobe Bryant rookie',
+                  detail: 'PSA candidate, Lakers lot',
+                  collectionName: 'Profile Two Vault',
+                },
+              ],
+            }),
+          }
+
+          cy.request('PUT', `/api/profiles/${secondProfileId}/settings`, {
+            settings: secondProfileSettings,
+          }).its('status').should('eq', 200)
+
+          cy.useBootstrappedProfile(profile_id, profile_name, { path: '/collections/' })
+          cy.get('[data-testid="collections-row-profile-two-vault"]').should('not.exist')
+
+          cy.request('PUT', '/api/profiles/active', { profile_id: secondProfileId })
+            .its('status')
+            .should('eq', 200)
+          cy.visit('/collections/')
+
+          cy.get('[data-testid="collections-row-profile-two-vault"]').should('be.visible')
+          cy.get('[data-testid="collections-selected-name"]').should(
+            'contain.text',
+            'Profile Two Vault'
+          )
+          cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should(
+            'be.visible'
+          )
+        }
+      )
+    })
   })
 })

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -2369,7 +2369,7 @@ export function Collection({
                     value={activeWorkspaceCollection}
                     onChange={(event) => {
                       const selected = event.target.value
-                      setActiveWorkspaceCollection(selected)
+                      void setActiveWorkspaceCollection(selected)
                       setActiveFolder(selected)
                     }}
                   >
@@ -2409,8 +2409,8 @@ export function Collection({
                     <Button
                       type='button'
                       data-testid='collection-inline-save'
-                      onClick={() => {
-                        const created = addCollection(inlineCollectionName)
+                      onClick={async () => {
+                        const created = await addCollection(inlineCollectionName)
                         if (created) {
                           setActiveFolder(created)
                         }

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -227,13 +227,13 @@ export function Collections() {
 
   const filteredCount = table.getFilteredRowModel().rows.length
 
-  function handleSelectCollection(row: CollectionRow) {
+  async function handleSelectCollection(row: CollectionRow) {
     setSelectedCollectionID(row.key)
-    setActiveWorkspaceCollection(row.name)
+    await setActiveWorkspaceCollection(row.name)
   }
 
-  function handleCreateCollection() {
-    const created = addCollection(createValue)
+  async function handleCreateCollection() {
+    const created = await addCollection(createValue)
     if (!created) {
       toast.error('Collection name must be unique and non-empty.')
       return
@@ -244,11 +244,11 @@ export function Collections() {
     toast.success(`${created} created and set as the active collection.`)
   }
 
-  function handleRenameCollection() {
+  async function handleRenameCollection() {
     if (!selectedRow) {
       return
     }
-    const renamed = renameCollection(selectedRow.name, editValue)
+    const renamed = await renameCollection(selectedRow.name, editValue)
     if (!renamed) {
       toast.error('Rename failed. Use a unique non-empty collection name.')
       return
@@ -258,12 +258,12 @@ export function Collections() {
     toast.success(`${selectedRow.name} renamed to ${renamed}.`)
   }
 
-  function handleDeleteCollection() {
+  async function handleDeleteCollection() {
     if (!selectedRow) {
       return
     }
     const removedName = selectedRow.name
-    const removed = removeCollection(removedName)
+    const removed = await removeCollection(removedName)
     if (!removed) {
       toast.error('Collection removal failed.')
       return
@@ -273,11 +273,11 @@ export function Collections() {
     toast.success(`${removedName} removed from workspace collections.`)
   }
 
-  function handleAssignToSelectedCollection() {
+  async function handleAssignToSelectedCollection() {
     if (!assignmentItemID || !selectedRow || isProtectedCollection) {
       return
     }
-    const updated = assignItemToCollection(assignmentItemID, selectedRow.name)
+    const updated = await assignItemToCollection(assignmentItemID, selectedRow.name)
     if (!updated) {
       toast.error('Select an item and a valid collection before saving.')
       return
@@ -286,13 +286,13 @@ export function Collections() {
     toast.success(`${updated.name} assigned to ${selectedRow.name}.`)
   }
 
-  function handleMoveItem(item: WorkspaceCollectionItem) {
+  async function handleMoveItem(item: WorkspaceCollectionItem) {
     const destination = moveTargets[item.id]
     if (!destination) {
       toast.error('Choose a destination collection before moving the item.')
       return
     }
-    const updated = assignItemToCollection(item.id, destination)
+    const updated = await assignItemToCollection(item.id, destination)
     if (!updated) {
       toast.error('Item move failed.')
       return
@@ -379,7 +379,9 @@ export function Collections() {
                             className='cursor-pointer'
                             data-state={isSelected ? 'selected' : undefined}
                             data-testid={`collections-row-${row.original.key}`}
-                            onClick={() => handleSelectCollection(row.original)}
+                            onClick={() => {
+                              void handleSelectCollection(row.original)
+                            }}
                           >
                             {row.getVisibleCells().map((cell) => (
                               <TableCell key={cell.id}>
@@ -460,7 +462,9 @@ export function Collections() {
                     </Select>
                     <Button
                       type='button'
-                      onClick={handleAssignToSelectedCollection}
+                      onClick={() => {
+                        void handleAssignToSelectedCollection()
+                      }}
                       data-testid='collections-assignment-submit'
                     >
                       Assign to {selectedCollectionName}
@@ -519,7 +523,9 @@ export function Collections() {
                           type='button'
                           variant='outline'
                           data-testid={`collections-move-submit-${collectionKey(item.name)}`}
-                          onClick={() => handleMoveItem(item)}
+                          onClick={() => {
+                            void handleMoveItem(item)
+                          }}
                         >
                           <ArrowRightLeft className='mr-2 h-4 w-4' />
                           Move item
@@ -554,7 +560,13 @@ export function Collections() {
             <Button type='button' variant='outline' onClick={() => setCreateOpen(false)}>
               Cancel
             </Button>
-            <Button type='button' onClick={handleCreateCollection} data-testid='collections-create-submit'>
+            <Button
+              type='button'
+              onClick={() => {
+                void handleCreateCollection()
+              }}
+              data-testid='collections-create-submit'
+            >
               Save collection
             </Button>
           </DialogFooter>
@@ -577,7 +589,13 @@ export function Collections() {
             <Button type='button' variant='outline' onClick={() => setEditOpen(false)}>
               Cancel
             </Button>
-            <Button type='button' onClick={handleRenameCollection} data-testid='collections-edit-submit'>
+            <Button
+              type='button'
+              onClick={() => {
+                void handleRenameCollection()
+              }}
+              data-testid='collections-edit-submit'
+            >
               Save rename
             </Button>
           </DialogFooter>
@@ -601,7 +619,14 @@ export function Collections() {
             <Button type='button' variant='outline' onClick={() => setDeleteOpen(false)}>
               Cancel
             </Button>
-            <Button type='button' variant='destructive' onClick={handleDeleteCollection} data-testid='collections-delete-submit'>
+            <Button
+              type='button'
+              variant='destructive'
+              onClick={() => {
+                void handleDeleteCollection()
+              }}
+              data-testid='collections-delete-submit'
+            >
               Delete collection
             </Button>
           </DialogFooter>

--- a/ui.web/src/features/collections/use-workspace-collections.ts
+++ b/ui.web/src/features/collections/use-workspace-collections.ts
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
-import { useAuthStore } from '@/stores/auth-store'
+import { useMemo } from 'react'
+import { useProfileSettings } from '@/features/settings/use-profile-settings'
 
 export type WorkspaceCollectionSummary = {
   name: string
@@ -19,6 +19,14 @@ export type WorkspaceCollectionItem = {
 }
 
 type CollectionSeed = Omit<WorkspaceCollectionSummary, 'key'>
+
+type PersistedWorkspaceCollectionsState = {
+  collections?: string[]
+  activeCollection?: string
+  items?: WorkspaceCollectionItem[]
+}
+
+const collectionsSettingsKey = 'collections.workspace.v1'
 
 const DEFAULT_COLLECTIONS: CollectionSeed[] = [
   {
@@ -136,102 +144,119 @@ function buildDefaultSummary(name: string): WorkspaceCollectionSummary {
   }
 }
 
-function profileScopeKey(profileID?: string | null, userEmail?: string | null): string {
-  return normalizeCollectionName(profileID || userEmail || 'default-profile')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
+function normalizeWorkspaceCollectionItem(
+  item: WorkspaceCollectionItem
+): WorkspaceCollectionItem {
+  return {
+    id: normalizeCollectionName(item.id),
+    name: normalizeCollectionName(item.name),
+    detail: normalizeCollectionName(item.detail),
+    collectionName: item.collectionName
+      ? normalizeCollectionName(item.collectionName)
+      : null,
+  }
+}
+
+function normalizeCollectionsList(value?: string[]): string[] {
+  const normalized = (value ?? [])
+    .map((entry) => normalizeCollectionName(entry))
+    .filter(Boolean)
+
+  return Array.from(new Set(['All Items', ...normalized]))
+}
+
+function defaultWorkspaceCollectionsState(): Required<PersistedWorkspaceCollectionsState> {
+  return {
+    collections: DEFAULT_COLLECTIONS.map((entry) => entry.name),
+    activeCollection: 'All Items',
+    items: DEFAULT_ITEMS.map(normalizeWorkspaceCollectionItem),
+  }
+}
+
+function parseWorkspaceCollectionsState(
+  rawValue: string | undefined
+): Required<PersistedWorkspaceCollectionsState> {
+  if (!rawValue) {
+    return defaultWorkspaceCollectionsState()
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as PersistedWorkspaceCollectionsState
+    const normalizedCollections = normalizeCollectionsList(parsed.collections)
+    const normalizedItems = Array.isArray(parsed.items)
+      ? parsed.items
+          .map(normalizeWorkspaceCollectionItem)
+          .filter((item) => item.id && item.name)
+      : DEFAULT_ITEMS.map(normalizeWorkspaceCollectionItem)
+
+    const normalizedActive = normalizeCollectionName(
+      parsed.activeCollection ?? 'All Items'
+    )
+    const activeCollection = normalizedCollections.includes(normalizedActive)
+      ? normalizedActive
+      : 'All Items'
+
+    return {
+      collections: normalizedCollections,
+      activeCollection,
+      items: normalizedItems,
+    }
+  } catch {
+    return defaultWorkspaceCollectionsState()
+  }
+}
+
+function serializeWorkspaceCollectionsState(
+  collections: string[],
+  activeCollection: string,
+  items: WorkspaceCollectionItem[]
+): string {
+  const normalizedCollections = normalizeCollectionsList(collections)
+  const normalizedItems = items
+    .map(normalizeWorkspaceCollectionItem)
+    .filter((item) => item.id && item.name)
+  const normalizedActive = normalizeCollectionName(activeCollection)
+
+  return JSON.stringify({
+    collections: normalizedCollections,
+    activeCollection: normalizedCollections.includes(normalizedActive)
+      ? normalizedActive
+      : 'All Items',
+    items: normalizedItems,
+  })
 }
 
 export function useWorkspaceCollections() {
-  const userEmail = useAuthStore((state) => state.auth.user?.email)
-  const profileScope = profileScopeKey(null, userEmail)
-  const listKey = `cabinet.workspace.collections.${profileScope}`
-  const activeKey = `cabinet.workspace.collections.active.${profileScope}`
-  const itemsKey = `cabinet.workspace.collectionItems.${profileScope}`
-
-  const [workspaceCollections, setWorkspaceCollections] = useState<string[]>(
-    DEFAULT_COLLECTIONS.map((entry) => entry.name)
+  const {
+    activeProfileId,
+    settings,
+    saveSettings,
+  } = useProfileSettings()
+  const persistedState = useMemo(
+    () => parseWorkspaceCollectionsState(settings[collectionsSettingsKey]),
+    [settings]
   )
-  const [activeWorkspaceCollection, setActiveWorkspaceCollection] = useState('All Items')
-  const [workspaceItems, setWorkspaceItems] = useState<WorkspaceCollectionItem[]>(DEFAULT_ITEMS)
 
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
+  const workspaceCollections = persistedState.collections
+  const activeWorkspaceCollection = persistedState.activeCollection
+  const workspaceItems = persistedState.items
+
+  const persistWorkspaceCollectionsState = async (
+    nextState: Required<PersistedWorkspaceCollectionsState>
+  ) => {
+    if (!activeProfileId) {
+      throw new Error('active_profile_missing')
     }
 
-    const persistedCollections = window.localStorage.getItem(listKey)
-    if (persistedCollections) {
-      try {
-        const parsed = JSON.parse(persistedCollections) as string[]
-        const normalized = parsed
-          .map((entry) => normalizeCollectionName(entry))
-          .filter(Boolean)
-        if (normalized.length) {
-          const unique = Array.from(new Set(['All Items', ...normalized]))
-          setWorkspaceCollections(unique)
-        }
-      } catch {
-        // Ignore malformed persisted collections and fall back to defaults.
-      }
-    } else {
-      setWorkspaceCollections(DEFAULT_COLLECTIONS.map((entry) => entry.name))
-    }
-
-    const persistedActive = window.localStorage.getItem(activeKey)
-    if (persistedActive) {
-      const normalizedActive = normalizeCollectionName(persistedActive)
-      if (normalizedActive) {
-        setActiveWorkspaceCollection(normalizedActive)
-      }
-    } else {
-      setActiveWorkspaceCollection('All Items')
-    }
-
-    const persistedItems = window.localStorage.getItem(itemsKey)
-    if (persistedItems) {
-      try {
-        const parsed = JSON.parse(persistedItems) as WorkspaceCollectionItem[]
-        if (Array.isArray(parsed) && parsed.length) {
-          setWorkspaceItems(
-            parsed.map((item) => ({
-              ...item,
-              name: normalizeCollectionName(item.name),
-              detail: normalizeCollectionName(item.detail),
-              collectionName: item.collectionName
-                ? normalizeCollectionName(item.collectionName)
-                : null,
-            }))
-          )
-        }
-      } catch {
-        // Ignore malformed persisted items and fall back to defaults.
-      }
-    } else {
-      setWorkspaceItems(DEFAULT_ITEMS)
-    }
-  }, [activeKey, itemsKey, listKey])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
-    window.localStorage.setItem(listKey, JSON.stringify(workspaceCollections))
-  }, [listKey, workspaceCollections])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
-    window.localStorage.setItem(activeKey, activeWorkspaceCollection)
-  }, [activeKey, activeWorkspaceCollection])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
-    window.localStorage.setItem(itemsKey, JSON.stringify(workspaceItems))
-  }, [itemsKey, workspaceItems])
+    await saveSettings({
+      ...settings,
+      [collectionsSettingsKey]: serializeWorkspaceCollectionsState(
+        nextState.collections,
+        nextState.activeCollection,
+        nextState.items
+      ),
+    })
+  }
 
   const collectionSummaries = useMemo(() => {
     return workspaceCollections.map((name) => {
@@ -243,14 +268,15 @@ export function useWorkspaceCollections() {
 
       return {
         ...base,
-        itemCount: name === 'All Items' ? Math.max(base.itemCount, assignedCount) : assignedCount,
+        itemCount:
+          name === 'All Items' ? Math.max(base.itemCount, assignedCount) : assignedCount,
         updatedLabel:
           assignedCount > 0 && name !== 'All Items' ? 'Updated just now' : base.updatedLabel,
       }
     })
   }, [workspaceCollections, workspaceItems])
 
-  const addCollection = (value: string): string | null => {
+  const addCollection = async (value: string): Promise<string | null> => {
     const normalized = normalizeCollectionName(value)
     if (!normalized) {
       return null
@@ -261,12 +287,20 @@ export function useWorkspaceCollections() {
     if (exists) {
       return null
     }
-    setWorkspaceCollections((current) => [...current, normalized])
-    setActiveWorkspaceCollection(normalized)
+
+    await persistWorkspaceCollectionsState({
+      collections: [...workspaceCollections, normalized],
+      activeCollection: normalized,
+      items: workspaceItems,
+    })
+
     return normalized
   }
 
-  const renameCollection = (currentName: string, nextName: string): string | null => {
+  const renameCollection = async (
+    currentName: string,
+    nextName: string
+  ): Promise<string | null> => {
     const normalizedCurrent = normalizeCollectionName(currentName)
     const normalizedNext = normalizeCollectionName(nextName)
     if (!normalizedCurrent || !normalizedNext || normalizedCurrent === 'All Items') {
@@ -281,27 +315,27 @@ export function useWorkspaceCollections() {
       return null
     }
 
-    setWorkspaceCollections((current) =>
-      current.map((collection) =>
+    await persistWorkspaceCollectionsState({
+      collections: workspaceCollections.map((collection) =>
         collection.toLowerCase() === normalizedCurrent.toLowerCase()
           ? normalizedNext
           : collection
-      )
-    )
-    setWorkspaceItems((current) =>
-      current.map((item) =>
+      ),
+      activeCollection:
+        activeWorkspaceCollection.toLowerCase() === normalizedCurrent.toLowerCase()
+          ? normalizedNext
+          : activeWorkspaceCollection,
+      items: workspaceItems.map((item) =>
         item.collectionName?.toLowerCase() === normalizedCurrent.toLowerCase()
           ? { ...item, collectionName: normalizedNext }
           : item
-      )
-    )
-    if (activeWorkspaceCollection.toLowerCase() === normalizedCurrent.toLowerCase()) {
-      setActiveWorkspaceCollection(normalizedNext)
-    }
+      ),
+    })
+
     return normalizedNext
   }
 
-  const removeCollection = (name: string): boolean => {
+  const removeCollection = async (name: string): Promise<boolean> => {
     const normalized = normalizeCollectionName(name)
     if (!normalized || normalized === 'All Items') {
       return false
@@ -313,42 +347,53 @@ export function useWorkspaceCollections() {
       return false
     }
 
-    setWorkspaceCollections((current) =>
-      current.filter((collection) => collection.toLowerCase() !== normalized.toLowerCase())
-    )
-    setWorkspaceItems((current) =>
-      current.map((item) =>
+    await persistWorkspaceCollectionsState({
+      collections: workspaceCollections.filter(
+        (collection) => collection.toLowerCase() !== normalized.toLowerCase()
+      ),
+      activeCollection:
+        activeWorkspaceCollection.toLowerCase() === normalized.toLowerCase()
+          ? 'All Items'
+          : activeWorkspaceCollection,
+      items: workspaceItems.map((item) =>
         item.collectionName?.toLowerCase() === normalized.toLowerCase()
           ? { ...item, collectionName: null }
           : item
-      )
-    )
-    if (activeWorkspaceCollection.toLowerCase() === normalized.toLowerCase()) {
-      setActiveWorkspaceCollection('All Items')
-    }
+      ),
+    })
+
     return true
   }
 
-  const assignItemToCollection = (itemID: string, collectionName: string): WorkspaceCollectionItem | null => {
+  const assignItemToCollection = (
+    itemID: string,
+    collectionName: string
+  ): Promise<WorkspaceCollectionItem | null> => {
     const normalizedCollection = normalizeCollectionName(collectionName)
     if (!itemID || !normalizedCollection || normalizedCollection === 'All Items') {
-      return null
+      return Promise.resolve(null)
     }
     if (!workspaceCollections.some((collection) => collection === normalizedCollection)) {
-      return null
+      return Promise.resolve(null)
     }
 
-    let updatedItem: WorkspaceCollectionItem | null = null
-    setWorkspaceItems((current) =>
-      current.map((item) => {
-        if (item.id !== itemID) {
-          return item
-        }
-        updatedItem = { ...item, collectionName: normalizedCollection }
-        return updatedItem
-      })
+    const updatedItems = workspaceItems.map((item) =>
+      item.id === itemID
+        ? { ...item, collectionName: normalizedCollection }
+        : item
     )
-    return updatedItem
+    const updatedItem =
+      updatedItems.find((item) => item.id === itemID) ?? null
+
+    if (!updatedItem) {
+      return Promise.resolve(null)
+    }
+
+    return persistWorkspaceCollectionsState({
+      collections: workspaceCollections,
+      activeCollection: activeWorkspaceCollection,
+      items: updatedItems,
+    }).then(() => updatedItem)
   }
 
   const collectionItems = useMemo(() => workspaceItems, [workspaceItems])
@@ -356,7 +401,20 @@ export function useWorkspaceCollections() {
   return {
     workspaceCollections,
     activeWorkspaceCollection,
-    setActiveWorkspaceCollection,
+    setActiveWorkspaceCollection: async (nextCollection: string) => {
+      const normalizedCollection = normalizeCollectionName(nextCollection)
+      if (!normalizedCollection) {
+        return
+      }
+      const safeCollection = workspaceCollections.includes(normalizedCollection)
+        ? normalizedCollection
+        : 'All Items'
+      await persistWorkspaceCollectionsState({
+        collections: workspaceCollections,
+        activeCollection: safeCollection,
+        items: workspaceItems,
+      })
+    },
     addCollection,
     renameCollection,
     removeCollection,

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -705,9 +705,9 @@ export function Tasks({
               <select
                 className='h-9 rounded-md border bg-background px-2 text-sm'
                 value={activeWorkspaceCollection}
-                onChange={(event) =>
-                  setActiveWorkspaceCollection(event.target.value)
-                }
+                onChange={(event) => {
+                  void setActiveWorkspaceCollection(event.target.value)
+                }}
               >
                 {workspaceCollections.map((collection) => (
                   <option
@@ -757,8 +757,8 @@ export function Tasks({
                   <Button
                     type='button'
                     data-testid='wishlist-inline-save'
-                    onClick={() => {
-                      const created = addCollection(inlineCollectionName)
+                    onClick={async () => {
+                      const created = await addCollection(inlineCollectionName)
                       if (!created) {
                         setInlineCollectionValidationMessage(
                           'Collection name is required.'
@@ -766,7 +766,7 @@ export function Tasks({
                         return
                       }
                       setInlineCollectionValidationMessage('')
-                      setActiveWorkspaceCollection(created)
+                      await setActiveWorkspaceCollection(created)
                       setInlineCollectionName('')
                       setInlineCollectionInputOpen(false)
                     }}


### PR DESCRIPTION
## Summary
- move workspace collections persistence into profile settings under `collections.workspace.v1`
- update collections, inventory, and wishlist callers to await async collection mutators
- add profile-scoped collections persistence coverage across refresh and active-profile switching

## Validation
- `npm.cmd run build` in `ui.web`
- `npx.cmd eslint ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts ui.web/src/features/collections/use-workspace-collections.ts ui.web/src/features/collections/index.tsx ui.web/src/features/collection/index.tsx ui.web/src/features/tasks/index.tsx`
- `npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts`
- `git diff --check`