### PR TITLE
#599 feat(settings): add recovery access to operations

### DIFF
--- a/internal/app/ui_template_contract_test.go
+++ b/internal/app/ui_template_contract_test.go
@@ -432,6 +432,33 @@ func TestSettingsOperationsQueueControlsContract(t *testing.T) {
 	}
 }
 
+func TestSettingsOperationsRecoveryWorkflowContract(t *testing.T) {
+	t.Parallel()
+
+	b, err := os.ReadFile("../../ui.web/src/features/settings/operations/index.tsx")
+	if err != nil {
+		t.Fatalf("read settings operations: %v", err)
+	}
+	src := string(b)
+
+	required := []string{
+		"settings-operations-auth-recovery-card",
+		"settings-operations-recovery-passphrase-input",
+		"settings-operations-recovery-passphrase-submit",
+		"settings-operations-recovery-reset-submit",
+		"settings-operations-auth-recovery-status",
+		"settings-operations-auth-recovery-summary",
+		"/api/auth/recovery/passphrase",
+		"/api/auth/recovery/reset/begin",
+		"Recovery reset session started.",
+	}
+	for _, token := range required {
+		if !strings.Contains(src, token) {
+			t.Fatalf("settings operations missing recovery workflow token: %s", token)
+		}
+	}
+}
+
 func TestI18nShellSharedLabelsContract(t *testing.T) {
 	t.Parallel()
 

--- a/ui.web/cypress/e2e/settings/operations/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/operations/spec.cy.ts
@@ -214,6 +214,98 @@ describe('settings/operations', () => {
     cy.get('[data-testid="settings-operations-queue-pause"]').should('not.be.disabled')
   })
 
+  it('UI-SCREEN-SETTINGS-OPERATIONS-002B sets recovery passphrase and begins reset without route reload', () => {
+    cy.intercept('GET', '/api/runtime', {
+      statusCode: 200,
+      body: {
+        app_version: 'rev-auth-recovery',
+        build_date: '2026-04-23',
+        bind_mode: 'loopback',
+        runtime_host: '127.0.0.1',
+        runtime_port: 17880,
+        update_channel: 'stable',
+        update_public_key_configured: true,
+      },
+    }).as('runtimeInfo')
+    cy.intercept('GET', '/api/runtime/recovery', {
+      statusCode: 200,
+      body: {
+        recovery_required: true,
+      },
+    }).as('runtimeRecovery')
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: {
+        id: 'profile-ops-recovery',
+      },
+    }).as('activeProfile')
+    cy.intercept('GET', '/api/profiles/profile-ops-recovery/settings', {
+      statusCode: 200,
+      body: {
+        settings: {
+          scanner_schedule: 'manual',
+        },
+      },
+    }).as('profileSettings')
+    cy.intercept('POST', '/api/auth/recovery/passphrase', (req) => {
+      expect(req.body).to.deep.equal({
+        profile_id: 'profile-ops-recovery',
+        passphrase: 'reset-hunter2',
+      })
+      req.reply({
+        statusCode: 200,
+        body: {
+          ok: true,
+        },
+      })
+    }).as('setRecoveryPassphrase')
+    cy.intercept('POST', '/api/auth/recovery/reset/begin', (req) => {
+      expect(req.body).to.deep.equal({
+        profile_id: 'profile-ops-recovery',
+        passphrase: 'reset-hunter2',
+      })
+      req.reply({
+        statusCode: 200,
+        body: {
+          session_id: 'recovery-session-1',
+        },
+      })
+    }).as('beginRecoveryReset')
+
+    signInToOperations()
+    cy.wait('@runtimeInfo')
+    cy.wait('@runtimeRecovery')
+    cy.wait('@activeProfile')
+    cy.wait('@profileSettings')
+
+    cy.get('[data-testid="settings-operations-auth-recovery-card"]').should(
+      'contain',
+      'Recovery Access'
+    )
+    cy.get('[data-testid="settings-operations-recovery-passphrase-input"]')
+      .clear()
+      .type('reset-hunter2')
+    cy.get('[data-testid="settings-operations-recovery-passphrase-submit"]').click()
+    cy.wait('@setRecoveryPassphrase')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-auth-recovery-status"]').should(
+      'contain',
+      'Recovery passphrase saved.'
+    )
+
+    cy.get('[data-testid="settings-operations-recovery-reset-submit"]').click()
+    cy.wait('@beginRecoveryReset')
+    cy.location('pathname').should('match', /^\/settings\/operations\/?$/)
+    cy.get('[data-testid="settings-operations-auth-recovery-status"]').should(
+      'contain',
+      'Recovery reset session started.'
+    )
+    cy.get('[data-testid="settings-operations-auth-recovery-summary"]').should(
+      'contain',
+      'recovery-session-1'
+    )
+  })
+
   it('UI-SCREEN-SETTINGS-OPERATIONS-003 exports snapshot data and shows dry-run conflicts', () => {
     cy.intercept('GET', '/api/runtime', {
       statusCode: 200,

--- a/ui.web/src/features/settings/operations/index.tsx
+++ b/ui.web/src/features/settings/operations/index.tsx
@@ -37,6 +37,10 @@ type RuntimeSetupImportResponse = {
   runtime_port?: number
 }
 
+type RecoveryResetResponse = {
+  session_id?: string
+}
+
 type ExportSnapshotResponse = {
   schema_version?: number
   exported_at?: string
@@ -184,6 +188,17 @@ export function SettingsOperations() {
   const [queuePendingAction, setQueuePendingAction] = useState<'pause' | 'resume' | null>(null)
   const [queueStatusOverride, setQueueStatusOverride] = useState<string | null>(null)
   const [queueTone, setQueueTone] = useState<'default' | 'destructive'>('default')
+  const [recoveryPassphraseInput, setRecoveryPassphraseInput] = useState('')
+  const [recoveryPassphrasePending, setRecoveryPassphrasePending] = useState(false)
+  const [recoveryResetPending, setRecoveryResetPending] = useState(false)
+  const [authRecoveryStatus, setAuthRecoveryStatus] = useState(
+    'No recovery passphrase or reset action has run yet.'
+  )
+  const [authRecoveryTone, setAuthRecoveryTone] = useState<'default' | 'destructive'>(
+    'default'
+  )
+  const [authRecoverySummary, setAuthRecoverySummary] =
+    useState<RecoveryResetResponse | null>(null)
 
   const loadOperations = useCallback(async () => {
     setLoading(true)
@@ -523,6 +538,70 @@ export function SettingsOperations() {
     }
   }, [activeProfileId, profileSettings, queueResumeSchedule, saveSettings])
 
+  const runSetRecoveryPassphrase = useCallback(async () => {
+    if (!activeProfileId) {
+      setAuthRecoveryTone('destructive')
+      setAuthRecoveryStatus('Recovery access is unavailable without an active profile.')
+      return
+    }
+
+    setRecoveryPassphrasePending(true)
+    setAuthRecoveryTone('default')
+    try {
+      const response = await fetch('/api/auth/recovery/passphrase', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile_id: activeProfileId,
+          passphrase: recoveryPassphraseInput,
+        }),
+      })
+      if (!response.ok) {
+        throw new Error('failed_to_set_recovery_passphrase')
+      }
+      setAuthRecoverySummary(null)
+      setAuthRecoveryStatus('Recovery passphrase saved.')
+    } catch {
+      setAuthRecoveryTone('destructive')
+      setAuthRecoveryStatus('Recovery passphrase save failed.')
+    } finally {
+      setRecoveryPassphrasePending(false)
+    }
+  }, [activeProfileId, recoveryPassphraseInput])
+
+  const runBeginRecoveryReset = useCallback(async () => {
+    if (!activeProfileId) {
+      setAuthRecoveryTone('destructive')
+      setAuthRecoveryStatus('Recovery access is unavailable without an active profile.')
+      return
+    }
+
+    setRecoveryResetPending(true)
+    setAuthRecoveryTone('default')
+    try {
+      const response = await fetch('/api/auth/recovery/reset/begin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile_id: activeProfileId,
+          passphrase: recoveryPassphraseInput,
+        }),
+      })
+      if (!response.ok) {
+        throw new Error('failed_to_begin_recovery_reset')
+      }
+      const payload = (await response.json()) as RecoveryResetResponse
+      setAuthRecoverySummary(payload)
+      setAuthRecoveryStatus('Recovery reset session started.')
+    } catch {
+      setAuthRecoverySummary(null)
+      setAuthRecoveryTone('destructive')
+      setAuthRecoveryStatus('Recovery reset could not be started.')
+    } finally {
+      setRecoveryResetPending(false)
+    }
+  }, [activeProfileId, recoveryPassphraseInput])
+
   const runtimeAddress = runtimeInfo
     ? `${runtimeInfo.runtime_host?.trim() || '127.0.0.1'}:${runtimeInfo.runtime_port ?? 17880}`
     : 'Unavailable'
@@ -551,6 +630,14 @@ export function SettingsOperations() {
     Boolean(profileSettingsError) ||
     profileSettingsSaving ||
     queuePendingAction !== null
+  const authRecoveryActionsDisabled =
+    loading ||
+    Boolean(error) ||
+    profileSettingsLoading ||
+    Boolean(profileSettingsError) ||
+    recoveryPassphraseInput.trim() === '' ||
+    recoveryPassphrasePending ||
+    recoveryResetPending
 
   return (
     <ContentSection
@@ -671,6 +758,83 @@ export function SettingsOperations() {
                 <p>No imported setup summary yet.</p>
               )}
             </div>
+          </div>
+        </div>
+
+        <div
+          className='rounded-md border p-3 space-y-3'
+          data-testid='settings-operations-auth-recovery-card'
+        >
+          <div className='space-y-1'>
+            <p className='font-medium'>Recovery Access</p>
+            <p className='text-muted-foreground'>
+              Set a recovery passphrase and begin a recovery reset session for the active profile without leaving Operations.
+            </p>
+          </div>
+
+          <div className='space-y-2'>
+            <label
+              htmlFor='settings-operations-recovery-passphrase-input'
+              className='text-sm font-medium'
+            >
+              Recovery passphrase
+            </label>
+            <Input
+              id='settings-operations-recovery-passphrase-input'
+              data-testid='settings-operations-recovery-passphrase-input'
+              type='password'
+              value={recoveryPassphraseInput}
+              onChange={(event) => {
+                setRecoveryPassphraseInput(event.target.value)
+              }}
+              placeholder='Enter recovery passphrase'
+            />
+          </div>
+
+          <div className='flex gap-2'>
+            <Button
+              variant='outline'
+              size='sm'
+              data-testid='settings-operations-recovery-passphrase-submit'
+              disabled={authRecoveryActionsDisabled}
+              onClick={() => {
+                void runSetRecoveryPassphrase()
+              }}
+            >
+              {recoveryPassphrasePending ? 'Saving Passphrase…' : 'Save Recovery Passphrase'}
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              data-testid='settings-operations-recovery-reset-submit'
+              disabled={authRecoveryActionsDisabled}
+              onClick={() => {
+                void runBeginRecoveryReset()
+              }}
+            >
+              {recoveryResetPending ? 'Starting Recovery Reset…' : 'Begin Recovery Reset'}
+            </Button>
+          </div>
+
+          <p
+            data-testid='settings-operations-auth-recovery-status'
+            className={authRecoveryTone === 'destructive' ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}
+          >
+            {authRecoveryStatus}
+          </p>
+
+          <div
+            className='rounded-md border bg-muted/20 p-3 text-sm text-muted-foreground'
+            data-testid='settings-operations-auth-recovery-summary'
+          >
+            {authRecoverySummary ? (
+              <div className='space-y-1'>
+                <p>Recovery session: {authRecoverySummary.session_id || 'Unknown session'}</p>
+                <p>Profile: {activeProfileId || 'Unknown profile'}</p>
+              </div>
+            ) : (
+              <p>No recovery reset session has been started yet.</p>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a real Recovery Access workflow to Settings > Operations
- allow setting the recovery passphrase and beginning a recovery reset session from the same screen
- add contract and Cypress coverage for the route-stable recovery flow

## Validation
- go test ./internal/app -run TestSettingsOperationsRecoveryWorkflowContract -count=1
- npm.cmd run build
- npx.cmd eslint cypress/e2e/settings/operations/spec.cy.ts src/features/settings/operations/index.tsx src/features/settings/use-profile-settings.ts
- git diff --check
- ./scripts/build-cabinet.ps1
- npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/settings/operations/spec.cy.ts