### PR TITLE
#587 feat(settings): add runtime operations visibility

### DIFF
--- a/ui.web/cypress/e2e/settings/operations/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/operations/spec.cy.ts
@@ -1,0 +1,123 @@
+describe('settings/operations', () => {
+  function signInToOperations() {
+    cy.visit('/sign-in?redirect=%2Fsettings%2Foperations')
+    cy.get('input[name="email"]').clear().type('e2e-settings@example.com')
+    cy.get('input[name="password"]').clear().type('password123')
+    cy.contains('button', 'Sign in').click()
+    cy.location('pathname', { timeout: 15000 }).should(
+      'match',
+      /^\/settings\/operations\/?$/
+    )
+  }
+
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+  })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-001 renders runtime metadata and recovery visibility', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-test123',
+        build_date: '2026-04-22',
+        bind_mode: 'lan',
+        runtime_host: '192.168.1.53',
+        runtime_port: 17882,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: true,
+      },
+    }).as('runtimeRecovery')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-runtime-card"]').should(
+      'contain',
+      'rev-test123'
+    )
+    cy.get('[data-testid="settings-operations-runtime-card"]').should(
+      'contain',
+      '192.168.1.53:17882'
+    )
+    cy.get('[data-testid="settings-operations-runtime-card"]').should(
+      'contain',
+      'lan'
+    )
+    cy.get('[data-testid="settings-operations-runtime-card"]').should(
+      'contain',
+      'stable'
+    )
+    cy.get('[data-testid="settings-operations-recovery-card"]').should(
+      'contain',
+      'Recovery required'
+    )
+  })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-002 retries runtime visibility without route reload', () => {
+    let runtimeAttempt = 0
+    let recoveryAttempt = 0
+
+    cy.intercept('GET', '/api/runtime', (req) => {
+      runtimeAttempt += 1
+      if (runtimeAttempt === 1) {
+        req.reply(503, { error: 'runtime_unavailable' })
+        return
+      }
+      req.reply({
+        statusCode: 200,
+        body: {
+          app_version: 'rev-recovered',
+          build_date: '2026-04-22',
+          bind_mode: 'loopback',
+          runtime_host: '127.0.0.1',
+          runtime_port: 17880,
+          update_channel: 'stable',
+          update_public_key_configured: false,
+        },
+      })
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', (req) => {
+      recoveryAttempt += 1
+      if (recoveryAttempt === 1) {
+        req.reply(503, { error: 'runtime_recovery_unavailable' })
+        return
+      }
+      req.reply({
+        statusCode: 200,
+        body: {
+          recovery_required: false,
+        },
+      })
+    }).as('runtimeRecovery')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+    cy.get('[data-testid="settings-operations-runtime-error"]').should(
+      'contain',
+      'Runtime information is unavailable right now.'
+    )
+
+    cy.get('[data-testid="settings-operations-retry"]').click()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-runtime-error"]').should('not.exist')
+    cy.get('[data-testid="settings-operations-runtime-card"]').should(
+      'contain',
+      'rev-recovered'
+    )
+    cy.get('[data-testid="settings-operations-recovery-card"]').should(
+      'contain',
+      'No recovery required'
+    )
+  })
+})

--- a/ui.web/src/features/settings/operations/index.tsx
+++ b/ui.web/src/features/settings/operations/index.tsx
@@ -1,9 +1,63 @@
-import { Button } from '@/components/ui/button'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ContentSection } from '../components/content-section'
+import { Button } from '@/components/ui/button'
+
+type RuntimeResponse = {
+  app_version?: string
+  build_date?: string
+  bind_mode?: string
+  runtime_host?: string
+  runtime_port?: number
+  update_channel?: string
+  update_public_key_configured?: boolean
+}
+
+type RuntimeRecoveryResponse = {
+  recovery_required?: boolean
+}
 
 export function SettingsOperations() {
   const { t } = useTranslation('pages')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [runtimeInfo, setRuntimeInfo] = useState<RuntimeResponse | null>(null)
+  const [recoveryInfo, setRecoveryInfo] = useState<RuntimeRecoveryResponse | null>(null)
+
+  const loadOperations = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [runtimeResp, recoveryResp] = await Promise.all([
+        fetch('/api/runtime'),
+        fetch('/api/runtime/recovery'),
+      ])
+      if (!runtimeResp.ok || !recoveryResp.ok) {
+        throw new Error('runtime_operations_unavailable')
+      }
+      const runtimePayload = (await runtimeResp.json()) as RuntimeResponse
+      const recoveryPayload = (await recoveryResp.json()) as RuntimeRecoveryResponse
+      setRuntimeInfo(runtimePayload)
+      setRecoveryInfo(recoveryPayload)
+    } catch {
+      setRuntimeInfo(null)
+      setRecoveryInfo(null)
+      setError('Runtime information is unavailable right now.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadOperations()
+  }, [loadOperations])
+
+  const runtimeAddress = runtimeInfo
+    ? `${runtimeInfo.runtime_host?.trim() || '127.0.0.1'}:${runtimeInfo.runtime_port ?? 17880}`
+    : 'Unavailable'
+  const updateKeyStatus = runtimeInfo?.update_public_key_configured
+    ? 'Configured'
+    : 'Missing'
 
   return (
     <ContentSection
@@ -11,25 +65,79 @@ export function SettingsOperations() {
       desc={t('settings.operations.description')}
     >
       <div className='space-y-4 text-sm'>
-        <div className='rounded-md border p-3'>
-          <p className='font-medium'>Maintenance Window</p>
+        {error ? (
+          <div
+            className='rounded-md border border-destructive/50 bg-destructive/10 p-3 text-destructive'
+            data-testid='settings-operations-runtime-error'
+          >
+            <p className='font-medium'>{error}</p>
+            <p className='mt-1 text-xs text-muted-foreground'>
+              Check runtime health and retry without leaving the Operations screen.
+            </p>
+          </div>
+        ) : null}
+
+        <div
+          className='rounded-md border p-3 space-y-2'
+          data-testid='settings-operations-runtime-card'
+        >
+          <div className='flex items-start justify-between gap-3'>
+            <div>
+              <p className='font-medium'>Runtime</p>
+              <p className='text-muted-foreground'>
+                Live runtime version, bind mode, and update channel for this lane.
+              </p>
+            </div>
+            <Button
+              variant='outline'
+              size='sm'
+              data-testid='settings-operations-retry'
+              disabled={loading}
+              onClick={() => {
+                void loadOperations()
+              }}
+            >
+              {loading ? 'Refreshing…' : 'Refresh'}
+            </Button>
+          </div>
+          <p>Version: {loading ? 'Loading runtime...' : runtimeInfo?.app_version || 'Unavailable'}</p>
+          <p>Build date: {loading ? 'Loading runtime...' : runtimeInfo?.build_date || 'Unavailable'}</p>
+          <p>Address: {loading ? 'Loading runtime...' : runtimeAddress}</p>
+          <p>Bind mode: {loading ? 'Loading runtime...' : runtimeInfo?.bind_mode || 'Unavailable'}</p>
+          <p>Update channel: {loading ? 'Loading runtime...' : runtimeInfo?.update_channel || 'Unavailable'}</p>
+          <p>Update signing key: {loading ? 'Loading runtime...' : updateKeyStatus}</p>
+        </div>
+
+        <div
+          className='rounded-md border p-3 space-y-2'
+          data-testid='settings-operations-recovery-card'
+        >
+          <p className='font-medium'>Recovery state</p>
           <p className='text-muted-foreground'>
-            Schedule maintenance tasks and control service-impacting operations.
+            Surface whether the last runtime shutdown requires recovery attention.
+          </p>
+          <p>
+            {loading
+              ? 'Loading recovery state...'
+              : recoveryInfo?.recovery_required
+                ? 'Recovery required'
+                : 'No recovery required'}
           </p>
         </div>
+
         <div className='rounded-md border p-3'>
           <p className='font-medium'>Queue Controls</p>
           <p className='text-muted-foreground'>
             Pause and resume Market Watch and enrichment workers for active profile context.
           </p>
-        </div>
-        <div className='flex gap-2'>
-          <Button variant='outline' size='sm' disabled>
-            Pause Workers (Coming soon)
-          </Button>
-          <Button variant='outline' size='sm' disabled>
-            Resume Workers (Coming soon)
-          </Button>
+          <div className='mt-3 flex gap-2'>
+            <Button variant='outline' size='sm' disabled>
+              Pause Workers (Coming soon)
+            </Button>
+            <Button variant='outline' size='sm' disabled>
+              Resume Workers (Coming soon)
+            </Button>
+          </div>
         </div>
       </div>
     </ContentSection>


### PR DESCRIPTION
## Summary
- replace the placeholder Settings Operations screen with live runtime metadata and recovery visibility
- add retry handling for runtime and recovery fetch failures without leaving the route
- add focused Cypress coverage for runtime and recovery operations visibility

## Validation
- ./scripts/build-cabinet.ps1
- npx.cmd eslint cypress/e2e/settings/operations/spec.cy.ts src/features/settings/operations/index.tsx
- Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue; npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/settings/operations/spec.cy.ts
- git diff --check