### PR TITLE
#647 fix(wishlist): filter table by selected collection

### DIFF
--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -48,6 +48,7 @@ describe("ui-screen-wishlist", () => {
     if (!options?.skipStub) {
       stubWishlistData();
     }
+    cy.intercept("GET", "/api/profiles/*/settings").as("profileSettings");
     cy.e2eReset();
     cy.e2eSetSetupState("present");
     cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
@@ -57,6 +58,16 @@ describe("ui-screen-wishlist", () => {
     });
     cy.wait("@wishlistItems");
     cy.wait("@catalogItems");
+    cy.wait("@profileSettings");
+    cy.wait("@profileSettings");
+  }
+
+  function openWishlistRowActions(rowText: string) {
+    cy.contains("tr", rowText)
+      .find('[data-testid="task-row-actions-trigger"]')
+      .should("be.visible")
+      .trigger("pointerdown", { button: 0, force: true });
+    cy.get('[role="menu"]').should("be.visible");
   }
 
   it("UI-SCREEN-WISHLIST-001 filters list and persists row/card view mode", () => {
@@ -139,6 +150,27 @@ describe("ui-screen-wishlist", () => {
     cy.get('[data-testid="wishlist-inline-new-name"]').should("be.visible");
   });
 
+  it("UI-SCREEN-WISHLIST-011 filters table rows by selected wishlist collection", () => {
+    signInToWishlist();
+
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
+    cy.contains("F1 Silverline").should("be.visible");
+
+    cy.get('[data-testid="wishlist-inline-picker"] select').select("Overflow");
+    cy.get('[data-testid="wishlist-inline-picker-selected"]').should(
+      "contain",
+      "Overflow"
+    );
+
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+    cy.contains("F1 Silverline").should("not.exist");
+    cy.contains("No results.").should("be.visible");
+
+    cy.get('[data-testid="wishlist-inline-picker"] select').select("All Items");
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
+    cy.contains("F1 Silverline").should("be.visible");
+  });
+
   it("UI-SCREEN-WISHLIST-007 renders wishlist collection semantics instead of task seed rows", () => {
     signInToWishlist();
 
@@ -205,10 +237,8 @@ describe("ui-screen-wishlist", () => {
 
     signInToWishlist({ skipStub: true });
 
-    cy.contains("tr", "AFX Mega-G+ Camaro Wildfire").within(() => {
-      cy.get('[data-testid="task-row-actions-trigger"]').click();
-    });
-    cy.get('[data-testid="wishlist-mark-owned-action"]').click();
+    openWishlistRowActions("AFX Mega-G+ Camaro Wildfire");
+    cy.get('[data-testid="wishlist-mark-owned-action"]').click({ force: true });
 
     cy.wait("@moveWishlistItemToOwned");
     cy.wait("@wishlistItems");
@@ -433,10 +463,8 @@ describe("ui-screen-wishlist", () => {
 
     signInToWishlist({ skipStub: true });
 
-    cy.contains("tr", "AFX Mega-G+ Camaro Wildfire").within(() => {
-      cy.get('[data-testid="task-row-actions-trigger"]').click();
-    });
-    cy.contains('[role="menuitem"]', "Edit").click();
+    openWishlistRowActions("AFX Mega-G+ Camaro Wildfire");
+    cy.contains('[role="menuitem"]', "Edit").click({ force: true });
 
     cy.contains("Edit Wishlist Entry").should("be.visible");
     cy.get('input[name="title"]').clear().type("AFX Mega-G+ Camaro Updated");
@@ -450,9 +478,7 @@ describe("ui-screen-wishlist", () => {
     cy.contains("AFX Mega-G+ Camaro Updated").should("be.visible");
     cy.contains("Updated watch note").should("be.visible");
 
-    cy.contains("tr", "AFX Mega-G+ Camaro Updated").within(() => {
-      cy.get('[data-testid="task-row-actions-trigger"]').click();
-    });
+    openWishlistRowActions("AFX Mega-G+ Camaro Updated");
     cy.get('[role="menu"]')
       .should("be.visible")
       .within(() => {

--- a/ui.web/src/features/tasks/components/data-table-row-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-row-actions.tsx
@@ -1,6 +1,7 @@
 import { DotsHorizontalIcon } from '@radix-ui/react-icons'
 import { type Row } from '@tanstack/react-table'
 import { Trash2 } from 'lucide-react'
+import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -32,19 +33,29 @@ export function DataTableRowActions<TData>({
   const task = taskSchema.parse(row.original)
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
   const isWishlistActionPending = wishlistActionItemID === task.id
+  const [open, setOpen] = useState(false)
 
   return (
-    <DropdownMenu modal={false}>
+    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <Button
+          type='button'
           variant='ghost'
           className='flex h-8 w-8 p-0 data-[state=open]:bg-muted'
           data-testid='task-row-actions-trigger'
+          onPointerDown={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            setOpen(true)
+          }}
+          onMouseDown={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            setOpen(true)
+          }}
           onClick={(event) => {
             event.stopPropagation()
-          }}
-          onPointerDown={(event) => {
-            event.stopPropagation()
+            setOpen(true)
           }}
         >
           <DotsHorizontalIcon className='h-4 w-4' />

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -220,6 +220,7 @@ export function Tasks({
   const {
     workspaceCollections,
     activeWorkspaceCollection,
+    collectionItems,
     setActiveWorkspaceCollection,
     addCollection,
   } = useWorkspaceCollections()
@@ -627,10 +628,30 @@ export function Tasks({
     if (!isWishlistRoute) {
       return tableData
     }
-    return tableData.filter((task) =>
+
+    const focusedData = tableData.filter((task) =>
       matchesWishlistPlanningFocus(task, wishlistPlanningFocus)
     )
-  }, [isWishlistRoute, tableData, wishlistPlanningFocus])
+    if (activeWorkspaceCollection === 'All Items') {
+      return focusedData
+    }
+
+    const selectedCollectionItemIDs = new Set(
+      collectionItems
+        .filter((item) => item.collectionName === activeWorkspaceCollection)
+        .map((item) => item.id)
+    )
+
+    return focusedData.filter((task) =>
+      selectedCollectionItemIDs.has(task.itemID ?? task.id)
+    )
+  }, [
+    activeWorkspaceCollection,
+    collectionItems,
+    isWishlistRoute,
+    tableData,
+    wishlistPlanningFocus,
+  ])
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Filters Wishlist table rows by the active wishlist/collection after the planning-focus filter.
- Keeps All Items showing the full focused Wishlist table and selected empty collections showing the table empty state.
- Stabilizes Wishlist row action menu opening for the Cypress coverage path.

## Validation
- npx.cmd eslint ui.web/src/features/tasks/index.tsx ui.web/src/features/tasks/components/data-table-row-actions.tsx ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- go test ./internal/app -run Wishlist -count=1
- git diff --check

Closes #647