### PR TITLE
#605 fix(runtime): avoid duplicate start on active endpoint

### DIFF
--- a/cmd/cabinet/main.go
+++ b/cmd/cabinet/main.go
@@ -38,6 +38,7 @@ func main() {
 	openBrowserValue, openBrowserSet := os.LookupEnv("CABINET_OPEN_BROWSER")
 	log.Printf("%s", buildEffectiveStartupConfigLine(cfg))
 	browserLaunch := resolveBrowserLaunch(os.Args[1:], openBrowserValue, openBrowserSet)
+	allowParallel := startupAllowsParallel()
 	attachDecision, attachErr := resolveRunningRuntimeAttach(cfg.DataDir, isRuntimeProcessAlive, isRuntimeEndpointHealthy)
 	if attachErr != nil {
 		log.Printf("runtime attach check skipped: %v", attachErr)
@@ -50,6 +51,20 @@ func main() {
 			return
 		}
 		if err := launcher.OpenBrowser(attachDecision.URL); err != nil {
+			log.Printf("browser attach launch skipped: %v", err)
+		}
+		return
+	}
+	requestedAttachDecision := resolveRequestedRuntimeAttach(cfg, allowParallel, isRuntimeEndpointHealthy)
+	if requestedAttachDecision.Attach {
+		log.Printf("%s", runtimeAttachLogLine(requestedAttachDecision, cfg.DataDir))
+		if !browserLaunch.Enabled {
+			if strings.TrimSpace(browserLaunch.DisableNote) != "" {
+				log.Printf("%s", browserLaunch.DisableNote)
+			}
+			return
+		}
+		if err := launcher.OpenBrowser(requestedAttachDecision.URL); err != nil {
 			log.Printf("browser attach launch skipped: %v", err)
 		}
 		return
@@ -114,5 +129,14 @@ func openBrowserEnabled(value string, ok bool) bool {
 		return false
 	default:
 		return true
+	}
+}
+
+func startupAllowsParallel() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CABINET_ALLOW_PARALLEL"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
 	}
 }

--- a/cmd/cabinet/runtime_attach.go
+++ b/cmd/cabinet/runtime_attach.go
@@ -14,12 +14,16 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/collectors-tech/cabinet/internal/config"
+	"github.com/collectors-tech/cabinet/internal/launcher"
 )
 
 type runtimeAttachDecision struct {
 	Attach bool
 	URL    string
 	PID    int
+	Reason string
 }
 
 type runtimeSetupAttachMetadata struct {
@@ -157,10 +161,44 @@ func runtimeAttachLogLine(decision runtimeAttachDecision, dataDir string) string
 		}
 	}
 	return fmt.Sprintf(
-		"CABINET_RUNTIME_ATTACH url=%s pid=%d data_dir=%s resolved_port=%d",
+		"CABINET_RUNTIME_ATTACH url=%s pid=%d data_dir=%s resolved_port=%d reason=%s",
 		strings.TrimSpace(decision.URL),
 		decision.PID,
 		strings.TrimSpace(dataDir),
 		resolvedPort,
+		attachReasonOrDefault(decision.Reason),
 	)
+}
+
+func resolveRequestedRuntimeAttach(
+	cfg config.Config,
+	allowParallel bool,
+	urlHealthy func(runtimeURL string) bool,
+) runtimeAttachDecision {
+	if allowParallel {
+		return runtimeAttachDecision{}
+	}
+
+	requestedURL := launcher.StartupURLFromAddr(cfg.Addr)
+	if strings.TrimSpace(requestedURL) == "" {
+		return runtimeAttachDecision{}
+	}
+	if !urlHealthy(requestedURL) {
+		return runtimeAttachDecision{}
+	}
+
+	return runtimeAttachDecision{
+		Attach: true,
+		URL:    requestedURL,
+		PID:    0,
+		Reason: "requested_endpoint_healthy",
+	}
+}
+
+func attachReasonOrDefault(reason string) string {
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" {
+		return "same_data_dir"
+	}
+	return trimmed
 }

--- a/cmd/cabinet/runtime_requested_attach_test.go
+++ b/cmd/cabinet/runtime_requested_attach_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/collectors-tech/cabinet/internal/config"
+)
+
+func TestResolveRequestedRuntimeAttachWhenEndpointHealthyAndParallelDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Addr:    "127.0.0.1:17882",
+		Host:    "127.0.0.1",
+		Port:    17882,
+		DataDir: t.TempDir(),
+	}
+
+	decision := resolveRequestedRuntimeAttach(cfg, false, func(runtimeURL string) bool {
+		return runtimeURL == "http://127.0.0.1:17882/"
+	})
+
+	if !decision.Attach {
+		t.Fatalf("expected attach=true when requested endpoint already serves cabinet")
+	}
+	if decision.URL != "http://127.0.0.1:17882/" {
+		t.Fatalf("expected requested endpoint URL, got %q", decision.URL)
+	}
+}
+
+func TestResolveRequestedRuntimeAttachSkipsAttachWhenParallelAllowed(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Addr:    "127.0.0.1:17882",
+		Host:    "127.0.0.1",
+		Port:    17882,
+		DataDir: t.TempDir(),
+	}
+
+	healthyChecks := 0
+	decision := resolveRequestedRuntimeAttach(cfg, true, func(runtimeURL string) bool {
+		healthyChecks++
+		return runtimeURL == "http://127.0.0.1:17882/"
+	})
+
+	if decision.Attach {
+		t.Fatalf("expected attach=false when explicit parallel mode is enabled")
+	}
+	if healthyChecks != 0 {
+		t.Fatalf("expected no endpoint health checks in explicit parallel mode, got %d", healthyChecks)
+	}
+}
+
+func TestResolveRequestedRuntimeAttachUsesLoopbackForLanBind(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Addr:    "0.0.0.0:17882",
+		Host:    "0.0.0.0",
+		Port:    17882,
+		DataDir: t.TempDir(),
+	}
+
+	decision := resolveRequestedRuntimeAttach(cfg, false, func(runtimeURL string) bool {
+		return runtimeURL == "http://127.0.0.1:17882/"
+	})
+
+	if !decision.Attach {
+		t.Fatalf("expected attach=true when loopback-mapped endpoint is healthy")
+	}
+	if decision.URL != "http://127.0.0.1:17882/" {
+		t.Fatalf("expected loopback attach URL, got %q", decision.URL)
+	}
+}


### PR DESCRIPTION
## Summary
- reuse a healthy requested Cabinet endpoint by default instead of starting a duplicate runtime
- keep explicit parallel mode as the escape hatch for intentional multi-instance runs
- add focused CLI tests for requested-endpoint attach behavior

## Validation
- go test ./cmd/cabinet -count=1
- go test ./internal/app -run TestRunFallsBackToNextAvailablePortWhenRequestedPortIsOccupied -count=1
- git diff --check
- pre-push OpenSpec validation hook
- pre-push fast API docs smoke test