### PR TITLE
#597 feat(settings): support csv column mapping in operations

### DIFF
--- a/ui.web/cypress/e2e/settings/operations/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/operations/spec.cy.ts
@@ -652,4 +652,161 @@ describe('settings/operations', () => {
       'CSV import apply failed.'
     )
   })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-011 runs CSV dry-run with custom column mapping', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-csv-mapping',
+        build_date: '2026-04-22',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: false,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('POST', '/api/data/import/csv/dry-run', (req) => {
+      expect(req.body).to.deep.equal({
+        csv: 'maker,kind,pn,name\nAFX,Slot,MAP-001,Mapped Item',
+        mapping: {
+          brand: 'maker',
+          category: 'kind',
+          part_number: 'pn',
+          title: 'name',
+        },
+      })
+      req.reply({
+        statusCode: 200,
+        body: {
+          total_items: 1,
+          new_items: 1,
+          conflicts: 0,
+          conflict_details: [],
+        },
+      })
+    }).as('importCsvDryRun')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-import-csv-input"]')
+      .clear()
+      .type('maker,kind,pn,name\nAFX,Slot,MAP-001,Mapped Item', {
+        parseSpecialCharSequences: false,
+      })
+    cy.get('[data-testid="settings-operations-import-csv-mapping-brand"]')
+      .clear()
+      .type('maker')
+    cy.get('[data-testid="settings-operations-import-csv-mapping-category"]')
+      .clear()
+      .type('kind')
+    cy.get('[data-testid="settings-operations-import-csv-mapping-part-number"]')
+      .clear()
+      .type('pn')
+    cy.get('[data-testid="settings-operations-import-csv-mapping-title"]')
+      .clear()
+      .type('name')
+    cy.get('[data-testid="settings-operations-import-csv-dry-run"]').click()
+    cy.wait('@importCsvDryRun')
+    cy.get('[data-testid="settings-operations-csv-summary"]').should(
+      'contain',
+      '1 items'
+    )
+    cy.get('[data-testid="settings-operations-csv-summary"]').should(
+      'contain',
+      '0 conflicts'
+    )
+  })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-012 applies CSV import with the selected custom mapping', () => {
+    const mappedCsv = 'maker,kind,pn,name\nAFX,Slot,MAP-APPLY-001,Mapped Apply Item'
+
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-csv-mapping-apply',
+        build_date: '2026-04-22',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: false,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('POST', '/api/data/import/csv/dry-run', {
+      statusCode: 200,
+      body: {
+        total_items: 1,
+        new_items: 1,
+        conflicts: 0,
+        conflict_details: [],
+      },
+    }).as('importCsvDryRun')
+    cy.intercept('POST', '/api/data/import/csv/apply', (req) => {
+      expect(req.body).to.deep.equal({
+        csv_import: {
+          csv: mappedCsv,
+          mapping: {
+            brand: 'maker',
+            category: 'kind',
+            part_number: 'pn',
+            title: 'name',
+          },
+        },
+        options: {
+          default_action: 'merge',
+        },
+      })
+      req.reply({
+        statusCode: 200,
+        body: {
+          ok: true,
+        },
+      })
+    }).as('importCsvApply')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-import-csv-input"]')
+      .clear()
+      .type(mappedCsv, {
+        parseSpecialCharSequences: false,
+      })
+    cy.get('[data-testid="settings-operations-import-csv-mapping-brand"]')
+      .clear()
+      .type('maker')
+    cy.get('[data-testid="settings-operations-import-csv-mapping-category"]')
+      .clear()
+      .type('kind')
+    cy.get('[data-testid="settings-operations-import-csv-mapping-part-number"]')
+      .clear()
+      .type('pn')
+    cy.get('[data-testid="settings-operations-import-csv-mapping-title"]')
+      .clear()
+      .type('name')
+    cy.get('[data-testid="settings-operations-import-csv-dry-run"]').click()
+    cy.wait('@importCsvDryRun')
+    cy.get('[data-testid="settings-operations-import-csv-apply"]').click()
+    cy.wait('@importCsvApply')
+    cy.get('[data-testid="settings-operations-csv-status"]').should(
+      'contain',
+      'CSV import applied successfully.'
+    )
+  })
 })

--- a/ui.web/src/features/settings/operations/index.tsx
+++ b/ui.web/src/features/settings/operations/index.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 
 type RuntimeResponse = {
@@ -60,6 +61,13 @@ type CSVImportRequest = {
   mapping: Record<string, string>
 }
 
+type CSVImportMappingState = {
+  brand: string
+  category: string
+  part_number: string
+  title: string
+}
+
 function parseImportSnapshotRequest(rawInput: string): ImportSnapshotRequest {
   const parsed = JSON.parse(rawInput) as {
     snapshot?: {
@@ -95,6 +103,12 @@ export function SettingsOperations() {
   const [importCsvInput, setImportCsvInput] = useState(
     'brand,category,part_number,title\nAFX,Slot,CSV-001,Example Item'
   )
+  const [importCsvMapping, setImportCsvMapping] = useState<CSVImportMappingState>({
+    brand: '',
+    category: '',
+    part_number: '',
+    title: '',
+  })
   const [lastExportSummary, setLastExportSummary] = useState<ExportSnapshotResponse | null>(null)
   const [importSummary, setImportSummary] = useState<ImportDryRunSummaryResponse | null>(null)
   const [csvStatus, setCsvStatus] = useState<string>('No CSV import or export action has run yet.')
@@ -134,6 +148,19 @@ export function SettingsOperations() {
   useEffect(() => {
     void loadOperations()
   }, [loadOperations])
+
+  const buildCsvImportRequest = useCallback((): CSVImportRequest => {
+    const mapping = Object.fromEntries(
+      Object.entries(importCsvMapping)
+        .map(([field, value]) => [field, value.trim()])
+        .filter(([, value]) => value !== '')
+    ) as Record<string, string>
+
+    return {
+      csv: importCsvInput,
+      mapping,
+    }
+  }, [importCsvInput, importCsvMapping])
 
   const runExportJson = useCallback(async () => {
     setExportPending(true)
@@ -249,10 +276,7 @@ export function SettingsOperations() {
     setLastCsvDryRunRequest(null)
     setCsvTone('default')
     try {
-      const body: CSVImportRequest = {
-        csv: importCsvInput,
-        mapping: {},
-      }
+      const body = buildCsvImportRequest()
       const response = await fetch('/api/data/import/csv/dry-run', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -275,7 +299,7 @@ export function SettingsOperations() {
     } finally {
       setImportCsvDryRunPending(false)
     }
-  }, [importCsvInput])
+  }, [buildCsvImportRequest])
 
   const runImportCsvApply = useCallback(async () => {
     if (!lastCsvDryRunRequest) {
@@ -585,6 +609,104 @@ export function SettingsOperations() {
               className='min-h-36 font-mono text-xs'
               spellCheck={false}
             />
+            <div className='space-y-2'>
+              <p className='text-xs font-medium text-muted-foreground'>
+                CSV column mapping
+              </p>
+              <div className='grid gap-2 md:grid-cols-2'>
+                <div className='space-y-1'>
+                  <label
+                    htmlFor='settings-operations-import-csv-mapping-brand'
+                    className='text-xs text-muted-foreground'
+                  >
+                    Brand column
+                  </label>
+                  <Input
+                    id='settings-operations-import-csv-mapping-brand'
+                    data-testid='settings-operations-import-csv-mapping-brand'
+                    value={importCsvMapping.brand}
+                    onChange={(event) => {
+                      setImportCsvMapping((current) => ({
+                        ...current,
+                        brand: event.target.value,
+                      }))
+                      setCsvSummary(null)
+                      setLastCsvDryRunRequest(null)
+                    }}
+                    placeholder='brand'
+                  />
+                </div>
+                <div className='space-y-1'>
+                  <label
+                    htmlFor='settings-operations-import-csv-mapping-category'
+                    className='text-xs text-muted-foreground'
+                  >
+                    Category column
+                  </label>
+                  <Input
+                    id='settings-operations-import-csv-mapping-category'
+                    data-testid='settings-operations-import-csv-mapping-category'
+                    value={importCsvMapping.category}
+                    onChange={(event) => {
+                      setImportCsvMapping((current) => ({
+                        ...current,
+                        category: event.target.value,
+                      }))
+                      setCsvSummary(null)
+                      setLastCsvDryRunRequest(null)
+                    }}
+                    placeholder='category'
+                  />
+                </div>
+                <div className='space-y-1'>
+                  <label
+                    htmlFor='settings-operations-import-csv-mapping-part-number'
+                    className='text-xs text-muted-foreground'
+                  >
+                    Part number column
+                  </label>
+                  <Input
+                    id='settings-operations-import-csv-mapping-part-number'
+                    data-testid='settings-operations-import-csv-mapping-part-number'
+                    value={importCsvMapping.part_number}
+                    onChange={(event) => {
+                      setImportCsvMapping((current) => ({
+                        ...current,
+                        part_number: event.target.value,
+                      }))
+                      setCsvSummary(null)
+                      setLastCsvDryRunRequest(null)
+                    }}
+                    placeholder='part_number'
+                  />
+                </div>
+                <div className='space-y-1'>
+                  <label
+                    htmlFor='settings-operations-import-csv-mapping-title'
+                    className='text-xs text-muted-foreground'
+                  >
+                    Title column
+                  </label>
+                  <Input
+                    id='settings-operations-import-csv-mapping-title'
+                    data-testid='settings-operations-import-csv-mapping-title'
+                    value={importCsvMapping.title}
+                    onChange={(event) => {
+                      setImportCsvMapping((current) => ({
+                        ...current,
+                        title: event.target.value,
+                      }))
+                      setCsvSummary(null)
+                      setLastCsvDryRunRequest(null)
+                    }}
+                    placeholder='title'
+                  />
+                </div>
+              </div>
+              <p className='text-xs text-muted-foreground'>
+                Leave fields blank to use the default CSV headers.
+              </p>
+            </div>
             <div className='flex flex-wrap items-center justify-between gap-3'>
               <div className='space-y-1'>
                 <label className='text-xs font-medium text-muted-foreground'>


### PR DESCRIPTION
## Summary
- add CSV column mapping controls for required item fields in Settings > Operations
- send selected mapping through CSV dry-run and CSV apply without route reload
- extend focused Settings Operations Cypress coverage for custom-mapped CSV dry-run/apply

## Validation
- npm.cmd run build
- npx.cmd eslint cypress/e2e/settings/operations/spec.cy.ts src/features/settings/operations/index.tsx
- npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/settings/operations/spec.cy.ts
- git diff --check