### PR TITLE
#608 feat(runtime): add restart handoff for active endpoint

### DIFF
--- a/cmd/cabinet/main.go
+++ b/cmd/cabinet/main.go
@@ -39,6 +39,28 @@ func main() {
 	log.Printf("%s", buildEffectiveStartupConfigLine(cfg))
 	browserLaunch := resolveBrowserLaunch(os.Args[1:], openBrowserValue, openBrowserSet)
 	allowParallel := startupAllowsParallel()
+	restartRequested := startupWantsRestart()
+	requestedProbe := resolveRequestedRuntimeProbe(cfg, fetchRuntimeEndpointProbe, isRuntimeAddrInUse)
+	log.Printf("%s", runtimeEndpointStatusLogLine(requestedProbe))
+	if restartRequested {
+		switch requestedProbe.Status {
+		case "occupied":
+			log.Fatalf("runtime restart failed: requested endpoint %s is occupied by a non-Cabinet listener", requestedProbe.URL)
+		case "cabinet":
+			restartResult, err := restartRequestedRuntime(
+				requestedProbe,
+				cfg.Addr,
+				requestRuntimeShutdown,
+				waitForRuntimeRestartReady,
+				isRuntimeProcessAlive,
+				terminateRuntimeProcess,
+			)
+			if err != nil {
+				log.Fatalf("runtime restart failed: %v", err)
+			}
+			log.Printf("%s", runtimeRestartLogLine(restartResult, cfg.DataDir))
+		}
+	}
 	attachDecision, attachErr := resolveRunningRuntimeAttach(cfg.DataDir, isRuntimeProcessAlive, isRuntimeEndpointHealthy)
 	if attachErr != nil {
 		log.Printf("runtime attach check skipped: %v", attachErr)
@@ -55,7 +77,10 @@ func main() {
 		}
 		return
 	}
-	requestedAttachDecision := resolveRequestedRuntimeAttach(cfg, allowParallel, isRuntimeEndpointHealthy)
+	requestedAttachDecision := runtimeAttachDecision{}
+	if !restartRequested && requestedProbe.Status == "cabinet" {
+		requestedAttachDecision = resolveRequestedRuntimeAttach(cfg, allowParallel, isRuntimeEndpointHealthy)
+	}
 	if requestedAttachDecision.Attach {
 		log.Printf("%s", runtimeAttachLogLine(requestedAttachDecision, cfg.DataDir))
 		if !browserLaunch.Enabled {

--- a/cmd/cabinet/runtime_control.go
+++ b/cmd/cabinet/runtime_control.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/collectors-tech/cabinet/internal/config"
+	"github.com/collectors-tech/cabinet/internal/launcher"
+)
+
+type runtimeEndpointProbe struct {
+	URL       string
+	Status    string
+	PortInUse bool
+	PID       int
+	DataDir   string
+}
+
+type runtimeShutdownResponse struct {
+	OK     bool   `json:"ok"`
+	PID    int    `json:"pid"`
+	Reason string `json:"reason"`
+}
+
+type runtimeRestartResult struct {
+	URL          string
+	PID          int
+	Forced       bool
+	Restarted    bool
+	EndpointDown bool
+}
+
+func startupWantsRestart() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CABINET_RESTART"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveRequestedRuntimeProbe(
+	cfg config.Config,
+	inspect func(string) (runtimeEndpointProbe, error),
+	portInUse func(string) bool,
+) runtimeEndpointProbe {
+	requestedURL := launcher.StartupURLFromAddr(cfg.Addr)
+	probe := runtimeEndpointProbe{
+		URL: requestedURL,
+	}
+
+	if inspected, err := inspect(requestedURL); err == nil {
+		inspected.URL = requestedURL
+		inspected.Status = "cabinet"
+		inspected.PortInUse = true
+		return inspected
+	}
+
+	if portInUse(cfg.Addr) {
+		probe.Status = "occupied"
+		probe.PortInUse = true
+		return probe
+	}
+
+	probe.Status = "free"
+	return probe
+}
+
+func fetchRuntimeEndpointProbe(runtimeURL string) (runtimeEndpointProbe, error) {
+	if !isRuntimeEndpointHealthy(runtimeURL) {
+		return runtimeEndpointProbe{}, fmt.Errorf("runtime endpoint unhealthy")
+	}
+
+	baseURL, err := url.Parse(strings.TrimSpace(runtimeURL))
+	if err != nil {
+		return runtimeEndpointProbe{}, fmt.Errorf("parse runtime url: %w", err)
+	}
+	baseURL.Path = "/api/runtime"
+	baseURL.RawQuery = ""
+	baseURL.Fragment = ""
+
+	req, err := http.NewRequest(http.MethodGet, baseURL.String(), nil)
+	if err != nil {
+		return runtimeEndpointProbe{}, fmt.Errorf("new runtime request: %w", err)
+	}
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	resp, err := client.Do(req)
+	if err != nil {
+		return runtimeEndpointProbe{}, fmt.Errorf("get runtime endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return runtimeEndpointProbe{}, fmt.Errorf("runtime status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		AppVersion  string `json:"app_version"`
+		RuntimePort int    `json:"runtime_port"`
+		PID         int    `json:"pid"`
+		DataDir     string `json:"data_dir"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return runtimeEndpointProbe{}, fmt.Errorf("decode runtime payload: %w", err)
+	}
+	if payload.RuntimePort <= 0 {
+		return runtimeEndpointProbe{}, fmt.Errorf("runtime payload missing port")
+	}
+
+	return runtimeEndpointProbe{
+		URL:       strings.TrimSpace(runtimeURL),
+		Status:    "cabinet",
+		PortInUse: true,
+		PID:       payload.PID,
+		DataDir:   strings.TrimSpace(payload.DataDir),
+	}, nil
+}
+
+func isRuntimeAddrInUse(addr string) bool {
+	dialAddr := normalizeStartupDialAddr(addr)
+	conn, err := net.DialTimeout("tcp", dialAddr, 250*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func normalizeStartupDialAddr(addr string) string {
+	host, port, err := net.SplitHostPort(strings.TrimSpace(addr))
+	if err != nil {
+		return net.JoinHostPort("127.0.0.1", "17880")
+	}
+	if strings.TrimSpace(host) == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	if strings.TrimSpace(port) == "" {
+		port = "17880"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func runtimeEndpointStatusLogLine(probe runtimeEndpointProbe) string {
+	return fmt.Sprintf(
+		"CABINET_RUNTIME_ENDPOINT_STATUS requested_url=%s status=%s port_in_use=%t pid=%d data_dir=%s",
+		strings.TrimSpace(probe.URL),
+		strings.TrimSpace(defaultRuntimeEndpointStatus(probe.Status)),
+		probe.PortInUse,
+		probe.PID,
+		strings.TrimSpace(probe.DataDir),
+	)
+}
+
+func runtimeRestartLogLine(result runtimeRestartResult, dataDir string) string {
+	return fmt.Sprintf(
+		"CABINET_RUNTIME_RESTART url=%s pid=%d forced=%t restarted=%t endpoint_down=%t data_dir=%s",
+		strings.TrimSpace(result.URL),
+		result.PID,
+		result.Forced,
+		result.Restarted,
+		result.EndpointDown,
+		strings.TrimSpace(dataDir),
+	)
+}
+
+func defaultRuntimeEndpointStatus(status string) string {
+	trimmed := strings.TrimSpace(status)
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
+}
+
+func requestRuntimeShutdown(runtimeURL, reason string) (runtimeShutdownResponse, error) {
+	baseURL, err := url.Parse(strings.TrimSpace(runtimeURL))
+	if err != nil {
+		return runtimeShutdownResponse{}, fmt.Errorf("parse runtime url: %w", err)
+	}
+	baseURL.Path = "/api/runtime/shutdown"
+	baseURL.RawQuery = ""
+	baseURL.Fragment = ""
+
+	body, err := json.Marshal(map[string]string{
+		"reason": strings.TrimSpace(reason),
+	})
+	if err != nil {
+		return runtimeShutdownResponse{}, fmt.Errorf("marshal shutdown request: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return runtimeShutdownResponse{}, fmt.Errorf("new shutdown request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 750 * time.Millisecond}
+	resp, err := client.Do(req)
+	if err != nil {
+		return runtimeShutdownResponse{}, fmt.Errorf("post runtime shutdown: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		return runtimeShutdownResponse{}, fmt.Errorf("runtime shutdown status %d", resp.StatusCode)
+	}
+
+	var payload runtimeShutdownResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return runtimeShutdownResponse{}, fmt.Errorf("decode shutdown response: %w", err)
+	}
+	return payload, nil
+}
+
+func restartRequestedRuntime(
+	probe runtimeEndpointProbe,
+	requestedAddr string,
+	shutdownRequester func(string, string) (runtimeShutdownResponse, error),
+	waitForReady func(string, string, time.Duration) bool,
+	pidAlive func(int) bool,
+	terminate func(int) error,
+) (runtimeRestartResult, error) {
+	result := runtimeRestartResult{
+		URL: probe.URL,
+		PID: probe.PID,
+	}
+
+	shutdownResp, shutdownErr := shutdownRequester(probe.URL, "restart")
+	if shutdownResp.PID > 0 {
+		result.PID = shutdownResp.PID
+	}
+	if shutdownErr == nil {
+		if waitForReady(probe.URL, requestedAddr, 5*time.Second) {
+			result.Restarted = true
+			result.EndpointDown = true
+			return result, nil
+		}
+	}
+
+	if result.PID <= 0 || !pidAlive(result.PID) {
+		return result, fmt.Errorf("restart handoff did not release endpoint cleanly")
+	}
+	if err := terminate(result.PID); err != nil {
+		return result, fmt.Errorf("terminate runtime pid %d: %w", result.PID, err)
+	}
+	result.Forced = true
+	if !waitForReady(probe.URL, requestedAddr, 5*time.Second) {
+		return result, fmt.Errorf("restarted runtime endpoint did not clear after forced termination")
+	}
+	result.Restarted = true
+	result.EndpointDown = true
+	return result, nil
+}
+
+func waitForRuntimeRestartReady(runtimeURL, requestedAddr string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !isRuntimeEndpointHealthy(runtimeURL) && !isRuntimeAddrInUse(requestedAddr) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+func terminateRuntimeProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid pid")
+	}
+	if runtime.GOOS == "windows" {
+		return exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T", "/F").Run()
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(syscall.SIGKILL)
+}

--- a/cmd/cabinet/runtime_control_test.go
+++ b/cmd/cabinet/runtime_control_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/collectors-tech/cabinet/internal/config"
+)
+
+func TestResolveRequestedRuntimeProbeCabinetVsOccupiedVsFree(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{Addr: "127.0.0.1:17882", Host: "127.0.0.1", Port: 17882}
+
+	cabinetProbe := resolveRequestedRuntimeProbe(
+		cfg,
+		func(runtimeURL string) (runtimeEndpointProbe, error) {
+			return runtimeEndpointProbe{URL: runtimeURL, PID: 4242, DataDir: "C:/cabinet/data"}, nil
+		},
+		func(string) bool { return true },
+	)
+	if cabinetProbe.Status != "cabinet" || !cabinetProbe.PortInUse || cabinetProbe.PID != 4242 {
+		t.Fatalf("expected cabinet probe, got %+v", cabinetProbe)
+	}
+
+	occupiedProbe := resolveRequestedRuntimeProbe(
+		cfg,
+		func(string) (runtimeEndpointProbe, error) {
+			return runtimeEndpointProbe{}, http.ErrServerClosed
+		},
+		func(string) bool { return true },
+	)
+	if occupiedProbe.Status != "occupied" || !occupiedProbe.PortInUse {
+		t.Fatalf("expected occupied probe, got %+v", occupiedProbe)
+	}
+
+	freeProbe := resolveRequestedRuntimeProbe(
+		cfg,
+		func(string) (runtimeEndpointProbe, error) {
+			return runtimeEndpointProbe{}, http.ErrServerClosed
+		},
+		func(string) bool { return false },
+	)
+	if freeProbe.Status != "free" || freeProbe.PortInUse {
+		t.Fatalf("expected free probe, got %+v", freeProbe)
+	}
+}
+
+func TestFetchRuntimeEndpointProbeReadsRuntimeMetadata(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/api/runtime", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"app_version":  "rev-test",
+			"runtime_port": 19991,
+			"pid":          5511,
+			"data_dir":     "C:/cabinet/runtime",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	probe, err := fetchRuntimeEndpointProbe(server.URL)
+	if err != nil {
+		t.Fatalf("fetchRuntimeEndpointProbe error: %v", err)
+	}
+	if probe.Status != "cabinet" || probe.PID != 5511 || probe.DataDir != "C:/cabinet/runtime" {
+		t.Fatalf("unexpected probe: %+v", probe)
+	}
+}
+
+func TestRestartRequestedRuntimeFallsBackToForcedTermination(t *testing.T) {
+	t.Parallel()
+
+	probe := runtimeEndpointProbe{
+		URL: "http://127.0.0.1:17882/",
+		PID: 4040,
+	}
+	shutdownCalls := 0
+	terminateCalls := 0
+	waitCalls := 0
+
+	result, err := restartRequestedRuntime(
+		probe,
+		"127.0.0.1:17882",
+		func(string, string) (runtimeShutdownResponse, error) {
+			shutdownCalls++
+			return runtimeShutdownResponse{OK: true, PID: 4040}, nil
+		},
+		func(string, string, time.Duration) bool {
+			waitCalls++
+			return waitCalls > 1
+		},
+		func(pid int) bool { return pid == 4040 },
+		func(pid int) error {
+			terminateCalls++
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartRequestedRuntime error: %v", err)
+	}
+	if shutdownCalls != 1 || terminateCalls != 1 {
+		t.Fatalf("expected 1 shutdown call and 1 terminate call, got shutdown=%d terminate=%d", shutdownCalls, terminateCalls)
+	}
+	if !result.Forced || !result.Restarted || !result.EndpointDown {
+		t.Fatalf("expected forced successful restart result, got %+v", result)
+	}
+}
+
+func TestRuntimeEndpointStatusLogLineIncludesPidAndStatus(t *testing.T) {
+	t.Parallel()
+
+	line := runtimeEndpointStatusLogLine(runtimeEndpointProbe{
+		URL:       "http://127.0.0.1:17882/",
+		Status:    "cabinet",
+		PortInUse: true,
+		PID:       1234,
+		DataDir:   "C:/cabinet/data",
+	})
+	for _, token := range []string{
+		"CABINET_RUNTIME_ENDPOINT_STATUS",
+		"status=cabinet",
+		"port_in_use=true",
+		"pid=1234",
+		"data_dir=C:/cabinet/data",
+	} {
+		if !strings.Contains(line, token) {
+			t.Fatalf("expected token %q in line %q", token, line)
+		}
+	}
+}

--- a/cmd/cabinet/startup_flags.go
+++ b/cmd/cabinet/startup_flags.go
@@ -28,6 +28,7 @@ func parseStartupArgs(args []string) (startupOverrides, error) {
 	var instanceName string
 	var authMode string
 	var baseURL string
+	var restart bool
 	var allowParallel bool
 	var logLevel string
 	var noOpenBrowser bool
@@ -39,6 +40,7 @@ func parseStartupArgs(args []string) (startupOverrides, error) {
 	fs.StringVar(&instanceName, "instance-name", "", "Instance/profile alias override.")
 	fs.StringVar(&authMode, "auth-mode", "", "Auth mode override (local|clerk).")
 	fs.StringVar(&baseURL, "base-url", "", "Base URL override for runtime callbacks/origin.")
+	fs.BoolVar(&restart, "restart", false, "Restart an already-running Cabinet instance on the requested endpoint.")
 	fs.BoolVar(&allowParallel, "allow-parallel", false, "Allow parallel runtime instances.")
 	fs.StringVar(&logLevel, "log-level", "", "Log level override (debug|info|warn|error).")
 	fs.BoolVar(&noOpenBrowser, "no-open-browser", false, "Disable browser auto-open on startup.")
@@ -105,6 +107,10 @@ func parseStartupArgs(args []string) (startupOverrides, error) {
 		env["CABINET_BASE_URL"] = baseURL
 	}
 
+	if restart {
+		env["CABINET_RESTART"] = "true"
+	}
+
 	if allowParallel {
 		env["CABINET_ALLOW_PARALLEL"] = "true"
 	}
@@ -157,6 +163,11 @@ func envOrDefault(key, fallback string) string {
 }
 
 func validateStartupOverrides(overrides startupOverrides) error {
+	if _, ok := overrides.Env["CABINET_RESTART"]; ok {
+		if _, parallel := overrides.Env["CABINET_ALLOW_PARALLEL"]; parallel {
+			return errors.New("restart cannot be combined with allow-parallel")
+		}
+	}
 	if _, ok := overrides.Env["CABINET_ALLOW_PARALLEL"]; ok {
 		if strings.TrimSpace(overrides.Env["CABINET_PROFILE"]) == "" && strings.TrimSpace(os.Getenv("CABINET_PROFILE")) == "" {
 			return errors.New("allow-parallel requires --profile or --instance-name")

--- a/cmd/cabinet/startup_flags_test.go
+++ b/cmd/cabinet/startup_flags_test.go
@@ -17,6 +17,7 @@ func TestParseStartupArgsBuildsEnvOverrides(t *testing.T) {
 		"--profile", "demo-profile",
 		"--auth-mode", "clerk",
 		"--base-url", "http://127.0.0.1:19090",
+		"--restart",
 		"--allow-parallel",
 		"--log-level", "debug",
 	})
@@ -38,6 +39,9 @@ func TestParseStartupArgsBuildsEnvOverrides(t *testing.T) {
 	}
 	if overrides.Env["CABINET_BASE_URL"] != "http://127.0.0.1:19090" {
 		t.Fatalf("expected CABINET_BASE_URL override")
+	}
+	if overrides.Env["CABINET_RESTART"] != "true" {
+		t.Fatalf("expected CABINET_RESTART=true")
 	}
 	if overrides.Env["CABINET_ALLOW_PARALLEL"] != "true" {
 		t.Fatalf("expected CABINET_ALLOW_PARALLEL=true")
@@ -126,5 +130,23 @@ func TestApplyStartupOverridesSetsEnvironmentVariables(t *testing.T) {
 	applyStartupOverrides(overrides)
 	if got := os.Getenv("CABINET_LOG_LEVEL"); got != "info" {
 		t.Fatalf("expected CABINET_LOG_LEVEL=info, got %q", got)
+	}
+}
+
+func TestValidateStartupOverridesRejectsRestartWithAllowParallel(t *testing.T) {
+	t.Parallel()
+
+	err := validateStartupOverrides(startupOverrides{
+		Env: map[string]string{
+			"CABINET_RESTART":       "true",
+			"CABINET_ALLOW_PARALLEL": "true",
+			"CABINET_PROFILE":       "demo",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected restart/allow-parallel validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "restart") {
+		t.Fatalf("expected restart validation error, got %v", err)
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -75,6 +75,7 @@ type App struct {
 	authService   *auth.Service
 	openapiSpec   []byte
 	runtimeLogs   *runtimeLogManager
+	runtimeStopCh chan string
 	startupNotice func(string)
 	startupIsTTY  func() bool
 }
@@ -130,6 +131,7 @@ func New(cfg config.Config) (*App, error) {
 	}
 	cloudLeases := newCloudLeaseStore()
 	cloudEntitlements := newCloudEntitlementStore()
+	runtimeStopCh := make(chan string, 1)
 
 	mux := http.NewServeMux()
 	if isE2EHooksEnabled(cfg) {
@@ -229,6 +231,40 @@ func New(cfg config.Config) (*App, error) {
 			"bind_mode":                    strings.TrimSpace(strings.ToLower(cfg.BindMode)),
 			"runtime_host":                 host,
 			"runtime_port":                 port,
+			"pid":                          os.Getpid(),
+			"data_dir":                     cfg.DataDir,
+		})
+	})
+	mux.HandleFunc("/api/runtime/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method_not_allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if !requestIsLoopback(r) {
+			http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+			return
+		}
+		var payload struct {
+			Reason string `json:"reason"`
+		}
+		if r.Body != nil {
+			defer r.Body.Close()
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+		}
+		reason := strings.TrimSpace(payload.Reason)
+		if reason == "" {
+			reason = "api_shutdown"
+		}
+		select {
+		case runtimeStopCh <- reason:
+		default:
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":     true,
+			"pid":    os.Getpid(),
+			"reason": reason,
 		})
 	})
 	mux.HandleFunc("/api/auth/provider-options", func(w http.ResponseWriter, r *http.Request) {
@@ -4583,13 +4619,14 @@ func New(cfg config.Config) (*App, error) {
 	}
 
 	a := &App{
-		cfg:         cfg,
-		db:          conn,
-		srv:         srv,
-		backupSvc:   backupSvc,
-		authService: authService,
-		openapiSpec: openapiSpec,
-		runtimeLogs: runtimeLogs,
+		cfg:           cfg,
+		db:            conn,
+		srv:           srv,
+		backupSvc:     backupSvc,
+		authService:   authService,
+		openapiSpec:   openapiSpec,
+		runtimeLogs:   runtimeLogs,
+		runtimeStopCh: runtimeStopCh,
 		startupNotice: func(line string) {
 			log.Print(line)
 		},
@@ -7273,6 +7310,11 @@ func (a *App) Run(ctx context.Context) error {
 		defer cancel()
 		_ = a.srv.Shutdown(shutdownCtx)
 		return a.closeRuntime(true, "shutdown", resolvedURL)
+	case reason := <-a.runtimeStopCh:
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = a.srv.Shutdown(shutdownCtx)
+		return a.closeRuntime(true, cleanReason(reason), resolvedURL)
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {
 			return a.closeRuntime(true, "server_closed", resolvedURL)
@@ -7312,6 +7354,21 @@ func listenWithPortFallback(addr string, maxFallbackAttempts int) (net.Listener,
 		}
 	}
 	return nil, err
+}
+
+func requestIsLoopback(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err != nil {
+		host = strings.TrimSpace(r.RemoteAddr)
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }
 
 func splitHostPort(addr string) (string, int) {

--- a/internal/app/runtime_restart_api_test.go
+++ b/internal/app/runtime_restart_api_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeShutdownEndpointAllowsLoopbackPost(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/shutdown", strings.NewReader(`{"reason":"restart"}`))
+	req.RemoteAddr = "127.0.0.1:40123"
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	a.srv.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"reason":"restart"`) {
+		t.Fatalf("expected restart reason in body, got %s", rr.Body.String())
+	}
+}
+
+func TestRuntimeShutdownEndpointRejectsNonLoopbackRequests(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/shutdown", strings.NewReader(`{"reason":"restart"}`))
+	req.RemoteAddr = "192.168.1.55:40123"
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	a.srv.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/openspec/changes/harden-runtime-single-endpoint-startup/.openspec.yaml
+++ b/openspec/changes/harden-runtime-single-endpoint-startup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/harden-runtime-single-endpoint-startup/design.md
+++ b/openspec/changes/harden-runtime-single-endpoint-startup/design.md
@@ -1,0 +1,114 @@
+## Context
+
+Cabinet currently has two startup ideas that can conflict:
+
+- normal desktop launches should feel like reopening the same app instance
+- runtime fallback and stress tooling must still support deliberate multi-instance operation
+
+The existing runtime specs cover port fallback (`RUNTIME-CORE-011`), same-data-dir attach (`RUNTIME-CORE-012`), and explicit multi-instance orchestration (`runtime-multi-instance`). The gap is the requested-endpoint case: if `host:port` is already serving a healthy Cabinet runtime, a normal launch should reuse that endpoint instead of silently starting a second process on a fallback port. That behavior must stay compatible with explicit parallel mode and stress tooling.
+
+## Goals / Non-Goals
+
+**Goals:**
+- make default desktop startup singleton-like at the requested endpoint
+- support an explicit “restart the running Cabinet on this endpoint” path
+- distinguish “Cabinet already running here” from generic “port occupied”
+- preserve intentional parallel/multi-instance workflows as an explicit override
+- make attach vs restart vs fallback decisions deterministic and visible in logs/startup output
+
+**Non-Goals:**
+- removing port fallback for non-Cabinet listeners
+- eliminating parallel-instance support
+- adding generic remote process management beyond the local requested Cabinet endpoint
+- redesigning runtime setup metadata, update flow, or lifecycle logging beyond what is needed to support the startup decision
+
+## Decisions
+
+### 1. Cabinet-on-requested-endpoint is an attach condition, not a fallback condition
+Default startup should first evaluate whether the requested endpoint is already serving a healthy Cabinet runtime. If yes, the launcher should attach/open that endpoint and exit without starting a new server process.
+
+Why:
+- matches user expectation for “start Cabinet again”
+- prevents accidental review-lane drift such as `17882` silently becoming `17883`
+- keeps one endpoint stable for demo/review lanes
+
+Alternative considered:
+- always fallback on any occupied port
+  - rejected because it treats “Cabinet already running” the same as “some unrelated listener exists,” which is the root of the accidental duplicate-start problem
+
+### 2. Generic port occupation still uses deterministic fallback
+If the requested endpoint is occupied by a non-Cabinet listener, startup should continue using the existing fallback-port behavior.
+
+Why:
+- preserves current runtime-core behavior for local development and automation
+- avoids introducing unnecessary startup failures when a different process happens to own the requested port
+
+Alternative considered:
+- fail fast on any occupied requested port
+  - rejected because it would break existing local/dev workflows and reduce resilience
+
+### 3. Parallel mode must be explicit and observable
+Parallel startup should remain available only as an explicit operator/test choice, and that choice should bypass singleton attach behavior.
+
+Why:
+- prevents accidental multi-instance starts
+- keeps stress tooling and isolated-lane automation viable
+- aligns default product behavior with desktop expectations while preserving test infrastructure
+
+Alternative considered:
+- infer parallel intent from different data dirs alone
+  - rejected because it is too implicit and easy to trigger accidentally
+
+### 4. Restart must be an explicit startup action, not a side effect
+Restarting an existing Cabinet runtime on the requested endpoint should require an explicit startup option, and that path should:
+
+- confirm the requested endpoint is a healthy Cabinet runtime
+- resolve the active PID from runtime lifecycle metadata / pid file
+- stop the old process cleanly when possible, then force-terminate if needed
+- wait for the requested port to become free before starting the new process
+
+Why:
+- restarting is materially different from attach/reuse and should never happen implicitly
+- it keeps the requested endpoint stable for review lanes while still allowing a “replace old with new” workflow
+
+Alternative considered:
+- always restart instead of attach when Cabinet is already running
+  - rejected because it is too destructive for normal desktop launches and would violate expected singleton behavior
+
+### 5. Startup diagnostics should explain which branch won
+Attach/restart/fallback decisions should remain machine-readable and clearly indicate whether startup:
+- same-data-dir metadata
+- requested healthy endpoint
+- restarted existing endpoint
+- fallback port
+
+Why:
+- makes demo/support investigations faster
+- reduces ambiguity when reviewing runtime behavior from logs or startup output
+
+## Risks / Trade-offs
+
+- [False-positive endpoint detection] → require Cabinet-specific health/runtime checks rather than attaching/restarting against any `200 OK` listener
+- [Over-constraining legitimate multi-instance workflows] → keep explicit parallel mode and orchestration specs as the supported escape hatch
+- [Restart kills the wrong process] → only allow restart when the requested endpoint verifies as Cabinet and the PID/lifecycle metadata line up with that endpoint
+- [Spec overlap between fallback and attach paths] → update runtime-core wording so the decision order is unambiguous: attach/restart-to-Cabinet first, fallback for non-Cabinet listeners second
+- [Launcher/runtime/script drift] → include launch-script behavior in tasks so helper scripts do not reintroduce ad hoc duplicate-start logic
+
+## Migration Plan
+
+1. Update runtime-core and runtime-multi-instance specs to clarify the decision order and explicit parallel override.
+2. Add/adjust startup tests for:
+   - same-data-dir attach
+   - requested-endpoint Cabinet attach
+   - requested-endpoint Cabinet restart
+   - non-Cabinet port fallback
+   - explicit parallel bypass
+3. Align launcher/runtime helpers and review-lane scripts with the clarified attach/restart behavior.
+4. Roll forward on `develop`; rollback is straightforward by reverting the startup decision change if attach classification causes unexpected regressions.
+
+## Open Questions
+
+- Should “Cabinet already running here” detection rely on `/healthz` only, `/api/runtime`, or both?
+- Should restart be exposed as a CLI flag only, or should demo/helper scripts expose a named `-Restart` wrapper switch too?
+- Should helper scripts like `start-demo2.ps1` continue doing their own preflight port checks once the runtime behavior is fully spec’d and tested?
+- Do we want a user-facing console line that explicitly says “Reused existing Cabinet runtime on requested endpoint” / “Restarted existing Cabinet runtime on requested endpoint” in addition to the structured attach log?

--- a/openspec/changes/harden-runtime-single-endpoint-startup/proposal.md
+++ b/openspec/changes/harden-runtime-single-endpoint-startup/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Cabinet now avoids some accidental duplicate launches, but the runtime behavior is still underspecified when a requested host/port is already serving a healthy Cabinet instance. We need a clear, testable product contract so normal launches prefer reuse of the active endpoint while intentional parallel-instance workflows remain available.
+
+## What Changes
+
+- Clarify runtime startup behavior when the requested endpoint is already serving Cabinet.
+- Define default single-endpoint reuse semantics for normal launches.
+- Add an explicit restart option that stops the currently running Cabinet on the requested endpoint and starts the new process on that same endpoint.
+- Define the explicit parallel-instance override path so intentional multi-instance runs still work.
+- Tighten startup diagnostics so attach vs restart vs fallback decisions are observable and deterministic.
+- Align launcher/runtime/demo scripts with the runtime singleton decision instead of relying on ad hoc port-in-use checks.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `general/runtime-core`: refine startup behavior so a healthy requested Cabinet endpoint is reused by default instead of starting a second runtime or silently port-falling back.
+- `general/runtime-multi-instance`: clarify that parallel-instance behavior is an explicit opt-in path and must not weaken the default singleton/startup attach contract.
+
+## Impact
+
+- `cmd/cabinet` startup decision flow and attach diagnostics
+- runtime restart/termination path for existing Cabinet processes
+- runtime port negotiation / endpoint health decision logic
+- launch scripts such as `scripts/runtime/start-demo2.ps1`
+- runtime tests covering attach, fallback, and explicit parallel mode
+- OpenSpec runtime requirements for launcher behavior

--- a/openspec/changes/harden-runtime-single-endpoint-startup/specs/runtime-core/spec.md
+++ b/openspec/changes/harden-runtime-single-endpoint-startup/specs/runtime-core/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime startup SHALL negotiate fallback port when requested port is occupied by a non-Cabinet listener
+When the requested runtime port is already in use by a non-Cabinet process, startup MUST bind deterministically to the next available port within the fallback scan window and continue serving.
+
+#### Scenario: Requested port occupied by another process
+- **GIVEN** runtime attempts to bind `host:requested_port`
+- **AND** that endpoint is occupied by another process that is not a healthy Cabinet runtime
+- **WHEN** startup bind resolution occurs
+- **THEN** runtime MUST attempt fallback ports (`requested_port+1 ... requested_port+N`) and bind the first available address
+- **AND** startup output MUST preserve `requested_port` and report actual `resolved_port`
+- **AND** resolved `/healthz` endpoint on the fallback URL MUST return `200`
+
+### Requirement: Runtime startup SHALL use PID-only lock file, attach to setup-metadata runtime, and reuse or restart a healthy requested Cabinet endpoint deterministically
+Runtime startup MUST keep `cabinet.pid` as PID-only lock signal, MUST resolve attach/open target from runtime setup metadata (`cabinet.json`) instead of storing endpoint metadata in the PID file, and MUST reuse a healthy Cabinet runtime already serving the requested endpoint before starting a second server process unless explicit restart behavior is requested.
+
+#### Scenario: Attach to already-running runtime in same data directory
+- **GIVEN** startup data directory contains `cabinet.pid` with an alive PID and `cabinet.json` runtime metadata (`runtime.resolvedUrl` or `meta.currentUrl`) for a healthy endpoint
+- **WHEN** Cabinet launcher starts again for the same data directory
+- **THEN** startup MUST attach to the existing runtime URL and open/attach the browser target without starting a second server process
+- **AND** runtime logs MUST emit a deterministic attach line containing `url`, `pid`, `data_dir`, and resolved port
+
+#### Scenario: Reuse healthy Cabinet runtime already serving requested endpoint
+- **GIVEN** Cabinet launcher starts for a requested `host:port`
+- **AND** the requested endpoint is already serving a healthy Cabinet runtime
+- **AND** explicit parallel mode is not enabled
+- **AND** explicit restart mode is not enabled
+- **WHEN** startup attach resolution executes
+- **THEN** startup MUST reuse the requested endpoint instead of starting a new server process
+- **AND** runtime logs MUST emit a deterministic attach line describing requested-endpoint reuse
+- **AND** startup MUST NOT silently fall through to a fallback port in this case
+
+#### Scenario: Restart healthy Cabinet runtime already serving requested endpoint
+- **GIVEN** Cabinet launcher starts for a requested `host:port`
+- **AND** the requested endpoint is already serving a healthy Cabinet runtime
+- **AND** explicit restart mode is enabled
+- **WHEN** startup restart resolution executes
+- **THEN** startup MUST identify the active Cabinet PID from runtime lifecycle metadata and/or pid file
+- **AND** startup MUST stop the existing Cabinet process before binding the new runtime
+- **AND** startup MUST wait until the requested endpoint is no longer in use before starting the replacement runtime
+- **AND** startup logs MUST emit deterministic restart diagnostics containing the requested endpoint, prior PID, and restart outcome
+- **AND** the replacement runtime MUST bind the originally requested port rather than silently port-falling back
+
+#### Scenario: Restart requested but endpoint is not a healthy Cabinet runtime
+- **GIVEN** Cabinet launcher starts for a requested `host:port`
+- **AND** explicit restart mode is enabled
+- **AND** the requested endpoint is occupied by a non-Cabinet listener or cannot be verified as a healthy Cabinet runtime
+- **WHEN** startup restart resolution executes
+- **THEN** startup MUST NOT terminate the existing listener
+- **AND** runtime MUST fail with an actionable restart validation error instead of force-replacing an unknown process
+
+#### Scenario: Explicit parallel mode bypasses requested-endpoint reuse
+- **GIVEN** Cabinet launcher starts for a requested `host:port`
+- **AND** the requested endpoint is already serving a healthy Cabinet runtime
+- **AND** explicit parallel mode is enabled
+- **WHEN** startup attach resolution executes
+- **THEN** startup MUST bypass requested-endpoint reuse behavior
+- **AND** runtime MAY continue into explicit parallel/fallback startup behavior consistent with the launch request
+
+#### Scenario: Stale PID recovery
+- **GIVEN** startup data directory contains stale `cabinet.pid` or metadata endpoint health check fails
+- **WHEN** attach resolution executes
+- **THEN** runtime MUST remove the stale PID file and continue with fresh startup
+- **AND** no attach/open action MUST occur for stale lock state
+
+#### Scenario: Startup reporting includes endpoint-occupied status
+- **GIVEN** Cabinet launcher starts for a requested `host:port`
+- **WHEN** startup preflight determines whether the requested endpoint is free, occupied by Cabinet, or occupied by another listener
+- **THEN** startup diagnostics MUST report that endpoint status
+- **AND** when attach or restart behavior is selected, diagnostics MUST report the selected action before runtime start/exit completes

--- a/openspec/changes/harden-runtime-single-endpoint-startup/specs/runtime-multi-instance/spec.md
+++ b/openspec/changes/harden-runtime-single-endpoint-startup/specs/runtime-multi-instance/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Data/profile isolation MUST be enforced per instance under explicit parallel mode
+Parallel instances SHALL run with distinct runtime data directories and lock files to prevent cross-instance overwrite, and multi-instance behavior SHALL only occur under an explicit parallel/start-orchestration path.
+
+#### Scenario: Isolated data roots for orchestrated parallel launch
+- **GIVEN** orchestrator launches parallel instances in explicit multi-instance mode
+- **WHEN** each process starts
+- **THEN** each instance MUST use a unique `CABINET_DATA_DIR`
+- **AND** each instance MUST use distinct runtime lock/lifecycle files under that data root
+
+#### Scenario: Normal desktop launch does not imply multi-instance mode
+- **GIVEN** a normal Cabinet desktop launch requests a host/port already serving a healthy Cabinet runtime
+- **WHEN** explicit parallel mode is not enabled
+- **THEN** the launch MUST follow runtime-core singleton attach behavior rather than creating another parallel runtime
+
+#### Scenario: Explicit restart does not count as multi-instance mode
+- **GIVEN** a Cabinet launch requests restart of an already-running healthy Cabinet endpoint
+- **WHEN** explicit parallel mode is not enabled
+- **THEN** the restart flow MUST replace the running endpoint instance rather than creating a second concurrent runtime

--- a/openspec/changes/harden-runtime-single-endpoint-startup/tasks.md
+++ b/openspec/changes/harden-runtime-single-endpoint-startup/tasks.md
@@ -1,0 +1,25 @@
+## 1. Startup Decision Contract
+
+- [x] 1.1 Add/adjust runtime startup tests that distinguish healthy Cabinet endpoint reuse from generic port-occupied fallback behavior.
+- [x] 1.2 Add explicit-parallel-mode tests proving requested-endpoint reuse is bypassed only when parallel startup is intentionally enabled.
+- [x] 1.3 Add restart-mode tests proving a healthy requested Cabinet endpoint can be stopped and replaced on the same port.
+- [x] 1.4 Verify attach/restart diagnostics clearly identify same-data-dir attach, requested-endpoint reuse, requested-endpoint restart, and fallback-port outcomes.
+
+## 2. Runtime / Launcher Implementation
+
+- [x] 2.1 Refine startup decision ordering so Cabinet checks for an existing healthy requested endpoint before port fallback.
+- [x] 2.2 Keep non-Cabinet port occupation on the existing deterministic fallback path.
+- [x] 2.3 Add an explicit restart startup option that resolves the active Cabinet PID, stops the old process, waits for the requested port to clear, and starts the replacement runtime on the same endpoint.
+- [x] 2.4 Align launcher/browser-open behavior so reuse or restart of an existing requested endpoint does not start a second server process.
+
+## 3. Parallel / Tooling Alignment
+
+- [x] 3.1 Make explicit parallel-mode handling consistent across CLI/runtime code and helper launch scripts.
+- [x] 3.2 Update review/demo lane startup helpers to expose restart behavior and rely on the runtime singleton contract instead of ad hoc duplicate-start checks where appropriate.
+- [x] 3.3 Validate multi-instance/stress tooling still uses isolated data roots and does not regress under the stricter default singleton behavior.
+
+## 4. Verification and Rollout
+
+- [x] 4.1 Run targeted runtime tests covering same-data-dir attach, requested-endpoint reuse, requested-endpoint restart, non-Cabinet fallback, and explicit parallel override.
+- [x] 4.2 Run targeted launcher/script verification for demo/startup workflows affected by the new attach/restart decision path.
+- [x] 4.3 Update implementation notes/checkpoints with the final attach/restart/fallback behavior and example diagnostics.

--- a/scripts/runtime/start-demo2.ps1
+++ b/scripts/runtime/start-demo2.ps1
@@ -1,7 +1,9 @@
 param(
   [switch]$Rebuild,
   [switch]$FreshData,
-  [switch]$Background
+  [switch]$Background,
+  [switch]$Restart,
+  [switch]$AllowParallel
 )
 
 $ErrorActionPreference = 'Stop'
@@ -29,16 +31,23 @@ if ($FreshData -and (Test-Path $dataDir)) {
   Remove-Item -Recurse -Force $dataDir
 }
 
-New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
-
-$existing = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
-if ($existing) {
-  $pids = @($existing | Select-Object -ExpandProperty OwningProcess -Unique)
-  throw "Port $port is already in use by PID(s): $($pids -join ', '). Stop the existing listener first."
+if ($Restart -and $AllowParallel) {
+  throw 'Restart cannot be combined with AllowParallel.'
 }
 
+$mode = 'reuse-or-attach'
+$parallelNote = 'singleton endpoint guard enabled'
+if ($Restart) {
+  $mode = 'restart'
+}
+if ($AllowParallel) {
+  $mode = 'parallel'
+  $parallelNote = 'explicit parallel mode enabled'
+}
+
+New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+
 $args = @(
-  '--allow-parallel',
   '--no-open-browser',
   '--data-dir', $dataDir,
   '--profile', $profile,
@@ -46,10 +55,19 @@ $args = @(
   '--port', $port
 )
 
+if ($Restart) {
+  $args += '--restart'
+}
+if ($AllowParallel) {
+  $args += '--allow-parallel'
+}
+
 Write-Host "[start-demo2] Executable: $exePath"
 Write-Host "[start-demo2] Data dir:   $dataDir"
 Write-Host "[start-demo2] Port:       $port"
 Write-Host "[start-demo2] URL:        $url"
+Write-Host "[start-demo2] Mode:       $mode"
+Write-Host "[start-demo2] Guard:      $parallelNote"
 
 if ($Background) {
   $proc = Start-Process -FilePath $exePath -ArgumentList $args -WorkingDirectory $repoRoot -PassThru

--- a/scripts/runtime/start-exploration-clerk.ps1
+++ b/scripts/runtime/start-exploration-clerk.ps1
@@ -3,6 +3,8 @@ param(
   [switch]$Rebuild,
   [switch]$FreshData,
   [switch]$Background,
+  [switch]$Restart,
+  [switch]$AllowParallel,
   [int]$Port = 17883
 )
 
@@ -45,16 +47,13 @@ try {
     Remove-Item -Recurse -Force $dataDir
   }
 
-  New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
-
-  $existing = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
-  if ($existing) {
-    $pids = @($existing | Select-Object -ExpandProperty OwningProcess -Unique)
-    throw "Port $Port is already in use by PID(s): $($pids -join ', '). Stop the existing listener first."
+  if ($Restart -and $AllowParallel) {
+    throw 'Restart cannot be combined with AllowParallel.'
   }
 
+  New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+
   $args = @(
-    '--allow-parallel',
     '--no-open-browser',
     '--data-dir', $dataDir,
     '--profile', $profile,
@@ -62,10 +61,28 @@ try {
     '--port', $Port
   )
 
+  $mode = 'reuse-or-attach'
+  $parallelNote = 'singleton endpoint guard enabled'
+  if ($Restart) {
+    $mode = 'restart'
+  }
+  if ($AllowParallel) {
+    $mode = 'parallel'
+    $parallelNote = 'explicit parallel mode enabled'
+  }
+  if ($Restart) {
+    $args += '--restart'
+  }
+  if ($AllowParallel) {
+    $args += '--allow-parallel'
+  }
+
   Write-Host "[start-exploration-clerk] Executable: $exePath"
   Write-Host "[start-exploration-clerk] Data dir:   $dataDir"
   Write-Host "[start-exploration-clerk] Port:       $Port"
   Write-Host "[start-exploration-clerk] URL:        $url"
+  Write-Host "[start-exploration-clerk] Mode:       $mode"
+  Write-Host "[start-exploration-clerk] Guard:      $parallelNote"
   Write-Host '[start-exploration-clerk] Effective auth env:'
   Write-Host '  CABINET_AUTH_IDENTITY_MODE=clerk'
   Write-Host ('  VITE_CLERK_PUBLISHABLE_KEY=' + $ClerkPublishableKey)

--- a/scripts/runtime/start-exploration-local.ps1
+++ b/scripts/runtime/start-exploration-local.ps1
@@ -2,6 +2,8 @@ param(
   [switch]$Rebuild,
   [switch]$FreshData,
   [switch]$Background,
+  [switch]$Restart,
+  [switch]$AllowParallel,
   [int]$Port = 17880
 )
 
@@ -29,16 +31,13 @@ if ($FreshData -and (Test-Path $dataDir)) {
   Remove-Item -Recurse -Force $dataDir
 }
 
-New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
-
-$existing = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
-if ($existing) {
-  $pids = @($existing | Select-Object -ExpandProperty OwningProcess -Unique)
-  throw "Port $Port is already in use by PID(s): $($pids -join ', '). Stop the existing listener first."
+if ($Restart -and $AllowParallel) {
+  throw 'Restart cannot be combined with AllowParallel.'
 }
 
+New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
+
 $args = @(
-  '--allow-parallel',
   '--no-open-browser',
   '--data-dir', $dataDir,
   '--profile', $profile,
@@ -46,10 +45,28 @@ $args = @(
   '--port', $Port
 )
 
+$mode = 'reuse-or-attach'
+$parallelNote = 'singleton endpoint guard enabled'
+if ($Restart) {
+  $mode = 'restart'
+}
+if ($AllowParallel) {
+  $mode = 'parallel'
+  $parallelNote = 'explicit parallel mode enabled'
+}
+if ($Restart) {
+  $args += '--restart'
+}
+if ($AllowParallel) {
+  $args += '--allow-parallel'
+}
+
 Write-Host "[start-exploration-local] Executable: $exePath"
 Write-Host "[start-exploration-local] Data dir:   $dataDir"
 Write-Host "[start-exploration-local] Port:       $Port"
 Write-Host "[start-exploration-local] URL:        $url"
+Write-Host "[start-exploration-local] Mode:       $mode"
+Write-Host "[start-exploration-local] Guard:      $parallelNote"
 Write-Host '[start-exploration-local] Expected first-run path:'
 Write-Host '  1. Complete setup wizard'
 Write-Host '  2. Choose Auth Mode = local'

--- a/scripts/start-cabinet-lan.ps1
+++ b/scripts/start-cabinet-lan.ps1
@@ -1,7 +1,9 @@
 param(
   [string]$RepoRoot = "d:\projects\collectors-tech\cabinet",
   [string]$LanIP = "192.168.1.8",
-  [int]$Port = 17880
+  [int]$Port = 17880,
+  [switch]$Restart,
+  [switch]$AllowParallel
 )
 
 $ErrorActionPreference = "Stop"
@@ -11,8 +13,9 @@ if (-not (Test-Path $exePath)) {
   throw "Cabinet executable not found: $exePath"
 }
 
-Get-Process cabinet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-Start-Sleep -Milliseconds 600
+if ($Restart -and $AllowParallel) {
+  throw "Restart cannot be combined with AllowParallel."
+}
 
 $env:CABINET_BIND_MODE = "lan"
 $env:CABINET_HOST = "0.0.0.0"
@@ -20,7 +23,19 @@ $env:CABINET_PORT = "$Port"
 $env:CABINET_WEBAUTHN_RP_ID = $LanIP
 $env:CABINET_WEBAUTHN_ORIGIN = "http://$LanIP`:$Port"
 
-Start-Process -FilePath $exePath -WorkingDirectory $RepoRoot | Out-Null
+$args = @()
+$mode = "reuse-or-attach"
+if ($Restart) {
+  $args += "--restart"
+  $mode = "restart"
+}
+if ($AllowParallel) {
+  $args += "--allow-parallel"
+  $mode = "parallel"
+}
+
+Write-Output "Cabinet LAN launcher mode=$mode port=$Port host=0.0.0.0"
+Start-Process -FilePath $exePath -ArgumentList $args -WorkingDirectory $RepoRoot | Out-Null
 Start-Sleep -Seconds 2
 
 $proc = Get-Process cabinet -ErrorAction SilentlyContinue | Select-Object -First 1


### PR DESCRIPTION
## Summary
- add requested-endpoint restart handoff with local shutdown plus guarded PID termination fallback
- report runtime endpoint occupancy and restart action during startup
- align demo/review launcher scripts with the singleton-or-restart runtime contract

## Testing
- go test ./cmd/cabinet -count=1
- go test ./internal/app -run "TestRunFallsBackToNextAvailablePortWhenRequestedPortIsOccupied|TestRuntimeShutdownEndpoint(AllowsLoopbackPost|RejectsNonLoopbackRequests)|TestRuntimeLANModeExposesBindMetadataAndHealth" -count=1
- npm.cmd run build
- ./scripts/build-cabinet.ps1
- openspec validate harden-runtime-single-endpoint-startup --type change --strict --no-interactive
- git diff --check
