### PR TITLE
#599 feat(settings): add operations log export workflow

### DIFF
--- a/ui.web/cypress/e2e/settings/operations/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/operations/spec.cy.ts
@@ -809,4 +809,48 @@ describe('settings/operations', () => {
       'CSV import applied successfully.'
     )
   })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-013 exports diagnostic logs without leaving the Operations route', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-logs-export',
+        build_date: '2026-04-23',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: false,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('GET', '/api/logs/export', {
+      statusCode: 200,
+      body: '{"entries":[{"level":"info","message":"[REDACTED]"}]}',
+      headers: {
+        'content-type': 'application/json',
+      },
+    }).as('exportLogs')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-export-logs"]').click()
+    cy.wait('@exportLogs')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-logs-status"]').should(
+      'contain',
+      'Exported runtime logs successfully.'
+    )
+    cy.get('[data-testid="settings-operations-logs-preview"]').should(
+      'contain',
+      '[REDACTED]'
+    )
+  })
 })

--- a/ui.web/src/features/settings/operations/index.tsx
+++ b/ui.web/src/features/settings/operations/index.tsx
@@ -114,6 +114,10 @@ export function SettingsOperations() {
   const [csvStatus, setCsvStatus] = useState<string>('No CSV import or export action has run yet.')
   const [csvTone, setCsvTone] = useState<'default' | 'destructive'>('default')
   const [csvSummary, setCsvSummary] = useState<ImportDryRunSummaryResponse | null>(null)
+  const [logsExportPending, setLogsExportPending] = useState(false)
+  const [logsStatus, setLogsStatus] = useState<string>('No diagnostics export has run yet.')
+  const [logsTone, setLogsTone] = useState<'default' | 'destructive'>('default')
+  const [logsPreview, setLogsPreview] = useState<string | null>(null)
   const [importDefaultAction, setImportDefaultAction] =
     useState<ImportApplyAction>('merge')
   const [importCsvDefaultAction, setImportCsvDefaultAction] =
@@ -270,6 +274,27 @@ export function SettingsOperations() {
     }
   }, [])
 
+  const runExportLogs = useCallback(async () => {
+    setLogsExportPending(true)
+    setLogsTone('default')
+    try {
+      const response = await fetch('/api/logs/export')
+      if (!response.ok) {
+        throw new Error('failed_to_export_logs')
+      }
+      const text = await response.text()
+      const preview = text.trim()
+      setLogsPreview(preview || null)
+      setLogsStatus('Exported runtime logs successfully.')
+    } catch {
+      setLogsPreview(null)
+      setLogsTone('destructive')
+      setLogsStatus('Runtime logs export failed.')
+    } finally {
+      setLogsExportPending(false)
+    }
+  }, [])
+
   const runImportCsvDryRun = useCallback(async () => {
     setImportCsvDryRunPending(true)
     setCsvSummary(null)
@@ -350,6 +375,7 @@ export function SettingsOperations() {
     exportCsvPending ||
     importCsvDryRunPending ||
     importCsvApplyPending
+  const logsActionsDisabled = loading || Boolean(error) || logsExportPending
 
   return (
     <ContentSection
@@ -415,6 +441,45 @@ export function SettingsOperations() {
                 ? 'Recovery required'
               : 'No recovery required'}
           </p>
+        </div>
+
+        <div
+          className='rounded-md border p-3 space-y-3'
+          data-testid='settings-operations-logs-card'
+        >
+          <div className='flex flex-wrap items-start justify-between gap-3'>
+            <div>
+              <p className='font-medium'>Diagnostics logs</p>
+              <p className='text-muted-foreground'>
+                Export the current redacted runtime log snapshot for recovery and support workflows.
+              </p>
+            </div>
+            <Button
+              variant='outline'
+              size='sm'
+              data-testid='settings-operations-export-logs'
+              disabled={logsActionsDisabled}
+              onClick={() => {
+                void runExportLogs()
+              }}
+            >
+              {logsExportPending ? 'Exporting Logs…' : 'Export Logs'}
+            </Button>
+          </div>
+
+          <p
+            data-testid='settings-operations-logs-status'
+            className={logsTone === 'destructive' ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}
+          >
+            {logsStatus}
+          </p>
+
+          <div
+            className='rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground'
+            data-testid='settings-operations-logs-preview'
+          >
+            {logsPreview ?? 'No log export preview yet. Export logs to review the current redacted snapshot.'}
+          </div>
         </div>
 
         <div


### PR DESCRIPTION
## Summary
- add a diagnostics log export workflow to Settings > Operations
- keep feedback route-stable with status text plus a redacted preview block
- add test-first Cypress coverage for the new operations workflow

## Testing
- npm.cmd run build
- npx.cmd eslint cypress/e2e/settings/operations/spec.cy.ts src/features/settings/operations/index.tsx
- ./scripts/build-cabinet.ps1
- git diff --check

## Note
- local Cypress execution is currently blocked by the Windows Cypress binary/runtime issue in this shell (`Cypress.exe: bad option: --smoke-test --ping=...`), so the spec was updated test-first but could not be executed locally here.
