### PR TITLE
#483 fix(inventory): restore inventory description copy

### DIFF
--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-shell/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-shell/spec.cy.ts
@@ -1,0 +1,28 @@
+describe("inventory-shell", () => {
+  function signIn() {
+    cy.visit("/sign-in?redirect=%2Finventory%2F");
+    cy.get('input[name="email"]').clear().type("e2e-inventory@example.com");
+    cy.get('input[name="password"]').clear().type("password123");
+    cy.contains("button", "Sign in").click();
+    cy.location("pathname", { timeout: 15000 }).should(
+      "match",
+      /^\/inventory\/?$/
+    );
+  }
+
+  it("UI-SCREEN-INVENTORY-SHELL-001 renders resolved inventory intro copy", () => {
+    cy.intercept("GET", "/api/items", {
+      statusCode: 200,
+      body: { items: [] },
+    }).as("itemsIntro");
+
+    signIn();
+    cy.wait("@itemsIntro");
+
+    cy.contains("Inventory").should("be.visible");
+    cy.contains("Browse, organize, and update the items you already own.").should(
+      "be.visible"
+    );
+    cy.contains("inventory.description").should("not.exist");
+  });
+});

--- a/ui.web/src/locales/en/pages.json
+++ b/ui.web/src/locales/en/pages.json
@@ -24,7 +24,8 @@
     }
   },
   "inventory": {
-    "title": "Inventory"
+    "title": "Inventory",
+    "description": "Browse, organize, and update the items you already own."
   },
   "wishlist": {
     "title": "Wishlist"


### PR DESCRIPTION
## Summary
- restore the missing English inventory description copy so the screen no longer falls back to the raw inventory.description key
- add a focused Cypress inventory shell regression for the intro copy so this stays covered without relying on broader inventory item suites

## Validation
- npm.cmd run build
- npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/inventory/ui-screen-inventory-shell/spec.cy.ts
- git diff --check
