### PR TITLE
#581 feat(inventory): add photo reorder and rebuild controls

### DIFF
--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
@@ -7,6 +7,18 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
   }
 
+  function photoRowNames() {
+    return cy.get('[data-testid="inventory-photo-row"]').then(($rows) =>
+      $rows
+        .map((_, row) => {
+          const filename =
+            row.querySelector('span')?.textContent?.trim() ?? ''
+          return filename
+        })
+        .get()
+    )
+  }
+
   it('UI-SCREEN-INVENTORY-PHOTOS-001 supports upload + primary + delete lifecycle', () => {
     let listCall = 0
     cy.intercept('GET', '/api/items', {
@@ -165,15 +177,12 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
 
     cy.contains('td', 'PN-PHOTO-B').closest('tr').click()
     cy.wait('@itemBPhotos')
-
     cy.get('[data-testid="collection-selected-item"]').should('contain', 'PN-PHOTO-B')
-    cy.contains('[data-testid="inventory-photo-row"]', 'item-b.jpg').should('be.visible')
-    cy.contains('[data-testid="inventory-photo-row"]', 'item-a.jpg').should('not.exist')
+    photoRowNames().should('deep.equal', ['item-b.jpg'])
 
     cy.wait('@itemAPhotos')
     cy.get('[data-testid="collection-selected-item"]').should('contain', 'PN-PHOTO-B')
-    cy.contains('[data-testid="inventory-photo-row"]', 'item-b.jpg').should('be.visible')
-    cy.contains('[data-testid="inventory-photo-row"]', 'item-a.jpg').should('not.exist')
+    photoRowNames().should('deep.equal', ['item-b.jpg'])
   })
 
   it('PHOTOS-MEDIA-006 reloads the selected item photo state without losing the primary badge', () => {
@@ -234,5 +243,133 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     cy.contains('[data-testid="inventory-photo-row"]', 'reload-one.jpg')
       .find('[data-testid="inventory-photo-primary-badge"]')
       .should('not.exist')
+  })
+
+  it('PHOTOS-MEDIA-007 reorders item photos and keeps the new order after refresh', () => {
+    const photos = [
+      { id: 'order-p1', filename: 'order-one.jpg', is_primary: true },
+      { id: 'order-p2', filename: 'order-two.jpg', is_primary: false },
+      { id: 'order-p3', filename: 'order-three.jpg', is_primary: false },
+    ]
+
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-photo-order',
+            part_number: 'PN-PHOTO-ORDER',
+            title: 'Ordered Photo Item',
+            status: 'active',
+            category: 'Cars',
+          },
+        ],
+      },
+    }).as('items')
+    cy.intercept('GET', '/api/items/item-photo-order/photos', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: { photos },
+      })
+    }).as('orderedPhotos')
+    cy.intercept('POST', '/api/items/item-photo-order/photos/reorder', (req) => {
+      expect(req.body).to.deep.equal({
+        photo_ids: ['order-p2', 'order-p1', 'order-p3'],
+      })
+      photos.splice(
+        0,
+        photos.length,
+        { id: 'order-p2', filename: 'order-two.jpg', is_primary: false },
+        { id: 'order-p1', filename: 'order-one.jpg', is_primary: true },
+        { id: 'order-p3', filename: 'order-three.jpg', is_primary: false }
+      )
+      req.reply({
+        statusCode: 200,
+        body: { ok: true },
+      })
+    }).as('reorderPhotos')
+
+    signIn()
+    cy.wait('@items')
+    cy.wait('@orderedPhotos')
+
+    photoRowNames().should('deep.equal', [
+      'order-one.jpg',
+      'order-two.jpg',
+      'order-three.jpg',
+    ])
+
+    cy.contains('[data-testid="inventory-photo-row"]', 'order-two.jpg')
+      .find('[data-testid="inventory-photo-move-up"]')
+      .click()
+    cy.wait('@reorderPhotos')
+    cy.wait('@orderedPhotos')
+
+    photoRowNames().should('deep.equal', [
+      'order-two.jpg',
+      'order-one.jpg',
+      'order-three.jpg',
+    ])
+
+    cy.reload()
+    cy.wait('@items')
+    cy.wait('@orderedPhotos')
+    photoRowNames().should('deep.equal', [
+      'order-two.jpg',
+      'order-one.jpg',
+      'order-three.jpg',
+    ])
+  })
+
+  it('PHOTOS-MEDIA-008 rebuilds photo derivatives with retry-safe feedback', () => {
+    let rebuildAttempts = 0
+
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-photo-rebuild',
+            part_number: 'PN-PHOTO-REBUILD',
+            title: 'Rebuild Photo Item',
+            status: 'active',
+            category: 'Cars',
+          },
+        ],
+      },
+    }).as('items')
+    cy.intercept('GET', '/api/items/item-photo-rebuild/photos', {
+      statusCode: 200,
+      body: {
+        photos: [{ id: 'rebuild-p1', filename: 'rebuild-one.jpg', is_primary: true }],
+      },
+    }).as('rebuildPhotos')
+    cy.intercept('POST', '/api/items/item-photo-rebuild/photos-rebuild', (req) => {
+      rebuildAttempts += 1
+      if (rebuildAttempts === 1) {
+        req.reply({
+          statusCode: 500,
+          body: { error: 'failed_to_rebuild_thumbnails' },
+        })
+        return
+      }
+      req.reply({
+        statusCode: 200,
+        body: { ok: true },
+      })
+    }).as('rebuildRequest')
+
+    signIn()
+    cy.wait('@items')
+    cy.wait('@rebuildPhotos')
+
+    cy.get('[data-testid="inventory-photo-rebuild"]').click()
+    cy.wait('@rebuildRequest')
+    cy.get('[data-testid="inventory-photo-rebuild-error"]').should('be.visible')
+    cy.get('[data-testid="inventory-photo-rebuild-retry"]').click()
+    cy.wait('@rebuildRequest')
+    cy.wait('@rebuildPhotos')
+    cy.get('[data-testid="inventory-photo-rebuild-success"]').should('be.visible')
+    cy.contains('[data-testid="inventory-photo-row"]', 'rebuild-one.jpg').should('be.visible')
   })
 })

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -739,6 +739,8 @@ export function Collection({
   const [photosLoading, setPhotosLoading] = useState(false)
   const [photosError, setPhotosError] = useState<string | null>(null)
   const [photosBusy, setPhotosBusy] = useState(false)
+  const [photoRebuildError, setPhotoRebuildError] = useState<string | null>(null)
+  const [photoRebuildSuccess, setPhotoRebuildSuccess] = useState<string | null>(null)
   const [cameraError, setCameraError] = useState<string | null>(null)
   const [cameraSuccess, setCameraSuccess] = useState<string | null>(null)
   const [activeProfileID, setActiveProfileID] = useState('')
@@ -780,6 +782,7 @@ export function Collection({
   )
   const aiApplyTriggerRef = useRef<HTMLButtonElement | null>(null)
   const inventoryPhotoRequestIDRef = useRef(0)
+  const selectedItemIDRef = useRef('')
   const {
     workspaceCollections,
     activeWorkspaceCollection,
@@ -791,6 +794,10 @@ export function Collection({
     setSelectedItemID(item?.id ?? '')
     setSelectedItemLabel(item ? item.part_number || item.id : '')
   }, [])
+
+  useEffect(() => {
+    selectedItemIDRef.current = selectedItemID
+  }, [selectedItemID])
 
   const startCreateItem = useCallback(() => {
     setItemEditorMode('create')
@@ -853,7 +860,7 @@ export function Collection({
         items.find(
           (item) =>
             item.id ===
-            (preferredSelectedItemID?.trim() || selectedItemID.trim())
+            (preferredSelectedItemID?.trim() || selectedItemIDRef.current.trim())
         ) ?? items[0] ?? null
       setInventoryItems(items)
       setTableData(mapped)
@@ -868,7 +875,7 @@ export function Collection({
     } finally {
       setLoading(false)
     }
-  }, [routePath, selectInventoryItem, selectedItemID])
+  }, [routePath, selectInventoryItem])
 
   useEffect(() => {
     void loadInventoryItems()
@@ -1587,6 +1594,11 @@ export function Collection({
   }, [selectedItemID])
 
   useEffect(() => {
+    setPhotoRebuildError(null)
+    setPhotoRebuildSuccess(null)
+  }, [selectedItemID])
+
+  useEffect(() => {
     if (
       selectedPhotoIndex !== null &&
       (selectedPhotoIndex < 0 || selectedPhotoIndex >= inventoryPhotos.length)
@@ -1829,6 +1841,79 @@ export function Collection({
     },
     [loadInventoryPhotos, selectedItemID]
   )
+
+  const handleReorderPhotos = useCallback(
+    async (photoID: string, direction: 'up' | 'down') => {
+      if (!selectedItemID || !photoID) {
+        return
+      }
+      const currentIndex = inventoryPhotos.findIndex((photo) => photo.id === photoID)
+      if (currentIndex < 0) {
+        return
+      }
+      const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
+      if (targetIndex < 0 || targetIndex >= inventoryPhotos.length) {
+        return
+      }
+
+      const reordered = [...inventoryPhotos]
+      const [moved] = reordered.splice(currentIndex, 1)
+      reordered.splice(targetIndex, 0, moved)
+
+      setPhotosBusy(true)
+      setPhotosError(null)
+      try {
+        const response = await fetch(
+          `/api/items/${encodeURIComponent(selectedItemID)}/photos/reorder`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              photo_ids: reordered.map((photo) => photo.id),
+            }),
+          }
+        )
+        if (!response.ok) {
+          throw new Error(`reorder_photos_${response.status}`)
+        }
+        await loadInventoryPhotos()
+      } catch {
+        setPhotosError('Unable to reorder photos right now. Retry this action.')
+      } finally {
+        setPhotosBusy(false)
+      }
+    },
+    [inventoryPhotos, loadInventoryPhotos, selectedItemID]
+  )
+
+  const handleRebuildPhotos = useCallback(async () => {
+    if (!selectedItemID) {
+      return
+    }
+    setPhotosBusy(true)
+    setPhotosError(null)
+    setPhotoRebuildError(null)
+    setPhotoRebuildSuccess(null)
+    try {
+      const response = await fetch(
+        `/api/items/${encodeURIComponent(selectedItemID)}/photos-rebuild`,
+        {
+          method: 'POST',
+        }
+      )
+      if (!response.ok) {
+        throw new Error(`rebuild_photos_${response.status}`)
+      }
+      setPhotoRebuildSuccess('Photo previews rebuilt successfully.')
+      await loadInventoryPhotos()
+    } catch {
+      setPhotoRebuildError(
+        'Unable to rebuild photo previews right now. Retry this action.'
+      )
+    } finally {
+      setPhotosBusy(false)
+    }
+  }, [loadInventoryPhotos, selectedItemID])
 
   const handleTakePhoto = useCallback(async () => {
     setCameraError(null)
@@ -2675,6 +2760,15 @@ export function Collection({
                           event.currentTarget.value = ''
                         }}
                       />
+                      <Button
+                        type='button'
+                        variant='outline'
+                        data-testid='inventory-photo-rebuild'
+                        onClick={() => void handleRebuildPhotos()}
+                        disabled={photosBusy || selectedItemID === ''}
+                      >
+                        Rebuild Photos
+                      </Button>
                       {photosBusy ? (
                         <span className='text-xs text-muted-foreground'>Working...</span>
                       ) : null}
@@ -2693,6 +2787,32 @@ export function Collection({
                         data-testid='inventory-camera-success'
                       >
                         {cameraSuccess}
+                      </div>
+                    ) : null}
+                    {photoRebuildError ? (
+                      <div
+                        className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
+                        data-testid='inventory-photo-rebuild-error'
+                      >
+                        <p className='font-medium'>Photo rebuild failed.</p>
+                        <p className='mt-1 text-muted-foreground'>{photoRebuildError}</p>
+                        <Button
+                          className='mt-3'
+                          size='sm'
+                          variant='outline'
+                          data-testid='inventory-photo-rebuild-retry'
+                          onClick={() => void handleRebuildPhotos()}
+                        >
+                          Retry
+                        </Button>
+                      </div>
+                    ) : null}
+                    {photoRebuildSuccess ? (
+                      <div
+                        className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-2 text-sm'
+                        data-testid='inventory-photo-rebuild-success'
+                      >
+                        {photoRebuildSuccess}
                       </div>
                     ) : null}
                     {photosLoading ? (
@@ -2751,7 +2871,7 @@ export function Collection({
                           ))}
                         </div>
                         <div className='space-y-2'>
-                          {inventoryPhotos.map((photo) => (
+                          {inventoryPhotos.map((photo, index) => (
                             <div
                               key={`row-${photo.id}`}
                               className='flex flex-wrap items-center justify-between gap-2 rounded-md border p-2'
@@ -2769,6 +2889,26 @@ export function Collection({
                                 ) : null}
                               </div>
                               <div className='flex gap-2'>
+                                <Button
+                                  size='sm'
+                                  variant='outline'
+                                  data-testid='inventory-photo-move-up'
+                                  onClick={() => void handleReorderPhotos(photo.id, 'up')}
+                                  disabled={photosBusy || index === 0}
+                                >
+                                  Move Up
+                                </Button>
+                                <Button
+                                  size='sm'
+                                  variant='outline'
+                                  data-testid='inventory-photo-move-down'
+                                  onClick={() => void handleReorderPhotos(photo.id, 'down')}
+                                  disabled={
+                                    photosBusy || index === inventoryPhotos.length - 1
+                                  }
+                                >
+                                  Move Down
+                                </Button>
                                 <Button
                                   size='sm'
                                   variant='outline'


### PR DESCRIPTION
## Summary
- add API-backed photo reorder controls and rebuild feedback in the inventory photo section
- stabilize selected-item photo scoping by removing the selection-triggered item reload loop
- extend inventory photo Cypress coverage for reorder persistence and rebuild retry behavior

## Validation
- ./scripts/build-cabinet.ps1
- npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
- npx.cmd eslint cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts src/features/collection/index.tsx
- git diff --check