### PR TITLE
#589 feat(settings): add data import export controls

### DIFF
--- a/ui.web/cypress/e2e/settings/operations/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/operations/spec.cy.ts
@@ -120,4 +120,132 @@ describe('settings/operations', () => {
       'No recovery required'
     )
   })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-003 exports snapshot data and shows dry-run conflicts', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-export',
+        build_date: '2026-04-22',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: false,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('GET', '/api/data/export/json', {
+      statusCode: 200,
+      body: {
+        schema_version: 1,
+        exported_at: '2026-04-22T12:00:00Z',
+        items: [
+          {
+            brand: 'AFX',
+            category: 'Slot',
+            part_number: 'OPS-001',
+            title: 'Exported Item',
+            instances: [],
+          },
+        ],
+      },
+    }).as('exportJson')
+    cy.intercept('POST', '/api/data/import/json/dry-run', {
+      statusCode: 200,
+      body: {
+        total_items: 2,
+        new_items: 1,
+        conflicts: 1,
+        conflict_details: [
+          {
+            part_number: 'OPS-001',
+            existing_id: 'item-1',
+          },
+        ],
+      },
+    }).as('importDryRun')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-export-json"]').click()
+    cy.wait('@exportJson')
+    cy.get('[data-testid="settings-operations-data-status"]').should(
+      'contain',
+      'Exported 1 item snapshot.'
+    )
+
+    cy.get('[data-testid="settings-operations-import-json-input"]')
+      .clear()
+      .type(
+        '{"snapshot":{"schema_version":1,"items":[{"brand":"AFX","category":"Slot","part_number":"OPS-001","title":"Conflict"},{"brand":"AFX","category":"Slot","part_number":"OPS-NEW","title":"New Item"}]}}',
+        { parseSpecialCharSequences: false }
+      )
+    cy.get('[data-testid="settings-operations-import-json-dry-run"]').click()
+    cy.wait('@importDryRun')
+    cy.get('[data-testid="settings-operations-import-summary"]').should(
+      'contain',
+      '2 items'
+    )
+    cy.get('[data-testid="settings-operations-import-summary"]').should(
+      'contain',
+      '1 conflict'
+    )
+    cy.get('[data-testid="settings-operations-import-summary"]').should(
+      'contain',
+      'OPS-001'
+    )
+  })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-004 reports dry-run failure without route reload', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-import-error',
+        build_date: '2026-04-22',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: false,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('POST', '/api/data/import/json/dry-run', {
+      statusCode: 400,
+      body: {
+        error: 'failed_to_dry_run_import',
+      },
+    }).as('importDryRun')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-import-json-input"]')
+      .clear()
+      .type(
+        '{"snapshot":{"schema_version":1,"items":[{"brand":"AFX","category":"Slot","part_number":"OPS-ERR","title":"Broken"}]}}',
+        { parseSpecialCharSequences: false }
+      )
+    cy.get('[data-testid="settings-operations-import-json-dry-run"]').click()
+    cy.wait('@importDryRun')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-data-status"]').should(
+      'contain',
+      'Import dry-run failed.'
+    )
+  })
 })

--- a/ui.web/src/features/settings/operations/index.tsx
+++ b/ui.web/src/features/settings/operations/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ContentSection } from '../components/content-section'
 import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
 
 type RuntimeResponse = {
   app_version?: string
@@ -17,12 +18,42 @@ type RuntimeRecoveryResponse = {
   recovery_required?: boolean
 }
 
+type ExportSnapshotResponse = {
+  schema_version?: number
+  exported_at?: string
+  items?: Array<{
+    part_number?: string
+    title?: string
+  }>
+}
+
+type ImportConflictDetail = {
+  part_number?: string
+  existing_id?: string
+}
+
+type ImportDryRunSummaryResponse = {
+  total_items?: number
+  new_items?: number
+  conflicts?: number
+  conflict_details?: ImportConflictDetail[]
+}
+
 export function SettingsOperations() {
   const { t } = useTranslation('pages')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [runtimeInfo, setRuntimeInfo] = useState<RuntimeResponse | null>(null)
   const [recoveryInfo, setRecoveryInfo] = useState<RuntimeRecoveryResponse | null>(null)
+  const [dataStatus, setDataStatus] = useState<string>('No import or export action has run yet.')
+  const [dataTone, setDataTone] = useState<'default' | 'destructive'>('default')
+  const [exportPending, setExportPending] = useState(false)
+  const [importDryRunPending, setImportDryRunPending] = useState(false)
+  const [importJsonInput, setImportJsonInput] = useState(
+    '{\n  "snapshot": {\n    "schema_version": 1,\n    "items": []\n  }\n}'
+  )
+  const [lastExportSummary, setLastExportSummary] = useState<ExportSnapshotResponse | null>(null)
+  const [importSummary, setImportSummary] = useState<ImportDryRunSummaryResponse | null>(null)
 
   const loadOperations = useCallback(async () => {
     setLoading(true)
@@ -51,6 +82,67 @@ export function SettingsOperations() {
   useEffect(() => {
     void loadOperations()
   }, [loadOperations])
+
+  const runExportJson = useCallback(async () => {
+    setExportPending(true)
+    setDataTone('default')
+    try {
+      const response = await fetch('/api/data/export/json')
+      if (!response.ok) {
+        throw new Error('failed_to_export_json')
+      }
+      const payload = (await response.json()) as ExportSnapshotResponse
+      const itemCount = Array.isArray(payload.items) ? payload.items.length : 0
+      setLastExportSummary(payload)
+      setDataStatus(`Exported ${itemCount} item snapshot${itemCount === 1 ? '' : 's'}.`)
+    } catch {
+      setLastExportSummary(null)
+      setDataTone('destructive')
+      setDataStatus('Export failed. Retry when runtime data services are healthy.')
+    } finally {
+      setExportPending(false)
+    }
+  }, [])
+
+  const runImportJsonDryRun = useCallback(async () => {
+    setImportDryRunPending(true)
+    setImportSummary(null)
+    setDataTone('default')
+    try {
+      const parsed = JSON.parse(importJsonInput) as {
+        snapshot?: {
+          schema_version?: number
+          items?: unknown[]
+        }
+        schema_version?: number
+        items?: unknown[]
+      }
+      const body =
+        parsed && typeof parsed === 'object' && parsed.snapshot
+          ? parsed
+          : { snapshot: parsed }
+      const response = await fetch('/api/data/import/json/dry-run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        throw new Error('failed_to_dry_run_import')
+      }
+      const payload = (await response.json()) as ImportDryRunSummaryResponse
+      setImportSummary(payload)
+      const conflictCount = Number(payload.conflicts ?? 0)
+      setDataStatus(
+        `Import dry-run completed with ${conflictCount} conflict${conflictCount === 1 ? '' : 's'}.`
+      )
+    } catch {
+      setImportSummary(null)
+      setDataTone('destructive')
+      setDataStatus('Import dry-run failed.')
+    } finally {
+      setImportDryRunPending(false)
+    }
+  }, [importJsonInput])
 
   const runtimeAddress = runtimeInfo
     ? `${runtimeInfo.runtime_host?.trim() || '127.0.0.1'}:${runtimeInfo.runtime_port ?? 17880}`
@@ -121,8 +213,112 @@ export function SettingsOperations() {
               ? 'Loading recovery state...'
               : recoveryInfo?.recovery_required
                 ? 'Recovery required'
-                : 'No recovery required'}
+              : 'No recovery required'}
           </p>
+        </div>
+
+        <div
+          className='rounded-md border p-3 space-y-3'
+          data-testid='settings-operations-data-card'
+        >
+          <div className='flex flex-wrap items-start justify-between gap-3'>
+            <div>
+              <p className='font-medium'>Data import and export</p>
+              <p className='text-muted-foreground'>
+                Export a JSON snapshot and dry-run a JSON import before applying any workspace changes.
+              </p>
+            </div>
+            <Button
+              variant='outline'
+              size='sm'
+              data-testid='settings-operations-export-json'
+              disabled={loading || Boolean(error) || exportPending || importDryRunPending}
+              onClick={() => {
+                void runExportJson()
+              }}
+            >
+              {exportPending ? 'Exporting…' : 'Export JSON'}
+            </Button>
+          </div>
+
+          <p
+            data-testid='settings-operations-data-status'
+            className={dataTone === 'destructive' ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}
+          >
+            {dataStatus}
+          </p>
+
+          {lastExportSummary ? (
+            <div className='rounded-md border bg-muted/20 p-3 text-sm text-muted-foreground'>
+              <p>
+                Snapshot schema {lastExportSummary.schema_version ?? 1} with{' '}
+                {lastExportSummary.items?.length ?? 0} item
+                {(lastExportSummary.items?.length ?? 0) === 1 ? '' : 's'} exported at{' '}
+                {lastExportSummary.exported_at || 'unknown time'}.
+              </p>
+            </div>
+          ) : null}
+
+          <div className='space-y-2'>
+            <label
+              htmlFor='settings-operations-import-json-input'
+              className='text-sm font-medium'
+            >
+              JSON import dry-run
+            </label>
+            <Textarea
+              id='settings-operations-import-json-input'
+              data-testid='settings-operations-import-json-input'
+              value={importJsonInput}
+              onChange={(event) => {
+                setImportJsonInput(event.target.value)
+              }}
+              className='min-h-36 font-mono text-xs'
+              spellCheck={false}
+            />
+            <div className='flex justify-end'>
+              <Button
+                variant='outline'
+                size='sm'
+                data-testid='settings-operations-import-json-dry-run'
+                disabled={loading || Boolean(error) || exportPending || importDryRunPending}
+                onClick={() => {
+                  void runImportJsonDryRun()
+                }}
+              >
+                {importDryRunPending ? 'Running Dry-Run…' : 'Run Dry-Run'}
+              </Button>
+            </div>
+          </div>
+
+          <div
+            className='rounded-md border bg-muted/20 p-3 text-sm text-muted-foreground'
+            data-testid='settings-operations-import-summary'
+          >
+            {importSummary ? (
+              <div className='space-y-2'>
+                <p>
+                  {importSummary.total_items ?? 0} items, {importSummary.new_items ?? 0} new,{' '}
+                  {importSummary.conflicts ?? 0} conflict
+                  {(importSummary.conflicts ?? 0) === 1 ? '' : 's'}.
+                </p>
+                {importSummary.conflict_details?.length ? (
+                  <div className='space-y-1'>
+                    {importSummary.conflict_details.map((detail) => (
+                      <p key={`${detail.part_number || 'unknown'}-${detail.existing_id || 'missing'}`}>
+                        {detail.part_number || 'Unknown part'} already exists as{' '}
+                        {detail.existing_id || 'unknown item'}.
+                      </p>
+                    ))}
+                  </div>
+                ) : (
+                  <p>No conflicts detected.</p>
+                )}
+              </div>
+            ) : (
+              <p>No dry-run summary yet. Paste a snapshot and run a dry-run to review conflicts.</p>
+            )}
+          </div>
         </div>
 
         <div className='rounded-md border p-3'>


### PR DESCRIPTION
## Summary
- add Settings Operations controls for JSON snapshot export and JSON import dry-run
- surface deterministic import/export status and conflict summaries without route reload
- extend settings operations Cypress coverage for export success and dry-run failure handling

## Validation
- ./scripts/build-cabinet.ps1
- npm.cmd run build in ui.web
- npx.cmd eslint cypress/e2e/settings/operations/spec.cy.ts src/features/settings/operations/index.tsx
- Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue; npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/settings/operations/spec.cy.ts
- git diff --check