### PR TITLE
#617 feat(search): command palette catalog and barcode workflow

### DIFF
--- a/ui.web/cypress/e2e/general/ui-global-search-command/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-global-search-command/spec.cy.ts
@@ -7,6 +7,7 @@ describe('ui-global-search-command', () => {
     cy.get('input[name="password"]').clear().type('password123')
     cy.contains('button', 'Sign in').click()
     cy.location('pathname', { timeout: 15000 }).should('eq', '/dashboard')
+    cy.contains('button', /search/i).should('be.visible')
   }
 
   function openCommandPaletteWithShortcut() {
@@ -44,5 +45,68 @@ describe('ui-global-search-command', () => {
 
     cy.get('html').should('have.class', 'dark')
     cy.get(commandInputSelector).should('not.exist')
+  })
+
+  it('UI-GLOBAL-SEARCH-COMMAND-004 surfaces local catalog results and opens filtered Inventory', () => {
+    cy.intercept('GET', '/api/search/items*', (req) => {
+      expect(req.query.text).to.eq('AFX')
+      req.reply({
+        statusCode: 200,
+        body: {
+          items: [
+            {
+              id: 'item-search-1',
+              part_number: 'AFX-123',
+              title: 'AFX Mega G+ Camaro',
+              brand: 'AFX',
+              category: 'Slot Cars',
+            },
+          ],
+        },
+      })
+    }).as('localSearch')
+
+    openCommandPaletteFromSearchButton()
+    cy.get(commandInputSelector).type('AFX')
+    cy.wait('@localSearch')
+
+    cy.get('[data-testid="command-local-result-item-search-1"]')
+      .should('contain', 'AFX Mega G+ Camaro')
+      .and('contain', 'AFX-123')
+      .click()
+
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
+    cy.location('search').should('contain', 'filter=AFX-123')
+  })
+
+  it('UI-GLOBAL-SEARCH-COMMAND-005 makes unresolved barcode lookup actionable from Market Watch', () => {
+    cy.intercept('GET', '/api/search/items*', {
+      statusCode: 200,
+      body: { items: [] },
+    }).as('localSearch')
+    cy.intercept('GET', '/api/barcodes/0000000000000', {
+      statusCode: 200,
+      body: { matches: [] },
+    }).as('barcodeLookup')
+
+    openCommandPaletteFromSearchButton()
+    cy.get(commandInputSelector).type('0000000000000')
+    cy.wait(['@localSearch', '@barcodeLookup'])
+
+    cy.get('[data-testid="command-barcode-empty"]')
+      .should('contain', 'No local barcode match')
+      .and('contain', 'Open Market Watch')
+    cy.get('[data-testid="command-barcode-open-scanner"]').click()
+
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/scanner\/?$/)
+    cy.location('search').should('contain', 'barcode=0000000000000')
+    cy.get('[data-testid="scanner-new-query-name"]').should(
+      'have.value',
+      'Barcode 0000000000000'
+    )
+    cy.get('[data-testid="scanner-new-query-keywords"]').should(
+      'have.value',
+      '0000000000000'
+    )
   })
 })

--- a/ui.web/src/components/command-menu.tsx
+++ b/ui.web/src/components/command-menu.tsx
@@ -1,6 +1,16 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { ArrowRight, ChevronRight, Laptop, Moon, Sun } from 'lucide-react'
+import {
+  ArrowRight,
+  Barcode,
+  ChevronRight,
+  Laptop,
+  LoaderCircle,
+  Moon,
+  PackageSearch,
+  ScanSearch,
+  Sun,
+} from 'lucide-react'
 import { useSearch } from '@/context/search-provider'
 import { useTheme } from '@/context/theme-provider'
 import {
@@ -15,10 +25,80 @@ import {
 import { sidebarData } from './layout/data/sidebar-data'
 import { ScrollArea } from './ui/scroll-area'
 
+type LocalSearchItem = {
+  id: string
+  part_number: string
+  title: string
+  brand: string
+  category: string
+}
+
+type BarcodeMatch = {
+  id: string
+  item_id: string
+  barcode: string
+}
+
+function normalizeLocalSearchItem(item: Partial<LocalSearchItem>): LocalSearchItem {
+  return {
+    id: item.id?.trim() ?? '',
+    part_number: item.part_number?.trim() ?? '',
+    title: item.title?.trim() || 'Untitled item',
+    brand: item.brand?.trim() || 'Unknown brand',
+    category: item.category?.trim() || 'General',
+  }
+}
+
+function isBarcodeCandidate(value: string) {
+  return /^[0-9]{6,}$/.test(value.trim())
+}
+
 export function CommandMenu() {
   const navigate = useNavigate()
   const { setTheme } = useTheme()
   const { open, setOpen } = useSearch()
+  const [searchValue, setSearchValue] = useState('')
+  const [localResults, setLocalResults] = useState<LocalSearchItem[]>([])
+  const [localSearchState, setLocalSearchState] = useState<
+    'idle' | 'loading' | 'success' | 'error'
+  >('idle')
+  const [barcodeMatches, setBarcodeMatches] = useState<BarcodeMatch[]>([])
+  const [barcodeState, setBarcodeState] = useState<
+    'idle' | 'loading' | 'success' | 'error'
+  >('idle')
+  const trimmedSearch = searchValue.trim()
+  const barcodeCandidate = useMemo(
+    () => isBarcodeCandidate(trimmedSearch),
+    [trimmedSearch]
+  )
+
+  const resetCommandSearch = () => {
+    setSearchValue('')
+    setLocalResults([])
+    setLocalSearchState('idle')
+    setBarcodeMatches([])
+    setBarcodeState('idle')
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      resetCommandSearch()
+    }
+  }
+
+  const handleSearchValueChange = (value: string) => {
+    setSearchValue(value)
+    const nextValue = value.trim()
+    if (nextValue.length < 2) {
+      setLocalResults([])
+      setLocalSearchState('idle')
+    }
+    if (!isBarcodeCandidate(nextValue)) {
+      setBarcodeMatches([])
+      setBarcodeState('idle')
+    }
+  }
 
   const runCommand = React.useCallback(
     (command: () => unknown) => {
@@ -28,12 +108,223 @@ export function CommandMenu() {
     [setOpen]
   )
 
+  useEffect(() => {
+    if (!open || trimmedSearch.length < 2) {
+      return
+    }
+
+    const controller = new AbortController()
+    const timeoutID = window.setTimeout(() => {
+      setLocalSearchState('loading')
+      fetch(
+        `/api/search/items?text=${encodeURIComponent(trimmedSearch)}&limit=5`,
+        { signal: controller.signal }
+      )
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`search_items_${response.status}`)
+          }
+          const payload = (await response.json()) as {
+            items?: Array<Partial<LocalSearchItem>>
+          }
+          setLocalResults(
+            (payload.items ?? [])
+              .map(normalizeLocalSearchItem)
+              .filter((item) => item.id !== '')
+          )
+          setLocalSearchState('success')
+        })
+        .catch((error: unknown) => {
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            return
+          }
+          setLocalResults([])
+          setLocalSearchState('error')
+        })
+    }, 150)
+
+    return () => {
+      window.clearTimeout(timeoutID)
+      controller.abort()
+    }
+  }, [open, trimmedSearch])
+
+  useEffect(() => {
+    if (!open || !barcodeCandidate) {
+      return
+    }
+
+    const controller = new AbortController()
+    const timeoutID = window.setTimeout(() => {
+      setBarcodeState('loading')
+      fetch(`/api/barcodes/${encodeURIComponent(trimmedSearch)}`, {
+        signal: controller.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`barcode_lookup_${response.status}`)
+          }
+          const payload = (await response.json()) as {
+            matches?: Array<Partial<BarcodeMatch>>
+          }
+          setBarcodeMatches(
+            (payload.matches ?? [])
+              .map((match) => ({
+                id: match.id?.trim() ?? '',
+                item_id: match.item_id?.trim() ?? '',
+                barcode: match.barcode?.trim() ?? trimmedSearch,
+              }))
+              .filter((match) => match.id !== '')
+          )
+          setBarcodeState('success')
+        })
+        .catch((error: unknown) => {
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            return
+          }
+          setBarcodeMatches([])
+          setBarcodeState('error')
+        })
+    }, 150)
+
+    return () => {
+      window.clearTimeout(timeoutID)
+      controller.abort()
+    }
+  }, [barcodeCandidate, open, trimmedSearch])
+
+  const openInventoryFilter = (filter: string) => {
+    void navigate({
+      to: '/inventory',
+      search: { filter } as never,
+    })
+  }
+
+  const openScannerForBarcode = (barcode: string) => {
+    void navigate({
+      to: '/scanner',
+      search: { barcode } as never,
+    })
+  }
+
   return (
-    <CommandDialog modal open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder='Type a command or search...' />
+    <CommandDialog modal open={open} onOpenChange={handleOpenChange}>
+      <CommandInput
+        placeholder='Type a command or search...'
+        value={searchValue}
+        onValueChange={handleSearchValueChange}
+        onInput={(event) =>
+          handleSearchValueChange(event.currentTarget.value)
+        }
+      />
       <CommandList>
         <ScrollArea type='hover' className='h-72 pe-1'>
           <CommandEmpty>No results found.</CommandEmpty>
+          {trimmedSearch.length >= 2 ? (
+            <CommandGroup heading='Local catalog'>
+              {localSearchState === 'loading' ? (
+                <CommandItem disabled value={`loading-${trimmedSearch}`}>
+                  <LoaderCircle className='animate-spin' />
+                  Searching local catalog...
+                </CommandItem>
+              ) : null}
+              {localSearchState === 'error' ? (
+                <CommandItem disabled value={`search-error-${trimmedSearch}`}>
+                  <PackageSearch />
+                  Local catalog search is unavailable.
+                </CommandItem>
+              ) : null}
+              {localSearchState === 'success' && localResults.length === 0 ? (
+                <CommandItem disabled value={`search-empty-${trimmedSearch}`}>
+                  <PackageSearch />
+                  No local catalog matches.
+                </CommandItem>
+              ) : null}
+              {localResults.map((item) => {
+                const filter = item.part_number || item.title || item.id
+                return (
+                  <CommandItem
+                    key={item.id}
+                    value={`${item.part_number} ${item.title} ${item.brand} ${item.category}`}
+                    data-testid={`command-local-result-${item.id}`}
+                    onSelect={() =>
+                      runCommand(() => openInventoryFilter(filter))
+                    }
+                  >
+                    <PackageSearch />
+                    <div className='min-w-0'>
+                      <p className='truncate font-medium'>{item.title}</p>
+                      <p className='truncate text-xs text-muted-foreground'>
+                        {item.part_number || item.id} · {item.brand} ·{' '}
+                        {item.category}
+                      </p>
+                    </div>
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          ) : null}
+          {barcodeCandidate ? (
+            <CommandGroup heading='Barcode lookup'>
+              {barcodeState === 'loading' ? (
+                <CommandItem disabled value={`barcode-loading-${trimmedSearch}`}>
+                  <LoaderCircle className='animate-spin' />
+                  Looking up barcode {trimmedSearch}...
+                </CommandItem>
+              ) : null}
+              {barcodeState === 'error' ? (
+                <CommandItem disabled value={`barcode-error-${trimmedSearch}`}>
+                  <Barcode />
+                  Barcode lookup is unavailable.
+                </CommandItem>
+              ) : null}
+              {barcodeState === 'success' && barcodeMatches.length > 0
+                ? barcodeMatches.map((match) => (
+                    <CommandItem
+                      key={match.id}
+                      value={`${match.barcode} ${match.item_id}`}
+                      data-testid={`command-barcode-match-${match.id}`}
+                      onSelect={() =>
+                        runCommand(() => openInventoryFilter(match.item_id))
+                      }
+                    >
+                      <Barcode />
+                      <div className='min-w-0'>
+                        <p className='truncate font-medium'>
+                          Local barcode match
+                        </p>
+                        <p className='truncate text-xs text-muted-foreground'>
+                          {match.barcode} · {match.item_id}
+                        </p>
+                      </div>
+                    </CommandItem>
+                  ))
+                : null}
+              {barcodeState === 'success' && barcodeMatches.length === 0 ? (
+                <>
+                  <CommandItem
+                    disabled
+                    value={`barcode-empty-${trimmedSearch}`}
+                    data-testid='command-barcode-empty'
+                  >
+                    <Barcode />
+                    No local barcode match. Open Market Watch to continue.
+                  </CommandItem>
+                  <CommandItem
+                    value={`open-market-watch-${trimmedSearch}`}
+                    data-testid='command-barcode-open-scanner'
+                    onSelect={() =>
+                      runCommand(() => openScannerForBarcode(trimmedSearch))
+                    }
+                  >
+                    <ScanSearch />
+                    Open Market Watch for {trimmedSearch}
+                  </CommandItem>
+                </>
+              ) : null}
+            </CommandGroup>
+          ) : null}
+          {trimmedSearch.length >= 2 ? <CommandSeparator /> : null}
           {sidebarData.navGroups.map((group) => (
             <CommandGroup key={group.title} heading={group.title}>
               {group.items.map((navItem, i) => {

--- a/ui.web/src/features/scanner/index.tsx
+++ b/ui.web/src/features/scanner/index.tsx
@@ -218,6 +218,28 @@ export function Scanner() {
     void loadScanner()
   }, [loadScanner])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const barcode = new URLSearchParams(window.location.search)
+      .get('barcode')
+      ?.trim()
+    if (!barcode) {
+      return
+    }
+    setNewName(`Barcode ${barcode}`)
+    setNewKeywords(barcode)
+    setActionStatus(`barcode_lookup_ready_${barcode}`)
+    setActionFeedback({
+      summary: 'Barcode lookup is ready for Market Watch.',
+      actions: [
+        'Review provider scope before creating the query set.',
+        'Create the query set or edit the barcode keyword first.',
+      ],
+    })
+  }, [])
+
   const resolveProviderScope = () => {
     if (providerMode === 'single') {
       const normalized = singleProvider.trim().toLowerCase()

--- a/ui.web/src/routes/_authenticated/scanner/index.tsx
+++ b/ui.web/src/routes/_authenticated/scanner/index.tsx
@@ -1,6 +1,12 @@
+import z from 'zod'
 import { createFileRoute } from '@tanstack/react-router'
 import { Scanner } from '@/features/scanner'
 
+const scannerSearchSchema = z.object({
+  barcode: z.string().optional().catch(''),
+})
+
 export const Route = createFileRoute('/_authenticated/scanner/')({
+  validateSearch: scannerSearchSchema,
   component: Scanner,
 })


### PR DESCRIPTION
## Summary
- Adds local catalog results to the global command palette with Inventory filter navigation.
- Adds barcode lookup states and an unresolved barcode handoff to Market Watch scanner.
- Allows `/scanner?barcode=...` to prefill a scanner query draft.

## Validation
- `npx.cmd eslint ui.web/cypress/e2e/general/ui-global-search-command/spec.cy.ts ui.web/src/components/command-menu.tsx ui.web/src/features/scanner/index.tsx ui.web/src/routes/_authenticated/scanner/index.tsx`
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- Runtime Cypress `ui-global-search-command/spec.cy.ts`: 5 passing
- `go test ./internal/app -run "Test(SearchDataIsIsolatedByActiveProfile|ScannerQuerySetsAreIsolatedByActiveProfile|Wave5SearchFiltersAndSavedFiltersProfileScoped|Wave7BarcodeLookupAndVariantDuplicateResolution)$"`

Closes #617