### PR TITLE
#631 Harden folder reorder drag coverage

### DIFF
--- a/ui.web/cypress/e2e/inventory/folder-tree-control/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/folder-tree-control/spec.cy.ts
@@ -1,4 +1,6 @@
 describe('inventory-folder-tree-control', () => {
+  const folderDragDataType = 'application/x-cabinet-folder-id'
+
   function getFocusableElements(doc: Document) {
     return Array.from(
       doc.querySelectorAll<HTMLElement>(
@@ -34,88 +36,34 @@ describe('inventory-folder-tree-control', () => {
     return focusableElements[currentIndex + 1] ?? null
   }
 
-  function resolvePointerCoordinates(
-    element: Element,
-    mode: 'child' | 'before' | 'after' | 'center' = 'center'
-  ) {
-    const rect = element.getBoundingClientRect()
-    const centerX = rect.left + Math.min(rect.width / 2, 96)
-    const edgeInset = Math.max(8, Math.min(16, rect.height * 0.2))
-
-    if (mode === 'before') {
-      return { x: centerX, y: rect.top + edgeInset }
-    }
-    if (mode === 'after') {
-      return { x: centerX, y: rect.bottom - edgeInset }
-    }
-    return { x: centerX, y: rect.top + rect.height / 2 }
-  }
-
-  function dispatchPointerDown(win: Window, selector: string, pointerId: number) {
-    const element = win.document.querySelector<HTMLElement>(selector)
-    expect(element, `${selector} exists`).to.not.equal(null)
-    const { x, y } = resolvePointerCoordinates(element as HTMLElement)
-    element?.dispatchEvent(
-      new win.PointerEvent('pointerdown', {
-        bubbles: true,
-        cancelable: true,
-        button: 0,
-        buttons: 1,
-        pointerId,
-        pointerType: 'mouse',
-        isPrimary: true,
-        clientX: x,
-        clientY: y,
+  function getFolderLabels(selector: string) {
+    return cy.get(selector).children('[role="none"]').then(($rows) =>
+      [...$rows].map((row) => {
+        const label = row.querySelector('[role="treeitem"] [data-testid^="collection-folder-"]')
+        return label?.textContent?.trim() ?? ''
       })
     )
   }
 
-  function dispatchPointerMove(
-    win: Window,
-    selector: string,
-    mode: 'child' | 'before' | 'after' | 'center',
-    pointerId: number
+  function dragFolderInto(
+    folderID: string,
+    targetSelector: string,
+    targetDropEvent: 'dragenter' | 'dragover' | 'drop' = 'drop'
   ) {
-    const element = win.document.querySelector<HTMLElement>(selector)
-    expect(element, `${selector} exists`).to.not.equal(null)
-    const { x, y } = resolvePointerCoordinates(element as HTMLElement, mode)
-    win.dispatchEvent(
-      new win.PointerEvent('pointermove', {
-        bubbles: true,
-        cancelable: true,
-        button: 0,
-        buttons: 1,
-        pointerId,
-        pointerType: 'mouse',
-        isPrimary: true,
-        clientX: x,
-        clientY: y,
-      })
-    )
-  }
-
-  function dispatchPointerUp(
-    win: Window,
-    selector: string,
-    mode: 'child' | 'before' | 'after' | 'center',
-    pointerId: number
-  ) {
-    const element = win.document.querySelector<HTMLElement>(selector)
-    expect(element, `${selector} exists`).to.not.equal(null)
-    const { x, y } = resolvePointerCoordinates(element as HTMLElement, mode)
-    win.dispatchEvent(
-      new win.PointerEvent('pointerup', {
-        bubbles: true,
-        cancelable: true,
-        button: 0,
-        buttons: 0,
-        pointerId,
-        pointerType: 'mouse',
-        isPrimary: true,
-        clientX: x,
-        clientY: y,
-      })
-    )
+    cy.window().then((win) => {
+      const transfer = new win.DataTransfer()
+      cy.get(`[data-testid="folder-tree-drag-handle-${folderID}"]`)
+        .trigger('dragstart', { dataTransfer: transfer })
+        .then(() => {
+          expect(transfer.getData(folderDragDataType), `${folderID} drag data`).to.equal(folderID)
+        })
+      cy.get(targetSelector)
+        .trigger('dragenter', { dataTransfer: transfer })
+        .trigger('dragover', { dataTransfer: transfer })
+        .trigger(targetDropEvent, { dataTransfer: transfer })
+      cy.get(`[data-testid="folder-tree-drag-handle-${folderID}"]`)
+        .trigger('dragend', { dataTransfer: transfer })
+    })
   }
 
   beforeEach(() => {
@@ -444,7 +392,13 @@ describe('inventory-folder-tree-control', () => {
       .should('have.css', 'pointer-events', 'auto')
 
     cy.window().then((win) => {
-      dispatchPointerDown(win, '[data-testid="folder-tree-drag-handle-store-1"]', 11)
+      const transfer = new win.DataTransfer()
+      cy.get('[data-testid="folder-tree-drag-handle-store-1"]')
+        .trigger('dragstart', { dataTransfer: transfer })
+        .then(() => {
+          expect(transfer.getData(folderDragDataType), 'store-1 drag data').to.equal('store-1')
+        })
+      cy.wrap(transfer, { log: false }).as('folderDragTransfer')
     })
     cy.get('[data-testid="folder-tree-drag-preview"]')
       .should(($preview) => {
@@ -466,16 +420,24 @@ describe('inventory-folder-tree-control', () => {
     cy.get('[data-testid="folder-tree-row-shell-warehouses"]').then(($row) => {
       $row[0].scrollIntoView({ block: 'center' })
     })
-    cy.window().then((win) => {
-      dispatchPointerMove(win, '[data-testid="folder-tree-row-shell-warehouses"]', 'child', 11)
+    cy.get<DataTransfer>('@folderDragTransfer').then((transfer) => {
+      cy.get('[data-testid="folder-tree-item-warehouses"]')
+        .trigger('dragenter', { dataTransfer: transfer })
+        .trigger('dragover', { dataTransfer: transfer })
     })
     cy.get('[data-testid="folder-tree-item-warehouses"]').should('have.class', 'bg-primary/20')
     cy.get('[data-testid="folder-tree-drop-hint"]')
       .should('exist')
       .and('contain.text', 'Move into Warehouses')
-    cy.window().then((win) => {
-      dispatchPointerUp(win, '[data-testid="folder-tree-row-shell-warehouses"]', 'child', 11)
+    cy.get<DataTransfer>('@folderDragTransfer').then((transfer) => {
+      cy.get('[data-testid="folder-tree-item-warehouses"]')
+        .trigger('drop', { dataTransfer: transfer })
+      cy.get('[data-testid="folder-tree-drag-handle-store-1"]')
+        .trigger('dragend', { dataTransfer: transfer })
     })
+    cy.get('[data-testid="folder-tree-group-warehouses"]')
+      .find('[data-testid="folder-tree-item-store-1"]')
+      .should('be.visible')
     cy.get('[data-testid="folder-tree-drag-preview"]').should('not.exist')
     cy.get('[data-testid="folder-tree-root-drop-zone"]').should('not.exist')
   })
@@ -614,6 +576,61 @@ describe('inventory-folder-tree-control', () => {
           ).to.be.gte(availableHeight - 6)
         })
       })
+    })
+  })
+
+  it('UI-SCREEN-INVENTORY-FOLDER-TREE-020 performs deterministic chained folder structural reordering', () => {
+    cy.get('[data-testid="folder-tree-toggle-warehouses"]').click()
+    cy.get('[data-testid="folder-tree-group-warehouses"]').should('be.visible')
+
+    dragFolderInto('store-1', '[data-testid="folder-tree-item-warehouses"]')
+    cy.get('[data-testid="folder-tree-group-warehouses"]')
+      .find('[data-testid="folder-tree-item-store-1"]')
+      .should('be.visible')
+    cy.get('[data-testid="collection-active-context"]').should('contain.text', 'Store 1')
+
+    cy.window().then((win) => {
+      const transfer = new win.DataTransfer()
+      cy.get('[data-testid="folder-tree-drag-handle-warehouses"]')
+        .trigger('dragstart', { dataTransfer: transfer })
+      cy.get('[data-testid="folder-tree-item-store-1"]')
+        .should('have.attr', 'data-invalid-drop-target', 'true')
+        .trigger('dragenter', { dataTransfer: transfer })
+        .trigger('dragover', { dataTransfer: transfer })
+        .trigger('drop', { dataTransfer: transfer })
+      cy.get('[data-testid="folder-tree-drag-handle-warehouses"]')
+        .trigger('dragend', { dataTransfer: transfer })
+    })
+    cy.get('[data-testid="folder-tree-group-warehouses"]')
+      .find('[data-testid="folder-tree-item-store-1"]')
+      .should('be.visible')
+
+    dragFolderInto('store-1', '[data-testid="folder-tree-drop-before-warehouse-1"]')
+    getFolderLabels('[data-testid="folder-tree-group-warehouses"]').should((labels) => {
+      expect(labels.slice(0, 4)).to.deep.equal([
+        'Store 1',
+        'Warehouse 1',
+        'Warehouse 2',
+        'Warehouse 3',
+      ])
+    })
+
+    dragFolderInto('warehouse-3', '[data-testid="folder-tree-drop-after-store-1"]')
+    getFolderLabels('[data-testid="folder-tree-group-warehouses"]').should((labels) => {
+      expect(labels.slice(0, 4)).to.deep.equal([
+        'Store 1',
+        'Warehouse 3',
+        'Warehouse 1',
+        'Warehouse 2',
+      ])
+    })
+
+    dragFolderInto('store-1', '[data-testid="folder-tree-root-drop-zone"]')
+    cy.get('[data-testid="folder-tree-group-warehouses"]')
+      .find('[data-testid="folder-tree-item-store-1"]')
+      .should('not.exist')
+    getFolderLabels('[data-testid="inventory-folder-tree-scroll-region"]').should((labels) => {
+      expect(labels).to.include('Store 1')
     })
   })
 })

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -170,6 +170,7 @@ const inventoryFolderTreeSettingsKey = 'inventory.folder-tree.v1'
 const inventoryItemFolderAssignmentsStorageKey =
   'cabinet.inventory.item-folder-assignments.v1'
 const inventoryItemDragDataType = 'application/x-cabinet-inventory-item-id'
+const folderDragDataType = 'application/x-cabinet-folder-id'
 
 const folderCategoryOptions = [
   'Catalog',
@@ -728,6 +729,27 @@ function readInventoryItemDragID(dataTransfer: DataTransfer): string {
     dataTransfer.getData(inventoryItemDragDataType) ||
     dataTransfer.getData('text/plain')
   ).trim()
+}
+
+function readFolderDragID(dataTransfer: DataTransfer): string {
+  return dataTransfer.getData(folderDragDataType).trim()
+}
+
+function canMoveFolderToTarget(
+  nodes: FolderNode[],
+  draggedID: string,
+  target: FolderDropTarget | null
+): boolean {
+  if (draggedID === '' || draggedID === 'all-items' || !target) {
+    return false
+  }
+  if (target.kind === 'root') {
+    return true
+  }
+  if (draggedID === target.nodeID) {
+    return false
+  }
+  return !isInvalidFolderDropTarget(nodes, draggedID, target.nodeID)
 }
 
 function resolveFolderDragPreviewPosition(clientX: number, clientY: number) {
@@ -1296,6 +1318,9 @@ export function Collection({
 
   const handleInventoryItemFolderDragOver = useCallback(
     (node: FolderNode, event: ReactDragEvent<HTMLElement>) => {
+      if (readFolderDragID(event.dataTransfer)) {
+        return
+      }
       if (node.id === 'all-items') {
         return
       }
@@ -1313,6 +1338,9 @@ export function Collection({
 
   const handleInventoryItemFolderDrop = useCallback(
     (node: FolderNode, event: ReactDragEvent<HTMLElement>) => {
+      if (readFolderDragID(event.dataTransfer)) {
+        return
+      }
       if (node.id === 'all-items') {
         return
       }
@@ -1331,6 +1359,78 @@ export function Collection({
       setActiveFolder(node.name)
     },
     []
+  )
+
+  const clearFolderHTMLDrag = useCallback(() => {
+    setDragPreviewPosition(null)
+    setDraggedFolderID(null)
+    setDragTarget(null)
+  }, [])
+
+  const startFolderHTMLDrag = useCallback(
+    (node: FolderNode, event: ReactDragEvent<HTMLButtonElement>) => {
+      if (node.id === 'all-items') {
+        event.preventDefault()
+        return
+      }
+
+      event.stopPropagation()
+      event.dataTransfer.effectAllowed = 'move'
+      event.dataTransfer.setData(folderDragDataType, node.id)
+      setDraggedFolderID(node.id)
+      setDragTarget(null)
+      setDragPreviewPosition(
+        resolveFolderDragPreviewPosition(event.clientX, event.clientY)
+      )
+    },
+    []
+  )
+
+  const handleFolderHTMLDragOver = useCallback(
+    (target: FolderDropTarget, event: ReactDragEvent<HTMLElement>) => {
+      const folderID = readFolderDragID(event.dataTransfer)
+      if (!folderID) {
+        return false
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      setDraggedFolderID(folderID)
+      setDragPreviewPosition(
+        resolveFolderDragPreviewPosition(event.clientX, event.clientY)
+      )
+
+      if (!canMoveFolderToTarget(folderTree, folderID, target)) {
+        event.dataTransfer.dropEffect = 'none'
+        setDragTarget(null)
+        return true
+      }
+
+      event.dataTransfer.dropEffect = 'move'
+      setDragTarget((previous) =>
+        folderDropTargetsEqual(previous, target) ? previous : target
+      )
+      return true
+    },
+    [folderTree]
+  )
+
+  const handleFolderHTMLDrop = useCallback(
+    (target: FolderDropTarget, event: ReactDragEvent<HTMLElement>) => {
+      const folderID = readFolderDragID(event.dataTransfer)
+      if (!folderID) {
+        return false
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      if (canMoveFolderToTarget(folderTree, folderID, target)) {
+        moveDraggedFolder(folderID, target)
+      }
+      clearFolderHTMLDrag()
+      return true
+    },
+    [clearFolderHTMLDrag, folderTree, moveDraggedFolder]
   )
 
   const renderFolderTree = useCallback(
@@ -1358,6 +1458,21 @@ export function Collection({
                 data-folder-row-id={node.id}
                 data-invalid-drop-target={
                   hasInvalidFolderDropTarget ? 'true' : 'false'
+                }
+                onDragEnter={(event) =>
+                  handleFolderHTMLDragOver(
+                    { kind: 'before', nodeID: node.id },
+                    event
+                  )
+                }
+                onDragOver={(event) =>
+                  handleFolderHTMLDragOver(
+                    { kind: 'before', nodeID: node.id },
+                    event
+                  )
+                }
+                onDrop={(event) =>
+                  handleFolderHTMLDrop({ kind: 'before', nodeID: node.id }, event)
                 }
                 className={cn(
                   'mx-2 mb-1 h-2 rounded-full border border-dashed transition-colors',
@@ -1429,9 +1544,24 @@ export function Collection({
                 )}
                 onClick={() => setActiveFolder(node.name)}
                 onKeyDown={(event) => handleTreeItemKeyDown(node, event)}
-                onDragEnter={(event) => handleInventoryItemFolderDragOver(node, event)}
-                onDragOver={(event) => handleInventoryItemFolderDragOver(node, event)}
-                onDrop={(event) => handleInventoryItemFolderDrop(node, event)}
+                onDragEnter={(event) => {
+                  if (handleFolderHTMLDragOver({ kind: 'child', nodeID: node.id }, event)) {
+                    return
+                  }
+                  handleInventoryItemFolderDragOver(node, event)
+                }}
+                onDragOver={(event) => {
+                  if (handleFolderHTMLDragOver({ kind: 'child', nodeID: node.id }, event)) {
+                    return
+                  }
+                  handleInventoryItemFolderDragOver(node, event)
+                }}
+                onDrop={(event) => {
+                  if (handleFolderHTMLDrop({ kind: 'child', nodeID: node.id }, event)) {
+                    return
+                  }
+                  handleInventoryItemFolderDrop(node, event)
+                }}
               >
                 <span
                   className={cn(
@@ -1596,6 +1726,8 @@ export function Collection({
                     draggedFolderID === node.id && 'text-foreground'
                   )}
                   onPointerDown={(event) => startFolderPointerDrag(node.id, event)}
+                  onDragStart={(event) => startFolderHTMLDrag(node, event)}
+                  onDragEnd={clearFolderHTMLDrag}
                   onMouseDown={(event) => event.stopPropagation()}
                   onClick={(event) => event.preventDefault()}
                 >
@@ -1611,6 +1743,15 @@ export function Collection({
                 data-folder-row-id={node.id}
                 data-invalid-drop-target={
                   hasInvalidFolderDropTarget ? 'true' : 'false'
+                }
+                onDragEnter={(event) =>
+                  handleFolderHTMLDragOver({ kind: 'after', nodeID: node.id }, event)
+                }
+                onDragOver={(event) =>
+                  handleFolderHTMLDragOver({ kind: 'after', nodeID: node.id }, event)
+                }
+                onDrop={(event) =>
+                  handleFolderHTMLDrop({ kind: 'after', nodeID: node.id }, event)
                 }
                 className={cn(
                   'mx-2 mt-1 h-2 rounded-full border border-dashed transition-colors',
@@ -1636,14 +1777,18 @@ export function Collection({
       }),
     [
       activeFolder,
+      clearFolderHTMLDrag,
       dragTarget,
       draggedFolderID,
       expandedNodeIDs,
+      handleFolderHTMLDragOver,
+      handleFolderHTMLDrop,
       handleInventoryItemFolderDragOver,
       handleInventoryItemFolderDrop,
       handleTreeItemKeyDown,
       folderTree,
       openFolderProperties,
+      startFolderHTMLDrag,
       startFolderPointerDrag,
       toggleNodeExpanded,
     ]
@@ -2419,6 +2564,15 @@ export function Collection({
                     <div
                       role='presentation'
                       data-testid='folder-tree-root-drop-zone'
+                      onDragEnter={(event) =>
+                        handleFolderHTMLDragOver({ kind: 'root' }, event)
+                      }
+                      onDragOver={(event) =>
+                        handleFolderHTMLDragOver({ kind: 'root' }, event)
+                      }
+                      onDrop={(event) =>
+                        handleFolderHTMLDrop({ kind: 'root' }, event)
+                      }
                       className='rounded-md border border-dashed border-primary/40 bg-primary/10 px-3 py-2 text-xs text-primary'
                     >
                       Drop here to move folder to the root level


### PR DESCRIPTION
## Summary
- add deterministic folder HTML drag/drop handling for child, before/after, invalid descendant, and root moves
- keep folder drag data separate from inventory item drag data
- expand Cypress folder-tree coverage for chained structural reordering and stable preview/hint assertions

## Validation
- `npx.cmd eslint ui.web/src/features/collection/index.tsx ui.web/cypress/e2e/inventory/folder-tree-control/spec.cy.ts`
- `go test ./internal/app -run "TestInventoryFolderTreeStructuredAffordancesContract|TestInventoryFolderTreePersistenceAndDragContract" -count=1`
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/folder-tree-control/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`