### PR TITLE
#610 fix(runtime): clarify singleton reuse on second launch

### DIFF
--- a/cmd/cabinet/main.go
+++ b/cmd/cabinet/main.go
@@ -66,6 +66,7 @@ func main() {
 		log.Printf("runtime attach check skipped: %v", attachErr)
 	} else if attachDecision.Attach {
 		log.Printf("%s", runtimeAttachLogLine(attachDecision, cfg.DataDir))
+		log.Printf("%s", runtimeAttachUserMessage(attachDecision))
 		if !browserLaunch.Enabled {
 			if strings.TrimSpace(browserLaunch.DisableNote) != "" {
 				log.Printf("%s", browserLaunch.DisableNote)
@@ -83,6 +84,7 @@ func main() {
 	}
 	if requestedAttachDecision.Attach {
 		log.Printf("%s", runtimeAttachLogLine(requestedAttachDecision, cfg.DataDir))
+		log.Printf("%s", runtimeAttachUserMessage(requestedAttachDecision))
 		if !browserLaunch.Enabled {
 			if strings.TrimSpace(browserLaunch.DisableNote) != "" {
 				log.Printf("%s", browserLaunch.DisableNote)

--- a/cmd/cabinet/main_cli_test.go
+++ b/cmd/cabinet/main_cli_test.go
@@ -85,3 +85,23 @@ func TestRuntimeAttachLogLineIncludesURLPIDAndResolvedPort(t *testing.T) {
 		}
 	}
 }
+
+func TestRuntimeAttachUserMessageForRequestedEndpointReuse(t *testing.T) {
+	t.Parallel()
+
+	line := runtimeAttachUserMessage(runtimeAttachDecision{
+		Attach: true,
+		URL:    "http://127.0.0.1:19090/",
+		Reason: "requested_endpoint_healthy",
+	})
+	for _, token := range []string{
+		"Cabinet is already running",
+		"http://127.0.0.1:19090/",
+		"--restart",
+		"--allow-parallel",
+	} {
+		if !strings.Contains(line, token) {
+			t.Fatalf("expected token %q in line %q", token, line)
+		}
+	}
+}

--- a/cmd/cabinet/runtime_attach.go
+++ b/cmd/cabinet/runtime_attach.go
@@ -170,6 +170,27 @@ func runtimeAttachLogLine(decision runtimeAttachDecision, dataDir string) string
 	)
 }
 
+func runtimeAttachUserMessage(decision runtimeAttachDecision) string {
+	reason := attachReasonOrDefault(decision.Reason)
+	switch reason {
+	case "requested_endpoint_healthy":
+		return fmt.Sprintf(
+			"Cabinet is already running on %s. Reusing the existing instance and exiting. Use --restart to replace it or --allow-parallel to run another instance.",
+			strings.TrimSpace(decision.URL),
+		)
+	case "same_data_dir":
+		return fmt.Sprintf(
+			"Cabinet is already running for this data directory at %s. Reusing the existing instance and exiting.",
+			strings.TrimSpace(decision.URL),
+		)
+	default:
+		return fmt.Sprintf(
+			"Cabinet reused the existing runtime at %s and exited.",
+			strings.TrimSpace(decision.URL),
+		)
+	}
+}
+
 func resolveRequestedRuntimeAttach(
 	cfg config.Config,
 	allowParallel bool,


### PR DESCRIPTION
## Summary
- add a clear user-facing message when a second default launch reuses an already-running Cabinet instance
- point operators to `--restart` and `--allow-parallel` from that reuse path
- add focused runtime coverage for the new reuse message

## Testing
- go test ./cmd/cabinet -run "Test(RuntimeAttachUserMessageForRequestedEndpointReuse|ResolveRequestedRuntimeAttachWhenEndpointHealthyAndParallelDisabled|ResolveRequestedRuntimeAttachSkipsAttachWhenParallelAllowed|RuntimeAttachLogLineIncludesURLPIDAndResolvedPort)" -count=1
- go test ./cmd/cabinet -count=1
- live smoke: first start holds port, second default launch exits, first PID keeps serving, and second-launch logs include `Cabinet is already running`, `--restart`, and `--allow-parallel`
- git diff --check
