### PR TITLE
#629 feat(wishlist): add explicit owned conversion

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -686,6 +686,29 @@ paths:
       responses:
         "204":
           description: Deleted
+  /api/wishlist/convert-owned:
+    post:
+      tags: [Wishlist]
+      summary: Convert wishlist entry to owned inventory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+      responses:
+        "200":
+          description: Wishlist entry converted to owned inventory
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "400":
+          description: Invalid or cross-profile wishlist entry
   /api/pricing/track:
     post:
       tags: [Pricing]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2747,6 +2747,36 @@ func New(cfg config.Config) (*App, error) {
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 	})
+	mux.HandleFunc("/api/wishlist/convert-owned", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method_not_allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		active, err := profiles.GetActiveProfile(r.Context())
+		if err != nil || strings.TrimSpace(active.ID) == "" {
+			http.Error(w, `{"error":"active_profile_not_set"}`, http.StatusBadRequest)
+			return
+		}
+		profileID := strings.TrimSpace(active.ID)
+		var req struct {
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid_json"}`, http.StatusBadRequest)
+			return
+		}
+		id := strings.TrimSpace(req.ID)
+		if id == "" {
+			http.Error(w, `{"error":"missing_id"}`, http.StatusBadRequest)
+			return
+		}
+		if err := wishlistSvc.ConvertToOwnedForProfile(r.Context(), profileID, id); err != nil {
+			http.Error(w, `{"error":"failed_to_convert_wishlist_to_owned"}`, http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
 	mux.HandleFunc("/api/wishlist", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		active, _ := profiles.GetActiveProfile(r.Context())

--- a/internal/app/openapi_parity_test.go
+++ b/internal/app/openapi_parity_test.go
@@ -29,6 +29,7 @@ func TestOpenAPIDocumentsRuntimeEndpoints(t *testing.T) {
 		"/api/scanner/failures/retry",
 		"/api/provider/health",
 		"/api/settings/reset-ignore-rules",
+		"/api/wishlist/convert-owned",
 		"/api/wishlist/hits",
 		"/api/pricing/snapshot/run",
 		"/api/pricing/graph",

--- a/internal/app/wishlist_convert_owned_api_test.go
+++ b/internal/app/wishlist_convert_owned_api_test.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestWishlistConvertOwnedEndpointMovesItemToInventoryForActiveProfile(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	p1 := createWishlistConvertProfile(t, a, "Wishlist P1")
+	p2 := createWishlistConvertProfile(t, a, "Wishlist P2")
+	activateWishlistConvertProfile(t, a, p1.ID)
+
+	createItem := doRequest(t, a, http.MethodPost, "/api/items", strings.NewReader(`{"part_number":"WISH-CONVERT-001","title":"Wishlist Convert Item","brand":"AFX","category":"Slot"}`), map[string]string{"Content-Type": "application/json"})
+	if createItem.Code != http.StatusCreated {
+		t.Fatalf("create item status=%d body=%s", createItem.Code, createItem.Body.String())
+	}
+	var item struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createItem.Body).Decode(&item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if item.ID == "" {
+		t.Fatal("expected item id")
+	}
+
+	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"ready to buy"}`), map[string]string{"Content-Type": "application/json"})
+	if createWish.Code != http.StatusCreated {
+		t.Fatalf("create wishlist status=%d body=%s", createWish.Code, createWish.Body.String())
+	}
+	var wish struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createWish.Body).Decode(&wish); err != nil {
+		t.Fatalf("decode wishlist: %v", err)
+	}
+	if wish.ID == "" {
+		t.Fatal("expected wishlist id")
+	}
+
+	activateWishlistConvertProfile(t, a, p2.ID)
+	otherProfileConvert := doRequest(t, a, http.MethodPost, "/api/wishlist/convert-owned", strings.NewReader(`{"id":"`+wish.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if otherProfileConvert.Code != http.StatusBadRequest {
+		t.Fatalf("expected cross-profile conversion rejection, status=%d body=%s", otherProfileConvert.Code, otherProfileConvert.Body.String())
+	}
+
+	activateWishlistConvertProfile(t, a, p1.ID)
+	convert := doRequest(t, a, http.MethodPost, "/api/wishlist/convert-owned", strings.NewReader(`{"id":"`+wish.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if convert.Code != http.StatusOK {
+		t.Fatalf("convert wishlist status=%d body=%s", convert.Code, convert.Body.String())
+	}
+
+	wishlistItems := doRequest(t, a, http.MethodGet, "/api/items?status=wishlist", nil, nil)
+	if wishlistItems.Code != http.StatusOK {
+		t.Fatalf("wishlist items status=%d body=%s", wishlistItems.Code, wishlistItems.Body.String())
+	}
+	var wishlistPayload struct {
+		Items []struct {
+			ID string `json:"id"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(wishlistItems.Body).Decode(&wishlistPayload); err != nil {
+		t.Fatalf("decode wishlist items: %v", err)
+	}
+	if len(wishlistPayload.Items) != 0 {
+		t.Fatalf("expected converted item removed from wishlist, got %+v", wishlistPayload.Items)
+	}
+
+	inventoryItems := doRequest(t, a, http.MethodGet, "/api/items", nil, nil)
+	if inventoryItems.Code != http.StatusOK {
+		t.Fatalf("inventory items status=%d body=%s", inventoryItems.Code, inventoryItems.Body.String())
+	}
+	var inventoryPayload struct {
+		Items []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(inventoryItems.Body).Decode(&inventoryPayload); err != nil {
+		t.Fatalf("decode inventory items: %v", err)
+	}
+	if len(inventoryPayload.Items) != 1 || inventoryPayload.Items[0].ID != item.ID || inventoryPayload.Items[0].Status != "active" {
+		t.Fatalf("expected converted item in active inventory, got %+v", inventoryPayload.Items)
+	}
+}
+
+func createWishlistConvertProfile(t *testing.T, a *App, name string) struct {
+	ID string `json:"id"`
+} {
+	t.Helper()
+	create := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"`+name+`"}`), map[string]string{"Content-Type": "application/json"})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", create.Code, create.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(create.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	if profile.ID == "" {
+		t.Fatal("expected profile id")
+	}
+	return profile
+}
+
+func activateWishlistConvertProfile(t *testing.T, a *App, profileID string) {
+	t.Helper()
+	setActive := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profileID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if setActive.Code != http.StatusOK {
+		t.Fatalf("set active profile status=%d body=%s", setActive.Code, setActive.Body.String())
+	}
+	var active struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(setActive.Body).Decode(&active); err != nil {
+		t.Fatalf("decode active profile: %v", err)
+	}
+	if active.ID != profileID {
+		t.Fatalf("expected active profile %q, got %q", profileID, active.ID)
+	}
+}

--- a/internal/wishlist/service.go
+++ b/internal/wishlist/service.go
@@ -99,6 +99,18 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	return s.DeleteForProfile(ctx, "", id)
 }
 
+func (s *Service) ConvertToOwnedForProfile(ctx context.Context, profileID, id string) error {
+	trimmedProfileID := strings.TrimSpace(profileID)
+	itemID, err := s.itemIDForEntry(ctx, trimmedProfileID, id)
+	if err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)`, strings.TrimSpace(id), trimmedProfileID, trimmedProfileID); err != nil {
+		return err
+	}
+	return s.syncItemWishlistState(ctx, trimmedProfileID, itemID, "active", "")
+}
+
 func (s *Service) DeleteForProfile(ctx context.Context, profileID, id string) error {
 	trimmedProfileID := strings.TrimSpace(profileID)
 	itemID, _ := s.itemIDForEntry(ctx, trimmedProfileID, id)

--- a/openspec/specs/wishlist/ui-screen-wishlist/spec.md
+++ b/openspec/specs/wishlist/ui-screen-wishlist/spec.md
@@ -70,6 +70,25 @@ Wishlist rows/cards MUST be sourced from canonical `/api/items?status=wishlist` 
 - **AND** rows header semantics MUST render `Item ID`, `Title`, `Watch Status`, and `Target Priority`
 - **AND** UI MUST NOT render generic task-template headers such as `Task` or task workflow labels such as `Backlog`
 
+### Requirement UI-SCREEN-WISHLIST-008: Wishlist screen SHALL support planning focus controls
+Wishlist screen SHALL show planning metadata and persist the selected planning focus for the wishlist route.
+
+#### Scenario: Persist wishlist planning focus
+- **GIVEN** wishlist route is loaded with wishlist metadata overlays
+- **WHEN** user selects a planning focus
+- **THEN** the selected focus MUST be visually active
+- **AND** the selected focus MUST persist across refresh and route return
+
+### Requirement UI-SCREEN-WISHLIST-009: Wishlist screen SHALL explicitly move acquired items to Inventory
+Wishlist row actions SHALL expose a deliberate `Mark owned` action that calls the explicit wishlist conversion API.
+
+#### Scenario: Mark wishlist row owned
+- **GIVEN** wishlist route shows a wanted item with wishlist entry metadata
+- **WHEN** user selects `Mark owned` from the row action menu
+- **THEN** UI MUST submit `POST /api/wishlist/convert-owned` with the wishlist entry `id`
+- **AND** the item MUST disappear from Wishlist after refresh
+- **AND** the item MUST be visible in Inventory
+
 ## Use-Case IDs and E2E Mapping
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |

--- a/openspec/specs/wishlist/wishlist-items/spec.md
+++ b/openspec/specs/wishlist/wishlist-items/spec.md
@@ -15,3 +15,20 @@ Cabinet SHALL treat the canonical item record as the source-of-truth for wishlis
   - `target_price` (number)
   - `priority` (`low|medium|high`)
   - `notes` (string, optional)
+
+### Requirement WISHLIST-ITEMS-002: Wishlist entries SHALL convert explicitly to owned inventory
+Cabinet SHALL provide an explicit active-profile scoped conversion action that moves a wanted item into owned Inventory without relying on generic deletion semantics.
+
+#### Scenario: Convert wishlist entry to owned
+- **GIVEN** an authenticated user has an active profile with a wishlist entry for a canonical item
+- **WHEN** the user submits `POST /api/wishlist/convert-owned` with the wishlist entry `id`
+- **THEN** API MUST return `200`
+- **AND** the wishlist entry MUST be removed from `/api/wishlist`
+- **AND** the canonical item MUST no longer appear in `/api/items?status=wishlist`
+- **AND** the canonical item MUST appear in `/api/items` with lifecycle status `active`
+
+#### Scenario: Reject cross-profile wishlist conversion
+- **GIVEN** a wishlist entry belongs to a different profile than the active profile
+- **WHEN** the user submits `POST /api/wishlist/convert-owned` with that wishlist entry `id`
+- **THEN** API MUST reject the conversion
+- **AND** the original wishlist entry and canonical item status MUST remain unchanged

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -192,10 +192,11 @@ describe("ui-screen-wishlist", () => {
     cy.intercept("GET", "/api/items?status=wishlist", (req) => {
       req.reply({ statusCode: 200, body: { items: wishlistItems } });
     }).as("catalogItems");
-    cy.intercept("DELETE", "/api/wishlist?id=wish-1", (req) => {
+    cy.intercept("POST", "/api/wishlist/convert-owned", (req) => {
+      expect(req.body).to.deep.equal({ id: "wish-1" });
       wishlistEntries = [];
       wishlistItems = [];
-      req.reply({ statusCode: 204, body: "" });
+      req.reply({ statusCode: 200, body: { ok: true } });
     }).as("moveWishlistItemToOwned");
     cy.intercept("GET", "/api/items", {
       statusCode: 200,

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -327,10 +327,11 @@ export function Tasks({
       }
       setWishlistActionItemID(task.id)
       try {
-        const response = await fetch(
-          `/api/wishlist?id=${encodeURIComponent(wishlistEntryID)}`,
-          { method: 'DELETE' }
-        )
+        const response = await fetch('/api/wishlist/convert-owned', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: wishlistEntryID }),
+        })
         if (!response.ok) {
           throw new Error('failed_to_move_wishlist_item_to_owned')
         }


### PR DESCRIPTION
## Summary
- Add explicit `POST /api/wishlist/convert-owned` API for moving wanted items into owned Inventory.
- Wire Wishlist `Mark owned` row action to the explicit conversion endpoint instead of generic delete semantics.
- Add active-profile scoped runtime API coverage, update Cypress Wishlist flow coverage, OpenAPI, and OpenSpec requirements.

## Validation
- `go test ./internal/app -run "TestWishlistConvertOwnedEndpointMovesItemToInventoryForActiveProfile|TestOpenAPIDocumentsRuntimeEndpoints|TestWishlistAndPricingEndpoints" -count=1`
- `go test ./internal/wishlist -count=1`
- `npx.cmd eslint ui.web/src/features/tasks/index.tsx ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts`
- `pwsh -NoLogo -NoProfile -File .\scripts\validate-openapi.ps1` (valid; existing warning backlog remains)
- `openspec validate --all --strict --no-interactive`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- Runtime Cypress Wishlist spec: 11 passing
- `git diff --check`

Closes #629