### PR TITLE
#485 fix(wishlist): restore localized page description

### DIFF
--- a/internal/app/ui_template_contract_test.go
+++ b/internal/app/ui_template_contract_test.go
@@ -230,6 +230,27 @@ func TestI18nBootstrapContract(t *testing.T) {
 	checkContains("../../ui.web/src/locales/en/nav.json", []string{"Dashboard", "Inventory", "Wishlist"})
 }
 
+func TestWishlistLocalizationContract(t *testing.T) {
+	t.Parallel()
+
+	checkContains := func(path string, required []string) {
+		t.Helper()
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		src := string(b)
+		for _, token := range required {
+			if !strings.Contains(src, token) {
+				t.Fatalf("%s missing required wishlist localization token: %s", path, token)
+			}
+		}
+	}
+
+	checkContains("../../ui.web/src/features/wishlist/index.tsx", []string{"t('wishlist.title')", "t('wishlist.description')"})
+	checkContains("../../ui.web/src/locales/en/pages.json", []string{`"wishlist"`, `"title": "Wishlist"`, `"description": "Track wanted items, target prices, and planning decisions before they become owned inventory."`})
+}
+
 func TestLegacyTasksAppsRoutesRemovedContract(t *testing.T) {
 	t.Parallel()
 

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -63,6 +63,10 @@ describe("ui-screen-wishlist", () => {
     signInToWishlist();
 
     cy.contains("Wishlist").should("be.visible");
+    cy.contains(
+      "Track wanted items, target prices, and planning decisions before they become owned inventory."
+    ).should("be.visible");
+    cy.contains("wishlist.description").should("not.exist");
     cy.get("table").should("be.visible");
     cy.contains("button", "Cards").click();
     cy.window().its("localStorage").invoke("getItem", "cabinet.viewMode.wishlist").should("eq", "cards");

--- a/ui.web/src/locales/en/pages.json
+++ b/ui.web/src/locales/en/pages.json
@@ -28,7 +28,8 @@
     "description": "Browse, organize, and update the items you already own."
   },
   "wishlist": {
-    "title": "Wishlist"
+    "title": "Wishlist",
+    "description": "Track wanted items, target prices, and planning decisions before they become owned inventory."
   },
   "integrations": {
     "title": "Integrations",


### PR DESCRIPTION
## Summary
- restore missing Wishlist description copy in English locale
- add Wishlist localization contract coverage
- add Wishlist E2E assertion for resolved description text

## Validation
- `go test ./internal/app -run TestWishlistLocalizationContract -count=1`
- `go test ./internal/app -run TestWishlistAndPricingEndpoints -count=1`
- `git diff --check`
- pre-push OpenSpec validation hook
- pre-push fast API docs smoke test

## Notes
Local `ui.web` build/lint in this shell are currently blocked by missing frontend dependencies (`tsc` and `globals` package resolution), so validation for this copy-only change used the contract + API path.
