### PR TITLE
#572 feat(collections): support direct item unassign

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -141,6 +141,28 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('be.visible')
   })
 
+  it('UI-SCREEN-COLLECTIONS-008A unassigns an item directly from the selected collection and persists after refresh', () => {
+    signInToCollections()
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
+
+    cy.get('[data-testid="collections-row-watch-list"]').click()
+    cy.wait('@saveCollectionSettings')
+    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('be.visible')
+    cy.get('[data-testid="collections-unassign-submit-1996-topps-kobe-bryant-rookie"]').click()
+    cy.wait('@saveCollectionSettings')
+
+    cy.contains('1996 Topps Kobe Bryant rookie removed from Watch List.').should('be.visible')
+    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('not.exist')
+
+    cy.get('[data-testid="collections-assignment-select"]').click()
+    cy.contains('1996 Topps Kobe Bryant rookie (Unassigned)').should('be.visible')
+
+    cy.reload()
+    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('not.exist')
+    cy.get('[data-testid="collections-assignment-select"]').click()
+    cy.contains('1996 Topps Kobe Bryant rookie (Unassigned)').should('be.visible')
+  })
+
   it('UI-SCREEN-COLLECTIONS-009 retains tag iconography for collections route identity', () => {
     signInToCollections()
 

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -143,6 +143,7 @@ export function Collections() {
     collectionItems,
     collectionSummaries,
     assignItemToCollection,
+    unassignItemFromCollection,
   } = useWorkspaceCollections()
 
   const [sorting, setSorting] = useState<SortingState>([{ id: 'name', desc: false }])
@@ -303,6 +304,20 @@ export function Collections() {
       return next
     })
     toast.success(`${item.name} moved to ${destination}.`)
+  }
+
+  async function handleUnassignItem(item: WorkspaceCollectionItem) {
+    const updated = await unassignItemFromCollection(item.id)
+    if (!updated) {
+      toast.error('Item release failed.')
+      return
+    }
+    setMoveTargets((current) => {
+      const next = { ...current }
+      delete next[item.id]
+      return next
+    })
+    toast.success(`${item.name} removed from ${selectedCollectionName}.`)
   }
 
   return (
@@ -529,6 +544,17 @@ export function Collections() {
                         >
                           <ArrowRightLeft className='mr-2 h-4 w-4' />
                           Move item
+                        </Button>
+                        <Button
+                          type='button'
+                          variant='outline'
+                          data-testid={`collections-unassign-submit-${collectionKey(item.name)}`}
+                          onClick={() => {
+                            void handleUnassignItem(item)
+                          }}
+                        >
+                          <Trash2 className='mr-2 h-4 w-4' />
+                          Unassign
                         </Button>
                       </div>
                     </div>

--- a/ui.web/src/features/collections/use-workspace-collections.ts
+++ b/ui.web/src/features/collections/use-workspace-collections.ts
@@ -396,6 +396,29 @@ export function useWorkspaceCollections() {
     }).then(() => updatedItem)
   }
 
+  const unassignItemFromCollection = (
+    itemID: string
+  ): Promise<WorkspaceCollectionItem | null> => {
+    if (!itemID) {
+      return Promise.resolve(null)
+    }
+
+    const updatedItems = workspaceItems.map((item) =>
+      item.id === itemID ? { ...item, collectionName: null } : item
+    )
+    const updatedItem = updatedItems.find((item) => item.id === itemID) ?? null
+
+    if (!updatedItem) {
+      return Promise.resolve(null)
+    }
+
+    return persistWorkspaceCollectionsState({
+      collections: workspaceCollections,
+      activeCollection: activeWorkspaceCollection,
+      items: updatedItems,
+    }).then(() => updatedItem)
+  }
+
   const collectionItems = useMemo(() => workspaceItems, [workspaceItems])
 
   return {
@@ -421,5 +444,6 @@ export function useWorkspaceCollections() {
     collectionSummaries,
     collectionItems,
     assignItemToCollection,
+    unassignItemFromCollection,
   }
 }


### PR DESCRIPTION
## Summary
- add a direct unassign action for collection members in the Collections manager
- persist unassign through profile-scoped collections settings
- cover the unassign workflow end-to-end across refresh

## Validation
- `./scripts/build-cabinet.ps1`
- `npx.cmd eslint ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts ui.web/src/features/collections/index.tsx ui.web/src/features/collections/use-workspace-collections.ts`
- `npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts`
- `git diff --check`