### PR TITLE
#503 fix(settings): restore profile settings page copy

### DIFF
--- a/ui.web/cypress/e2e/settings/profile/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/profile/spec.cy.ts
@@ -1,10 +1,10 @@
 describe('settings/profile', () => {
   function signInToSettings() {
-    cy.visit('/sign-in?redirect=%2Fsettings%2F')
-    cy.get('input[name="email"]').clear().type('e2e-settings@example.com')
-    cy.get('input[name="password"]').clear().type('password123')
-    cy.contains('button', 'Sign in').click()
-    cy.location('pathname', { timeout: 15000 }).should('match', /^\/settings\/profile\/?$/)
+    cy.e2eReset()
+    cy.e2eBootstrap()
+    cy.useBootstrappedProfile('e2e-profile-001', 'E2E Local', {
+      path: '/settings/profile',
+    })
   }
 
   beforeEach(() => {

--- a/ui.web/src/locales/en/pages.json
+++ b/ui.web/src/locales/en/pages.json
@@ -34,5 +34,39 @@
   "integrations": {
     "title": "Integrations",
     "description": "Configure providers, credentials, and connector actions."
+  },
+  "settings": {
+    "profile": {
+      "title": "Profile settings",
+      "description": "Manage your account profile and public display details."
+    },
+    "account": {
+      "title": "Account",
+      "description": "Update your account settings and manage sign-in preferences."
+    },
+    "appearance": {
+      "title": "Appearance",
+      "description": "Customize how Cabinet looks and switches between light and dark themes."
+    },
+    "notifications": {
+      "title": "Notifications",
+      "description": "Choose which updates alert you and how those alerts are delivered."
+    },
+    "display": {
+      "title": "Display",
+      "description": "Control which interface details are shown across the app."
+    },
+    "storage": {
+      "title": "Storage",
+      "description": "Review and manage storage locations for this workspace."
+    },
+    "billing": {
+      "title": "Billing",
+      "description": "Review subscription, billing, and plan preferences."
+    },
+    "operations": {
+      "title": "Operations",
+      "description": "Manage background work, import/export, and runtime operations."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Restores missing English Settings page-copy keys so `/settings/profile` renders human-readable copy instead of raw translation keys.
- Adds the rest of the English Settings page-copy namespace to match existing JA/ZH locale shape.
- Updates the profile settings Cypress setup to use the shared bootstrapped active-profile helper so the form path is actually exercised.

## Validation
- Red first: runtime Cypress `ui.web/cypress/e2e/settings/profile/spec.cy.ts` failed because `Profile settings` was not visible and the form was blocked.
- `npx.cmd eslint ui.web/cypress/e2e/settings/profile/spec.cy.ts`
- `git diff --check`
- English pages JSON parse check passed.
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- Runtime Cypress `ui.web/cypress/e2e/settings/profile/spec.cy.ts`: 2 passing
- Pre-push OpenSpec validation: 9 passed, 0 failed.
- Pre-push fast API docs smoke test passed.

Closes #503
Related #515