### PR TITLE
#585 feat(settings): add storage repair controls

### DIFF
--- a/internal/app/profile_api_test.go
+++ b/internal/app/profile_api_test.go
@@ -129,4 +129,16 @@ func TestStorageMaintenanceEndpoints(t *testing.T) {
 	if rebuildPayload["rebuilt_items"].(float64) < 1 || rebuildPayload["rebuilt_photos"].(float64) < 1 {
 		t.Fatalf("expected rebuilt item/photo counts, got %+v", rebuildPayload)
 	}
+
+	repair := doRequest(t, a, http.MethodPost, "/api/data/repair", strings.NewReader(`{}`), map[string]string{"Content-Type": "application/json"})
+	if repair.Code != http.StatusOK {
+		t.Fatalf("repair status=%d body=%s", repair.Code, repair.Body.String())
+	}
+	var repairPayload map[string]any
+	if err := json.NewDecoder(repair.Body).Decode(&repairPayload); err != nil {
+		t.Fatalf("decode repair response: %v", err)
+	}
+	if strings.TrimSpace(repairPayload["integrity_check"].(string)) == "" {
+		t.Fatalf("expected integrity check result, got %+v", repairPayload)
+	}
 }

--- a/ui.web/cypress/e2e/settings/storage/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/storage/spec.cy.ts
@@ -254,4 +254,77 @@ describe('settings/storage', () => {
     )
     cy.get('[data-testid="settings-storage-restore-confirm"]').should('not.exist')
   })
+
+  it('UI-SCREEN-SETTINGS-STORAGE-009 runs storage integrity check and shows healthy result', () => {
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: { id: 'default' },
+    }).as('activeProfile')
+    cy.intercept('GET', '/api/profiles/*/storage', {
+      statusCode: 200,
+      body: {
+        db_path: 'C:/cabinet/profiles/default/cabinet.db',
+        media_dir: 'C:/cabinet/profiles/default/media',
+      },
+    }).as('storageInfo')
+    cy.intercept('GET', '/api/backup/list', {
+      statusCode: 200,
+      body: { backups: [] },
+    }).as('backupList')
+    cy.intercept('POST', '/api/data/repair', {
+      statusCode: 200,
+      body: { integrity_check: 'ok' },
+    }).as('repairCheck')
+
+    signInToStorage()
+    cy.wait('@activeProfile')
+    cy.wait('@storageInfo')
+    cy.wait('@backupList')
+
+    cy.get('[data-testid="settings-storage-repair-run"]').click()
+    cy.wait('@repairCheck')
+    cy.get('[data-testid="settings-storage-repair-result"]').should(
+      'contain',
+      'Database integrity check passed.'
+    )
+    cy.get('[data-testid="settings-storage-repair-result"]').should(
+      'contain',
+      'ok'
+    )
+  })
+
+  it('UI-SCREEN-SETTINGS-STORAGE-010 reports integrity-check failure without route reload', () => {
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: { id: 'default' },
+    }).as('activeProfile')
+    cy.intercept('GET', '/api/profiles/*/storage', {
+      statusCode: 200,
+      body: {
+        db_path: 'C:/cabinet/profiles/default/cabinet.db',
+        media_dir: 'C:/cabinet/profiles/default/media',
+      },
+    }).as('storageInfo')
+    cy.intercept('GET', '/api/backup/list', {
+      statusCode: 200,
+      body: { backups: [] },
+    }).as('backupList')
+    cy.intercept('POST', '/api/data/repair', {
+      statusCode: 500,
+      body: { error: 'failed_to_repair_check' },
+    }).as('repairCheck')
+
+    signInToStorage()
+    cy.wait('@activeProfile')
+    cy.wait('@storageInfo')
+    cy.wait('@backupList')
+
+    cy.get('[data-testid="settings-storage-repair-run"]').click()
+    cy.wait('@repairCheck')
+    cy.location('pathname').should('match', /^\/settings\/storage\/?$/)
+    cy.get('[data-testid="settings-storage-repair-result"]').should(
+      'contain',
+      'Database integrity check failed.'
+    )
+  })
 })

--- a/ui.web/src/features/settings/storage/index.tsx
+++ b/ui.web/src/features/settings/storage/index.tsx
@@ -35,6 +35,9 @@ export function SettingsStorage() {
   const [mediaDir, setMediaDir] = useState('')
   const [reindexPending, setReindexPending] = useState(false)
   const [rebuildPending, setRebuildPending] = useState(false)
+  const [repairPending, setRepairPending] = useState(false)
+  const [repairResult, setRepairResult] = useState<string | null>(null)
+  const [repairTone, setRepairTone] = useState<'default' | 'destructive'>('default')
   const [backupList, setBackupList] = useState<string[]>([])
   const [backupsLoading, setBackupsLoading] = useState(true)
   const [backupPending, setBackupPending] = useState(false)
@@ -179,6 +182,32 @@ export function SettingsStorage() {
     }
   }, [])
 
+  const runRepair = useCallback(async () => {
+    setRepairPending(true)
+    setRepairResult(null)
+    setRepairTone('default')
+    try {
+      const response = await fetch('/api/data/repair', { method: 'POST' })
+      if (!response.ok) {
+        throw new Error('failed_to_repair_check')
+      }
+      const payload = (await response.json()) as {
+        integrity_check?: string
+      }
+      const integrityCheck = payload.integrity_check?.trim() || 'unknown'
+      if (integrityCheck.toLowerCase() === 'ok') {
+        setRepairResult(`Database integrity check passed. Result: ${integrityCheck}`)
+      } else {
+        setRepairResult(`Database integrity check reported issues. Result: ${integrityCheck}`)
+      }
+    } catch {
+      setRepairTone('destructive')
+      setRepairResult('Database integrity check failed. Check diagnostics and try again.')
+    } finally {
+      setRepairPending(false)
+    }
+  }, [])
+
   const runBackup = useCallback(async () => {
     setBackupPending(true)
     setActionStatus(null)
@@ -233,6 +262,7 @@ export function SettingsStorage() {
     Boolean(error) ||
     reindexPending ||
     rebuildPending ||
+    repairPending ||
     backupPending ||
     restorePending
 
@@ -283,6 +313,33 @@ export function SettingsStorage() {
                 Storage repair and migration actions are restricted to diagnostics workflows.
               </p>
             </div>
+          </div>
+          <div className='rounded-md border p-3 space-y-3'>
+            <div className='flex items-start justify-between gap-3'>
+              <div>
+                <p className='font-medium'>Database integrity</p>
+                <p className='text-xs text-muted-foreground'>
+                  Run an integrity check before deeper diagnostics or restore workflows.
+                </p>
+              </div>
+              <Button
+                variant='outline'
+                size='sm'
+                data-testid='settings-storage-repair-run'
+                disabled={actionsDisabled}
+                onClick={() => {
+                  void runRepair()
+                }}
+              >
+                {repairPending ? 'Running Integrity Check…' : 'Run Integrity Check'}
+              </Button>
+            </div>
+            <p
+              data-testid='settings-storage-repair-result'
+              className={repairTone === 'destructive' ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}
+            >
+              {repairResult ?? 'No integrity check has been run yet.'}
+            </p>
           </div>
           <div className='flex gap-2'>
             <Button


### PR DESCRIPTION
## Summary
- add Settings Storage integrity-check visibility and repair controls
- surface deterministic integrity-check success and failure feedback in the storage screen
- extend storage maintenance coverage in API and Cypress tests

## Validation
- go test ./internal/app -run TestStorageMaintenanceEndpoints -count=1
- ./scripts/build-cabinet.ps1
- npx.cmd eslint cypress/e2e/settings/storage/spec.cy.ts src/features/settings/storage/index.tsx
- Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue; npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/settings/storage/spec.cy.ts
- git diff --check