### PR TITLE
#618 test(integrations): stabilize recovery bootstrap spec

### DIFF
--- a/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
@@ -247,11 +247,10 @@ describe('ui-screen-integrations', () => {
   })
 
   it('UI-SCREEN-INTEGRATIONS-005: recovers active-profile bootstrap inline by selecting or creating profile context', () => {
-    let activeProfileCalls = 0
+    let activeProfileRecovered = false
 
     cy.intercept('GET', '/api/profiles/active', (req) => {
-      activeProfileCalls += 1
-      if (activeProfileCalls === 1) {
+      if (!activeProfileRecovered) {
         req.reply({ statusCode: 404, body: { error: 'active_profile_not_set' } })
         return
       }
@@ -267,6 +266,7 @@ describe('ui-screen-integrations', () => {
 
     cy.intercept('PUT', '/api/profiles/active', (req) => {
       expect(req.body.profile_id).to.eq('profile-e2e-002')
+      activeProfileRecovered = true
       req.reply({ statusCode: 200, body: { id: 'profile-e2e-002', name: 'Recovered Profile' } })
     }).as('setActiveProfile')
 


### PR DESCRIPTION
## Summary
- keep `/api/profiles/active` at `404` until the recovery action actually succeeds
- stabilize the runtime-backed integrations recovery coverage under React StrictMode bootstrap
- revalidate the full integrations screen suite against the built runtime

## Validation
- `npx.cmd eslint ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts`
- `npx.cmd cypress run --browser electron --config-file cypress.config.runtime.cjs --spec cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts`
  - result: `8 passing`
- `git diff --check`
