### PR TITLE
#574 fix(collections): keep wishlist inline create in sync

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -264,4 +264,60 @@ describe('ui-screen-collections', () => {
       )
     })
   })
+
+  it('UI-SCREEN-COLLECTIONS-012 reflects inventory inline collection create inside the collections manager', () => {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/profiles/*/settings').as('loadCollectionSettings')
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path: '/inventory/' })
+    })
+    cy.wait('@loadCollectionSettings')
+
+    cy.get('[data-testid="collection-inline-add-new"]').click()
+    cy.get('[data-testid="collection-inline-new-name"]').type('Inventory Sync Shelf')
+    cy.get('[data-testid="collection-inline-save"]').click()
+    cy.wait('@saveCollectionSettings')
+    cy.get('[data-testid="collection-inline-picker-selected"]').should(
+      'contain.text',
+      'Inventory Sync Shelf'
+    )
+
+    cy.visit('/collections/')
+    cy.wait('@loadCollectionSettings')
+    cy.get('[data-testid="collections-row-inventory-sync-shelf"]').should('be.visible')
+    cy.get('[data-testid="collections-selected-name"]').should(
+      'contain.text',
+      'Inventory Sync Shelf'
+    )
+  })
+
+  it('UI-SCREEN-COLLECTIONS-013 reflects wishlist inline collection create inside the collections manager', () => {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/profiles/*/settings').as('loadCollectionSettings')
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path: '/wishlist/' })
+    })
+    cy.wait('@loadCollectionSettings')
+
+    cy.get('[data-testid="wishlist-inline-add-new"]').click()
+    cy.get('[data-testid="wishlist-inline-new-name"]').type('Wishlist Sync Shelf')
+    cy.get('[data-testid="wishlist-inline-save"]').click()
+    cy.wait('@saveCollectionSettings')
+    cy.get('[data-testid="wishlist-inline-picker-selected"]').should(
+      'contain.text',
+      'Wishlist Sync Shelf'
+    )
+
+    cy.visit('/collections/')
+    cy.wait('@loadCollectionSettings')
+    cy.get('[data-testid="collections-row-wishlist-sync-shelf"]').should('be.visible')
+    cy.get('[data-testid="collections-selected-name"]').should(
+      'contain.text',
+      'Wishlist Sync Shelf'
+    )
+  })
 })

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -766,7 +766,6 @@ export function Tasks({
                         return
                       }
                       setInlineCollectionValidationMessage('')
-                      await setActiveWorkspaceCollection(created)
                       setInlineCollectionName('')
                       setInlineCollectionInputOpen(false)
                     }}


### PR DESCRIPTION
## Summary
- add route-hop coverage for Inventory and Wishlist inline collection create into the Collections manager
- fix the Wishlist inline-create path so it does not overwrite the newly created collection with a stale second save

## Validation
- `./scripts/build-cabinet.ps1`
- `npx.cmd eslint ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts ui.web/src/features/tasks/index.tsx`
- `npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts`
- `git diff --check`