### PR TITLE
#578 fix(inventory): scope photo storage by profile

### DIFF
--- a/internal/app/photos_api_test.go
+++ b/internal/app/photos_api_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -119,5 +120,125 @@ func TestPhotosReorderEndpoint(t *testing.T) {
 	}
 	if listed.Photos[0].ID != p3 || listed.Photos[1].ID != p1 || listed.Photos[2].ID != p2 {
 		t.Fatalf("unexpected reordered list: %#v", listed.Photos)
+	}
+}
+
+func TestPhotosUpload_UsesActiveProfileMediaDirectory(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+
+	createProfile := func(name string) string {
+		resp := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"`+name+`"}`), map[string]string{"Content-Type": "application/json"})
+		if resp.Code != http.StatusCreated {
+			t.Fatalf("create profile %s status=%d body=%s", name, resp.Code, resp.Body.String())
+		}
+		var created struct {
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+			t.Fatalf("decode profile %s: %v", name, err)
+		}
+		return created.ID
+	}
+
+	profileOneID := createProfile("Photos Profile One")
+	profileTwoID := createProfile("Photos Profile Two")
+
+	profileOneMediaDir := filepath.Join(a.cfg.DataDir, "profiles", profileOneID, "media-custom")
+	profileTwoMediaDir := filepath.Join(a.cfg.DataDir, "profiles", profileTwoID, "media-custom")
+
+	for profileID, mediaDir := range map[string]string{
+		profileOneID: profileOneMediaDir,
+		profileTwoID: profileTwoMediaDir,
+	} {
+		payloadBytes, err := json.Marshal(map[string]any{
+			"settings": map[string]string{
+				"storage.media_dir": mediaDir,
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal settings for %s: %v", profileID, err)
+		}
+		saveSettings := doRequest(
+			t,
+			a,
+			http.MethodPut,
+			"/api/profiles/"+profileID+"/settings",
+			strings.NewReader(string(payloadBytes)),
+			map[string]string{"Content-Type": "application/json"},
+		)
+		if saveSettings.Code != http.StatusOK {
+			t.Fatalf("save profile settings %s status=%d body=%s", profileID, saveSettings.Code, saveSettings.Body.String())
+		}
+	}
+
+	setActiveProfile := func(profileID string) {
+		resp := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profileID+`"}`), map[string]string{"Content-Type": "application/json"})
+		if resp.Code != http.StatusOK {
+			t.Fatalf("set active profile %s status=%d body=%s", profileID, resp.Code, resp.Body.String())
+		}
+	}
+
+	createItem := func(partNumber string) string {
+		resp := doRequest(t, a, http.MethodPost, "/api/items", strings.NewReader(`{"part_number":"`+partNumber+`","title":"`+partNumber+`"}`), map[string]string{"Content-Type": "application/json"})
+		if resp.Code != http.StatusCreated {
+			t.Fatalf("create item %s status=%d body=%s", partNumber, resp.Code, resp.Body.String())
+		}
+		var created struct {
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+			t.Fatalf("decode item %s: %v", partNumber, err)
+		}
+		return created.ID
+	}
+
+	uploadPhoto := func(itemID string) struct {
+		OriginalPath  string `json:"original_path"`
+		PreviewPath   string `json:"preview_path"`
+		ThumbnailPath string `json:"thumbnail_path"`
+	} {
+		body, contentType := buildMultipartPhoto(t, "photo.jpg", sampleJPEG(t))
+		resp := doRequest(t, a, http.MethodPost, "/api/items/"+itemID+"/photos", body, map[string]string{"Content-Type": contentType})
+		if resp.Code != http.StatusCreated {
+			t.Fatalf("upload photo for %s status=%d body=%s", itemID, resp.Code, resp.Body.String())
+		}
+		var created struct {
+			OriginalPath  string `json:"original_path"`
+			PreviewPath   string `json:"preview_path"`
+			ThumbnailPath string `json:"thumbnail_path"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+			t.Fatalf("decode photo for %s: %v", itemID, err)
+		}
+		return created
+	}
+
+	setActiveProfile(profileOneID)
+	itemOneID := createItem("PHOTO-P1")
+	photoOne := uploadPhoto(itemOneID)
+
+	setActiveProfile(profileTwoID)
+	itemTwoID := createItem("PHOTO-P2")
+	photoTwo := uploadPhoto(itemTwoID)
+
+	if !strings.HasPrefix(photoOne.OriginalPath, profileOneMediaDir) {
+		t.Fatalf("expected profile one original path in %s, got %s", profileOneMediaDir, photoOne.OriginalPath)
+	}
+	if !strings.HasPrefix(photoOne.PreviewPath, profileOneMediaDir) {
+		t.Fatalf("expected profile one preview path in %s, got %s", profileOneMediaDir, photoOne.PreviewPath)
+	}
+	if !strings.HasPrefix(photoOne.ThumbnailPath, profileOneMediaDir) {
+		t.Fatalf("expected profile one thumbnail path in %s, got %s", profileOneMediaDir, photoOne.ThumbnailPath)
+	}
+	if !strings.HasPrefix(photoTwo.OriginalPath, profileTwoMediaDir) {
+		t.Fatalf("expected profile two original path in %s, got %s", profileTwoMediaDir, photoTwo.OriginalPath)
+	}
+	if !strings.HasPrefix(photoTwo.PreviewPath, profileTwoMediaDir) {
+		t.Fatalf("expected profile two preview path in %s, got %s", profileTwoMediaDir, photoTwo.PreviewPath)
+	}
+	if !strings.HasPrefix(photoTwo.ThumbnailPath, profileTwoMediaDir) {
+		t.Fatalf("expected profile two thumbnail path in %s, got %s", profileTwoMediaDir, photoTwo.ThumbnailPath)
 	}
 }

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -47,7 +47,11 @@ func (s *Service) Upload(ctx context.Context, itemID, filename string, r io.Read
 	}
 
 	photoID := uuid.NewString()
-	itemDir := filepath.Join(s.mediaDir, itemID)
+	rootMediaDir, err := s.resolveMediaDirForItem(ctx, itemID)
+	if err != nil {
+		return Photo{}, err
+	}
+	itemDir := filepath.Join(rootMediaDir, itemID)
 	if err := os.MkdirAll(itemDir, 0o755); err != nil {
 		return Photo{}, fmt.Errorf("create item media dir: %w", err)
 	}
@@ -100,6 +104,40 @@ func (s *Service) Upload(ctx context.Context, itemID, filename string, r io.Read
 	}
 
 	return s.GetByID(ctx, photoID)
+}
+
+func (s *Service) resolveMediaDirForItem(ctx context.Context, itemID string) (string, error) {
+	itemID = strings.TrimSpace(itemID)
+	if itemID == "" {
+		return "", fmt.Errorf("item_id is required")
+	}
+
+	var configuredMediaDir sql.NullString
+	err := s.db.QueryRowContext(
+		ctx,
+		`
+		SELECT ps.value
+		FROM canonical_items ci
+		LEFT JOIN profile_settings ps
+			ON ps.profile_id = ci.profile_id
+			AND ps.key = 'storage.media_dir'
+		WHERE ci.id = ?
+		`,
+		itemID,
+	).Scan(&configuredMediaDir)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("item not found")
+		}
+		return "", fmt.Errorf("resolve item media dir: %w", err)
+	}
+
+	mediaDir := strings.TrimSpace(configuredMediaDir.String)
+	if mediaDir != "" {
+		return mediaDir, nil
+	}
+
+	return s.mediaDir, nil
 }
 
 func (s *Service) ListByItem(ctx context.Context, itemID string) ([]Photo, error) {

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
@@ -1,4 +1,19 @@
 describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
+  const validPhotoJPEGBase64 =
+    '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAACAAIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7B8CfDHwdceB/D0svhPQ5JX063ZnfTYSzExKSSdvJooorip/AvQ+SqfG/U//Z'
+
+  function bootstrapInventoryPhotos(path = '/inventory/') {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/items').as('inventoryItems')
+    cy.intercept('GET', /\/api\/items\/.*\/photos/).as('inventoryPhotos')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path })
+    })
+    cy.wait('@inventoryItems')
+    cy.wait('@inventoryPhotos')
+  }
+
   function signIn() {
     cy.visit('/sign-in?redirect=%2Finventory%2F')
     cy.get('input[name="email"]').clear().type('e2e-photos@example.com')
@@ -11,8 +26,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     return cy.get('[data-testid="inventory-photo-row"]').then(($rows) =>
       $rows
         .map((_, row) => {
-          const filename =
-            row.querySelector('span')?.textContent?.trim() ?? ''
+          const filename = row.querySelector('span')?.textContent?.trim() ?? ''
           return filename
         })
         .get()
@@ -60,9 +74,18 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
         },
       })
     }).as('listPhotos')
-    cy.intercept('POST', '/api/items/item-photo-1/photos', { statusCode: 201, body: { id: 'p3', filename: 'three.jpg', is_primary: false } }).as('uploadPhoto')
-    cy.intercept('PUT', '/api/items/item-photo-1/photos/p2/primary', { statusCode: 204, body: '' }).as('setPrimary')
-    cy.intercept('DELETE', '/api/items/item-photo-1/photos/p1', { statusCode: 204, body: '' }).as('deletePhoto')
+    cy.intercept('POST', '/api/items/item-photo-1/photos', {
+      statusCode: 201,
+      body: { id: 'p3', filename: 'three.jpg', is_primary: false },
+    }).as('uploadPhoto')
+    cy.intercept('PUT', '/api/items/item-photo-1/photos/p2/primary', {
+      statusCode: 204,
+      body: '',
+    }).as('setPrimary')
+    cy.intercept('DELETE', '/api/items/item-photo-1/photos/p1', {
+      statusCode: 204,
+      body: '',
+    }).as('deletePhoto')
 
     signIn()
     cy.wait('@items')
@@ -371,5 +394,81 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     cy.wait('@rebuildPhotos')
     cy.get('[data-testid="inventory-photo-rebuild-success"]').should('be.visible')
     cy.contains('[data-testid="inventory-photo-row"]', 'rebuild-one.jpg').should('be.visible')
+  })
+
+  it('PHOTOS-MEDIA-009 persists uploaded photos through reload and keeps them profile-scoped', () => {
+    bootstrapInventoryPhotos()
+
+    cy.get('[data-testid="inventory-photos-section"]').should('be.visible')
+    cy.get('[data-testid="inventory-photo-upload-input"]').selectFile({
+      contents: Cypress.Buffer.from(validPhotoJPEGBase64, 'base64'),
+      fileName: 'profile-scoped-photo.jpg',
+      mimeType: 'image/jpeg',
+    })
+    cy.wait('@inventoryPhotos')
+    cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg').should(
+      'be.visible'
+    )
+    cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg')
+      .find('[data-testid="inventory-photo-primary-badge"]')
+      .should('exist')
+
+    cy.reload()
+    cy.wait('@inventoryItems')
+    cy.wait('@inventoryPhotos')
+    cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg').should(
+      'be.visible'
+    )
+    cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg')
+      .find('[data-testid="inventory-photo-primary-badge"]')
+      .should('exist')
+
+    let secondProfileId = ''
+    cy.request('POST', '/api/profiles', { name: 'Inventory Photos Profile Two' }).then(
+      (createResp) => {
+        expect(createResp.status).to.be.oneOf([200, 201])
+        secondProfileId = createResp.body.id as string
+        cy.request('PUT', '/api/profiles/active', { profile_id: secondProfileId })
+          .its('status')
+          .should('eq', 200)
+        cy.request('POST', '/api/items', {
+          part_number: 'P2-PHOTO-001',
+          title: 'Profile Two Photo Item',
+        })
+          .its('status')
+          .should('eq', 201)
+      }
+    )
+
+    cy.visit('/inventory/', {
+      onBeforeLoad(win) {
+        if (secondProfileId) {
+          win.localStorage.setItem(`cabinet.workspace.${secondProfileId}`, '1')
+        }
+      },
+    })
+    cy.wait('@inventoryItems')
+    cy.wait('@inventoryPhotos')
+    cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg').should(
+      'not.exist'
+    )
+    cy.get('[data-testid="inventory-photos-empty"]').should('be.visible')
+
+    cy.request('PUT', '/api/profiles/active', { profile_id: 'e2e-profile-001' })
+      .its('status')
+      .should('eq', 200)
+    cy.visit('/inventory/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('cabinet.workspace.e2e-profile-001', '1')
+      },
+    })
+    cy.wait('@inventoryItems')
+    cy.wait('@inventoryPhotos')
+    cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg').should(
+      'be.visible'
+    )
+    cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg')
+      .find('[data-testid="inventory-photo-primary-badge"]')
+      .should('exist')
   })
 })


### PR DESCRIPTION
## Summary
- resolve inventory photo uploads against the owning item's profile media directory instead of the runtime-global media root
- add an API regression for profile-scoped photo storage paths
- extend inventory photo E2E coverage to prove upload persistence, primary badge persistence, and profile isolation through reloads

## Validation
- go test ./internal/app -run TestPhotos -count=1
- ./scripts/build-cabinet.ps1
- npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
- git diff --check
