### PR TITLE
#599 feat(settings): add runtime setup import workflow

### DIFF
--- a/ui.web/cypress/e2e/settings/operations/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/operations/spec.cy.ts
@@ -853,4 +853,107 @@ describe('settings/operations', () => {
       '[REDACTED]'
     )
   })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-014 imports runtime setup config without leaving the Operations route', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-setup-import',
+        build_date: '2026-04-23',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: true,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('POST', '/api/runtime/setup-import', (req) => {
+      expect(req.body).to.deep.equal({
+        source_path: 'C:\\cabinet\\recovery\\setup-import-source.json',
+      })
+      req.reply({
+        statusCode: 200,
+        body: {
+          ok: true,
+          setup_required: false,
+          instance_name: 'Imported Recovery Instance',
+          profile_key: 'imported-recovery',
+          config_path: 'C:\\cabinet\\data\\cabinet.json',
+          runtime_url: 'http://127.0.0.1:17880',
+          runtime_port: 17880,
+        },
+      })
+    }).as('setupImport')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-setup-import-source"]')
+      .clear()
+      .type('C:\\cabinet\\recovery\\setup-import-source.json')
+    cy.get('[data-testid="settings-operations-setup-import-submit"]').click()
+    cy.wait('@setupImport')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-setup-import-status"]').should(
+      'contain',
+      'Runtime setup imported successfully.'
+    )
+    cy.get('[data-testid="settings-operations-setup-import-summary"]').should(
+      'contain',
+      'Imported Recovery Instance'
+    )
+    cy.get('[data-testid="settings-operations-setup-import-summary"]').should(
+      'contain',
+      'imported-recovery'
+    )
+  })
+
+  it('UI-SCREEN-SETTINGS-OPERATIONS-015 reports runtime setup import failure without leaving the Operations route', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-setup-import-error',
+        build_date: '2026-04-23',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: true,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('POST', '/api/runtime/setup-import', {
+      statusCode: 400,
+      body: {
+        error: 'failed_to_import_setup_config',
+      },
+    }).as('setupImport')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+
+    cy.get('[data-testid="settings-operations-setup-import-source"]')
+      .clear()
+      .type('C:\\cabinet\\recovery\\missing.json')
+    cy.get('[data-testid="settings-operations-setup-import-submit"]').click()
+    cy.wait('@setupImport')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-setup-import-status"]').should(
+      'contain',
+      'Runtime setup import failed.'
+    )
+  })
 })

--- a/ui.web/src/features/settings/operations/index.tsx
+++ b/ui.web/src/features/settings/operations/index.tsx
@@ -26,6 +26,16 @@ type RuntimeRecoveryResponse = {
   recovery_required?: boolean
 }
 
+type RuntimeSetupImportResponse = {
+  ok?: boolean
+  setup_required?: boolean
+  instance_name?: string
+  profile_key?: string
+  config_path?: string
+  runtime_url?: string
+  runtime_port?: number
+}
+
 type ExportSnapshotResponse = {
   schema_version?: number
   exported_at?: string
@@ -89,6 +99,16 @@ export function SettingsOperations() {
   const [error, setError] = useState<string | null>(null)
   const [runtimeInfo, setRuntimeInfo] = useState<RuntimeResponse | null>(null)
   const [recoveryInfo, setRecoveryInfo] = useState<RuntimeRecoveryResponse | null>(null)
+  const [setupImportSourcePath, setSetupImportSourcePath] = useState('')
+  const [setupImportPending, setSetupImportPending] = useState(false)
+  const [setupImportStatus, setSetupImportStatus] = useState(
+    'No runtime setup import has been run yet.'
+  )
+  const [setupImportTone, setSetupImportTone] = useState<'default' | 'destructive'>(
+    'default'
+  )
+  const [setupImportSummary, setSetupImportSummary] =
+    useState<RuntimeSetupImportResponse | null>(null)
   const [dataStatus, setDataStatus] = useState<string>('No import or export action has run yet.')
   const [dataTone, setDataTone] = useState<'default' | 'destructive'>('default')
   const [exportPending, setExportPending] = useState(false)
@@ -295,6 +315,33 @@ export function SettingsOperations() {
     }
   }, [])
 
+  const runSetupImport = useCallback(async () => {
+    setSetupImportPending(true)
+    setSetupImportTone('default')
+    try {
+      const response = await fetch('/api/runtime/setup-import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          source_path: setupImportSourcePath.trim(),
+        }),
+      })
+      if (!response.ok) {
+        throw new Error('failed_to_import_runtime_setup')
+      }
+      const payload = (await response.json()) as RuntimeSetupImportResponse
+      setSetupImportSummary(payload)
+      setSetupImportStatus('Runtime setup imported successfully.')
+      await loadOperations()
+    } catch {
+      setSetupImportSummary(null)
+      setSetupImportTone('destructive')
+      setSetupImportStatus('Runtime setup import failed.')
+    } finally {
+      setSetupImportPending(false)
+    }
+  }, [loadOperations, setupImportSourcePath])
+
   const runImportCsvDryRun = useCallback(async () => {
     setImportCsvDryRunPending(true)
     setCsvSummary(null)
@@ -376,6 +423,8 @@ export function SettingsOperations() {
     importCsvDryRunPending ||
     importCsvApplyPending
   const logsActionsDisabled = loading || Boolean(error) || logsExportPending
+  const setupImportActionsDisabled =
+    loading || Boolean(error) || setupImportPending || setupImportSourcePath.trim() === ''
 
   return (
     <ContentSection
@@ -441,6 +490,62 @@ export function SettingsOperations() {
                 ? 'Recovery required'
               : 'No recovery required'}
           </p>
+
+          <div className='space-y-2 border-t pt-3'>
+            <label
+              htmlFor='settings-operations-setup-import-source'
+              className='text-sm font-medium'
+            >
+              Runtime setup import
+            </label>
+            <p className='text-muted-foreground'>
+              Import a runtime setup config from disk to recover a missing or damaged local setup.
+            </p>
+            <Input
+              id='settings-operations-setup-import-source'
+              data-testid='settings-operations-setup-import-source'
+              value={setupImportSourcePath}
+              onChange={(event) => {
+                setSetupImportSourcePath(event.target.value)
+                setSetupImportSummary(null)
+              }}
+              placeholder='C:\\cabinet\\recovery\\setup-import-source.json'
+            />
+            <div className='flex justify-end'>
+              <Button
+                variant='outline'
+                size='sm'
+                data-testid='settings-operations-setup-import-submit'
+                disabled={setupImportActionsDisabled}
+                onClick={() => {
+                  void runSetupImport()
+                }}
+              >
+                {setupImportPending ? 'Importing Setup…' : 'Import Setup Config'}
+              </Button>
+            </div>
+            <p
+              data-testid='settings-operations-setup-import-status'
+              className={setupImportTone === 'destructive' ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}
+            >
+              {setupImportStatus}
+            </p>
+            <div
+              className='rounded-md border bg-muted/20 p-3 text-sm text-muted-foreground'
+              data-testid='settings-operations-setup-import-summary'
+            >
+              {setupImportSummary ? (
+                <div className='space-y-1'>
+                  <p>Instance: {setupImportSummary.instance_name || 'Unknown instance'}</p>
+                  <p>Profile: {setupImportSummary.profile_key || 'Unknown profile'}</p>
+                  <p>Config: {setupImportSummary.config_path || 'Unknown config path'}</p>
+                  <p>Runtime URL: {setupImportSummary.runtime_url || 'Unknown runtime URL'}</p>
+                </div>
+              ) : (
+                <p>No imported setup summary yet.</p>
+              )}
+            </div>
+          </div>
         </div>
 
         <div


### PR DESCRIPTION
## Summary
- add runtime setup import controls to Settings > Operations
- keep import success/failure feedback route-stable with imported-config summary details
- extend the Operations recovery coverage for setup import success and failure paths

## Testing
- npm.cmd run build
- npx.cmd eslint cypress/e2e/settings/operations/spec.cy.ts src/features/settings/operations/index.tsx
- git diff --check

## Note
- local Cypress execution remains blocked by the current Windows Cypress binary/runtime problem in this shell (`Cypress.exe: bad option: --smoke-test --ping=...`), so the spec was updated test-first but could not be executed locally here.
