### PR TITLE
#599 feat(settings): add operations queue controls

### DIFF
--- a/internal/app/ui_template_contract_test.go
+++ b/internal/app/ui_template_contract_test.go
@@ -395,6 +395,43 @@ func TestInventorySavedViewsAndFilterContract(t *testing.T) {
 	}
 }
 
+func TestSettingsOperationsQueueControlsContract(t *testing.T) {
+	t.Parallel()
+
+	b, err := os.ReadFile("../../ui.web/src/features/settings/operations/index.tsx")
+	if err != nil {
+		t.Fatalf("read settings operations: %v", err)
+	}
+	src := string(b)
+
+	required := []string{
+		"useProfileSettings",
+		"scanner_schedule",
+		"operations_queue_resume_schedule",
+		"settings-operations-queue-card",
+		"settings-operations-queue-status",
+		"settings-operations-queue-pause",
+		"settings-operations-queue-resume",
+		"Workers paused.",
+		"Workers scheduled:",
+	}
+	for _, token := range required {
+		if !strings.Contains(src, token) {
+			t.Fatalf("settings operations missing queue control token: %s", token)
+		}
+	}
+
+	forbidden := []string{
+		"Pause Workers (Coming soon)",
+		"Resume Workers (Coming soon)",
+	}
+	for _, token := range forbidden {
+		if strings.Contains(src, token) {
+			t.Fatalf("settings operations still contains placeholder queue control token: %s", token)
+		}
+	}
+}
+
 func TestI18nShellSharedLabelsContract(t *testing.T) {
 	t.Parallel()
 

--- a/ui.web/cypress/e2e/settings/operations/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/operations/spec.cy.ts
@@ -121,6 +121,99 @@ describe('settings/operations', () => {
     )
   })
 
+  it('UI-SCREEN-SETTINGS-OPERATIONS-002A pauses and resumes worker scheduling without route reload', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-queue-controls',
+        build_date: '2026-04-23',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: false,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: {
+        id: 'profile-ops-queue',
+      },
+    }).as('activeProfile')
+    cy.intercept('GET', '/api/profiles/profile-ops-queue/settings', {
+      statusCode: 200,
+      body: {
+        settings: {
+          scanner_schedule: '0 */6 * * *',
+        },
+      },
+    }).as('profileSettings')
+    cy.intercept('PUT', '/api/profiles/profile-ops-queue/settings', (req) => {
+      const settings = req.body?.settings ?? {}
+      if (settings.scanner_schedule === 'manual') {
+        expect(settings.operations_queue_resume_schedule).to.equal('0 */6 * * *')
+        req.reply({
+          statusCode: 200,
+          body: {
+            settings: {
+              scanner_schedule: 'manual',
+              operations_queue_resume_schedule: '0 */6 * * *',
+            },
+          },
+        })
+        return
+      }
+
+      expect(settings.scanner_schedule).to.equal('0 */6 * * *')
+      expect(settings.operations_queue_resume_schedule).to.equal('0 */6 * * *')
+      req.reply({
+        statusCode: 200,
+        body: {
+          settings: {
+            scanner_schedule: '0 */6 * * *',
+            operations_queue_resume_schedule: '0 */6 * * *',
+          },
+        },
+      })
+    }).as('saveProfileSettings')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+    cy.wait('@activeProfile')
+    cy.wait('@profileSettings')
+
+    cy.get('[data-testid="settings-operations-queue-card"]').should(
+      'contain',
+      'Workers scheduled: 0 */6 * * *'
+    )
+    cy.get('[data-testid="settings-operations-queue-resume"]').should('be.disabled')
+
+    cy.get('[data-testid="settings-operations-queue-pause"]').click()
+    cy.wait('@saveProfileSettings')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-queue-status"]').should(
+      'contain',
+      'Workers paused.'
+    )
+    cy.get('[data-testid="settings-operations-queue-resume"]').should('not.be.disabled')
+
+    cy.get('[data-testid="settings-operations-queue-resume"]').click()
+    cy.wait('@saveProfileSettings')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-queue-status"]').should(
+      'contain',
+      'Workers scheduled: 0 */6 * * *'
+    )
+    cy.get('[data-testid="settings-operations-queue-pause"]').should('not.be.disabled')
+  })
+
   it('UI-SCREEN-SETTINGS-OPERATIONS-003 exports snapshot data and shows dry-run conflicts', () => {
     cy.intercept('GET', '/api/runtime', {
       statusCode: 200,

--- a/ui.web/src/features/settings/operations/index.tsx
+++ b/ui.web/src/features/settings/operations/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/select'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { useProfileSettings } from '../use-profile-settings'
 
 type RuntimeResponse = {
   app_version?: string
@@ -78,6 +79,34 @@ type CSVImportMappingState = {
   title: string
 }
 
+const queueWorkerScheduleSettingKey = 'scanner_schedule'
+const queueResumeScheduleSettingKey = 'operations_queue_resume_schedule'
+const pausedQueueWorkerSchedule = 'manual'
+const defaultQueueWorkerResumeSchedule = '0 */6 * * *'
+
+function normalizeQueueWorkerSchedule(value?: string): string {
+  const trimmed = value?.trim() ?? ''
+  return trimmed === '' ? pausedQueueWorkerSchedule : trimmed
+}
+
+function buildQueueStatusMessage(
+  schedule: string,
+  resumeSchedule: string,
+  profileSettingsLoading: boolean,
+  profileSettingsError: string | null
+): string {
+  if (profileSettingsLoading) {
+    return 'Loading worker scheduling…'
+  }
+  if (profileSettingsError) {
+    return 'Queue controls are unavailable right now.'
+  }
+  if (schedule === pausedQueueWorkerSchedule) {
+    return `Workers paused. Resume will restore schedule ${resumeSchedule}.`
+  }
+  return `Workers scheduled: ${schedule}`
+}
+
 function parseImportSnapshotRequest(rawInput: string): ImportSnapshotRequest {
   const parsed = JSON.parse(rawInput) as {
     snapshot?: {
@@ -95,6 +124,14 @@ function parseImportSnapshotRequest(rawInput: string): ImportSnapshotRequest {
 
 export function SettingsOperations() {
   const { t } = useTranslation('pages')
+  const {
+    activeProfileId,
+    settings: profileSettings,
+    loading: profileSettingsLoading,
+    error: profileSettingsError,
+    saving: profileSettingsSaving,
+    saveSettings,
+  } = useProfileSettings()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [runtimeInfo, setRuntimeInfo] = useState<RuntimeResponse | null>(null)
@@ -144,6 +181,9 @@ export function SettingsOperations() {
     useState<ImportApplyAction>('merge')
   const [lastDryRunRequest, setLastDryRunRequest] = useState<ImportSnapshotRequest | null>(null)
   const [lastCsvDryRunRequest, setLastCsvDryRunRequest] = useState<CSVImportRequest | null>(null)
+  const [queuePendingAction, setQueuePendingAction] = useState<'pause' | 'resume' | null>(null)
+  const [queueStatusOverride, setQueueStatusOverride] = useState<string | null>(null)
+  const [queueTone, setQueueTone] = useState<'default' | 'destructive'>('default')
 
   const loadOperations = useCallback(async () => {
     setLoading(true)
@@ -404,6 +444,85 @@ export function SettingsOperations() {
     }
   }, [importCsvDefaultAction, lastCsvDryRunRequest])
 
+  const queueWorkerSchedule = normalizeQueueWorkerSchedule(
+    profileSettings[queueWorkerScheduleSettingKey]
+  )
+  const queuePaused = queueWorkerSchedule === pausedQueueWorkerSchedule
+  const queueResumeSchedule =
+    profileSettings[queueResumeScheduleSettingKey]?.trim() ||
+    (queuePaused ? defaultQueueWorkerResumeSchedule : queueWorkerSchedule)
+  const queueStatus =
+    queueStatusOverride ??
+    buildQueueStatusMessage(
+      queueWorkerSchedule,
+      queueResumeSchedule,
+      profileSettingsLoading,
+      profileSettingsError
+    )
+
+  const runPauseWorkers = useCallback(async () => {
+    if (!activeProfileId) {
+      setQueueTone('destructive')
+      setQueueStatusOverride('Queue controls are unavailable without an active profile.')
+      return
+    }
+
+    const resumeSchedule =
+      queueWorkerSchedule === pausedQueueWorkerSchedule
+        ? queueResumeSchedule
+        : queueWorkerSchedule
+
+    setQueuePendingAction('pause')
+    setQueueTone('default')
+    try {
+      await saveSettings({
+        ...profileSettings,
+        [queueWorkerScheduleSettingKey]: pausedQueueWorkerSchedule,
+        [queueResumeScheduleSettingKey]: resumeSchedule,
+      })
+      setQueueStatusOverride(`Workers paused. Resume will restore schedule ${resumeSchedule}.`)
+    } catch {
+      setQueueTone('destructive')
+      setQueueStatusOverride(
+        'Failed to pause workers. Retry when profile settings are available.'
+      )
+    } finally {
+      setQueuePendingAction(null)
+    }
+  }, [
+    activeProfileId,
+    profileSettings,
+    queueResumeSchedule,
+    queueWorkerSchedule,
+    saveSettings,
+  ])
+
+  const runResumeWorkers = useCallback(async () => {
+    if (!activeProfileId) {
+      setQueueTone('destructive')
+      setQueueStatusOverride('Queue controls are unavailable without an active profile.')
+      return
+    }
+
+    setQueuePendingAction('resume')
+    setQueueTone('default')
+    try {
+      await saveSettings({
+        ...profileSettings,
+        [queueWorkerScheduleSettingKey]: queueResumeSchedule,
+        [queueResumeScheduleSettingKey]: queueResumeSchedule,
+      })
+      setQueueStatusOverride(`Workers scheduled: ${queueResumeSchedule}`)
+    } catch {
+      setQueueTone('destructive')
+      setQueueStatusOverride(
+        'Failed to resume workers. Retry when profile settings are available.'
+      )
+    } finally {
+      setQueuePendingAction(null)
+    }
+  }, [activeProfileId, profileSettings, queueResumeSchedule, saveSettings])
+
   const runtimeAddress = runtimeInfo
     ? `${runtimeInfo.runtime_host?.trim() || '127.0.0.1'}:${runtimeInfo.runtime_port ?? 17880}`
     : 'Unavailable'
@@ -425,6 +544,13 @@ export function SettingsOperations() {
   const logsActionsDisabled = loading || Boolean(error) || logsExportPending
   const setupImportActionsDisabled =
     loading || Boolean(error) || setupImportPending || setupImportSourcePath.trim() === ''
+  const queueActionsDisabled =
+    loading ||
+    Boolean(error) ||
+    profileSettingsLoading ||
+    Boolean(profileSettingsError) ||
+    profileSettingsSaving ||
+    queuePendingAction !== null
 
   return (
     <ContentSection
@@ -958,17 +1084,42 @@ export function SettingsOperations() {
           </div>
         </div>
 
-        <div className='rounded-md border p-3'>
+        <div
+          className='rounded-md border p-3 space-y-3'
+          data-testid='settings-operations-queue-card'
+        >
           <p className='font-medium'>Queue Controls</p>
           <p className='text-muted-foreground'>
             Pause and resume Market Watch and enrichment workers for active profile context.
           </p>
-          <div className='mt-3 flex gap-2'>
-            <Button variant='outline' size='sm' disabled>
-              Pause Workers (Coming soon)
+          <p
+            data-testid='settings-operations-queue-status'
+            className={queueTone === 'destructive' ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}
+          >
+            {queueStatus}
+          </p>
+          <div className='flex gap-2'>
+            <Button
+              variant='outline'
+              size='sm'
+              data-testid='settings-operations-queue-pause'
+              disabled={queueActionsDisabled || queuePaused}
+              onClick={() => {
+                void runPauseWorkers()
+              }}
+            >
+              {queuePendingAction === 'pause' ? 'Pausing Workers…' : 'Pause Workers'}
             </Button>
-            <Button variant='outline' size='sm' disabled>
-              Resume Workers (Coming soon)
+            <Button
+              variant='outline'
+              size='sm'
+              data-testid='settings-operations-queue-resume'
+              disabled={queueActionsDisabled || !queuePaused}
+              onClick={() => {
+                void runResumeWorkers()
+              }}
+            >
+              {queuePendingAction === 'resume' ? 'Resuming Workers…' : 'Resume Workers'}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the Operations queue placeholder with real pause/resume controls backed by profile settings
- preserve the last resume schedule using operations_queue_resume_schedule
- add contract and Cypress coverage for route-stable pause/resume behavior

## Validation
- go test ./internal/app -run TestSettingsOperationsQueueControlsContract -count=1
- npm.cmd run build
- npx.cmd eslint cypress/e2e/settings/operations/spec.cy.ts src/features/settings/operations/index.tsx src/features/settings/use-profile-settings.ts
- git diff --check
- npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/settings/operations/spec.cy.ts