### PR TITLE
#648 feat(wishlist): move collection picker into table filters

### DIFF
--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -125,10 +125,10 @@ describe("ui-screen-wishlist", () => {
   it("UI-SCREEN-WISHLIST-005 supports inline collection create and auto-select", () => {
     signInToWishlist();
 
-    cy.get('[data-testid="wishlist-inline-add-new"]').click();
-    cy.get('[data-testid="wishlist-inline-new-name"]').type("Wishlist Inline Alpha");
-    cy.get('[data-testid="wishlist-inline-save"]').click();
-    cy.get('[data-testid="wishlist-inline-picker-selected"]').should(
+    cy.get('[data-testid="wishlist-table-add-collection"]').click();
+    cy.get('[data-testid="wishlist-table-new-collection-name"]').type("Wishlist Inline Alpha");
+    cy.get('[data-testid="wishlist-table-new-collection-save"]').click();
+    cy.get('[data-testid="wishlist-table-collection-selected"]').should(
       "contain",
       "Wishlist Inline Alpha"
     );
@@ -137,17 +137,17 @@ describe("ui-screen-wishlist", () => {
   it("UI-SCREEN-WISHLIST-005 keeps inline create open and shows validation on blank save", () => {
     signInToWishlist();
 
-    cy.get('[data-testid="wishlist-inline-add-new"]').click();
-    cy.get('[data-testid="wishlist-inline-save"]').click();
-    cy.get('[data-testid="wishlist-inline-new-name"]').should(
+    cy.get('[data-testid="wishlist-table-add-collection"]').click();
+    cy.get('[data-testid="wishlist-table-new-collection-save"]').click();
+    cy.get('[data-testid="wishlist-table-new-collection-name"]').should(
       "have.attr",
       "aria-invalid",
       "true"
     );
-    cy.get('[data-testid="wishlist-inline-validation"]')
+    cy.get('[data-testid="wishlist-table-new-collection-validation"]')
       .should("be.visible")
       .and("contain", "Collection name is required.");
-    cy.get('[data-testid="wishlist-inline-new-name"]').should("be.visible");
+    cy.get('[data-testid="wishlist-table-new-collection-name"]').should("be.visible");
   });
 
   it("UI-SCREEN-WISHLIST-011 filters table rows by selected wishlist collection", () => {
@@ -156,8 +156,8 @@ describe("ui-screen-wishlist", () => {
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
     cy.contains("F1 Silverline").should("be.visible");
 
-    cy.get('[data-testid="wishlist-inline-picker"] select').select("Overflow");
-    cy.get('[data-testid="wishlist-inline-picker-selected"]').should(
+    cy.get('[data-testid="wishlist-table-collection-select"]').select("Overflow");
+    cy.get('[data-testid="wishlist-table-collection-selected"]').should(
       "contain",
       "Overflow"
     );
@@ -166,9 +166,32 @@ describe("ui-screen-wishlist", () => {
     cy.contains("F1 Silverline").should("not.exist");
     cy.contains("No results.").should("be.visible");
 
-    cy.get('[data-testid="wishlist-inline-picker"] select').select("All Items");
+    cy.get('[data-testid="wishlist-table-collection-select"]').select("All Items");
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
     cy.contains("F1 Silverline").should("be.visible");
+  });
+
+  it("UI-SCREEN-WISHLIST-012 uses compact table collection filter instead of separate picker section", () => {
+    signInToWishlist();
+
+    cy.get('[data-testid="wishlist-inline-picker"]').should("not.exist");
+    cy.get('[data-testid="wishlist-table-collection-filter"]').should(
+      "be.visible"
+    );
+    cy.get('[data-testid="wishlist-table-add-collection"]').should(
+      "be.visible"
+    );
+
+    cy.get('[data-testid="wishlist-table-collection-select"]').select(
+      "Overflow"
+    );
+    cy.get('[data-testid="wishlist-table-collection-selected"]').should(
+      "contain",
+      "Overflow"
+    );
+    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
+    cy.contains("F1 Silverline").should("not.exist");
+    cy.contains("No results.").should("be.visible");
   });
 
   it("UI-SCREEN-WISHLIST-007 renders wishlist collection semantics instead of task seed rows", () => {

--- a/ui.web/src/components/data-table/toolbar.tsx
+++ b/ui.web/src/components/data-table/toolbar.tsx
@@ -9,6 +9,7 @@ type DataTableToolbarProps<TData> = {
   table: Table<TData>
   searchPlaceholder?: string
   searchKey?: string
+  customFilters?: React.ReactNode
   filters?: {
     columnId: string
     title: string
@@ -24,14 +25,15 @@ export function DataTableToolbar<TData>({
   table,
   searchPlaceholder = 'Filter...',
   searchKey,
+  customFilters,
   filters = [],
 }: DataTableToolbarProps<TData>) {
   const isFiltered =
     table.getState().columnFilters.length > 0 || table.getState().globalFilter
 
   return (
-    <div className='flex items-center justify-between'>
-      <div className='flex flex-1 flex-col-reverse items-start gap-y-2 sm:flex-row sm:items-center sm:space-x-2'>
+    <div className='flex flex-wrap items-center justify-between gap-2'>
+      <div className='flex flex-1 flex-col-reverse items-start gap-y-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2'>
         {searchKey ? (
           <Input
             placeholder={searchPlaceholder}
@@ -51,7 +53,7 @@ export function DataTableToolbar<TData>({
             className='h-8 w-[150px] lg:w-[250px]'
           />
         )}
-        <div className='flex gap-x-2'>
+        <div className='flex flex-wrap gap-2'>
           {filters.map((filter) => {
             const column = table.getColumn(filter.columnId)
             if (!column) return null
@@ -65,6 +67,7 @@ export function DataTableToolbar<TData>({
             )
           })}
         </div>
+        {customFilters}
         {isFiltered && (
           <Button
             variant='ghost'

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -1,6 +1,7 @@
 import {
   type KeyboardEvent,
   type MouseEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -64,6 +65,7 @@ type DataTableProps = {
   onWishlistExport?: (tasks: Task[]) => void
   wishlistActionItemID?: string | null
   isWishlistMutating?: boolean
+  wishlistCollectionFilter?: ReactNode
 }
 
 type ViewMode = 'rows' | 'cards'
@@ -202,6 +204,7 @@ export function TasksTable({
   onWishlistExport,
   wishlistActionItemID,
   isWishlistMutating,
+  wishlistCollectionFilter,
 }: DataTableProps) {
   const isInventoryRoute = routePath === '/_authenticated/inventory/'
   const columns = useMemo(
@@ -632,6 +635,7 @@ export function TasksTable({
               : priorities,
           },
         ]}
+        customFilters={wishlistCollectionFilter}
       />
 
       <div className='flex flex-wrap items-center justify-between gap-2'>

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -653,6 +653,98 @@ export function Tasks({
     wishlistPlanningFocus,
   ])
 
+  const wishlistCollectionFilter = isWishlistRoute ? (
+    <div
+      className='flex flex-wrap items-center gap-2'
+      data-testid='wishlist-table-collection-filter'
+    >
+      <select
+        className='h-8 min-w-[10rem] rounded-md border bg-background px-2 text-sm'
+        data-testid='wishlist-table-collection-select'
+        value={activeWorkspaceCollection}
+        onChange={(event) => {
+          void setActiveWorkspaceCollection(event.target.value)
+        }}
+      >
+        {workspaceCollections.map((collection) => (
+          <option
+            key={collection}
+            value={collection}
+            data-testid={`wishlist-table-collection-option-${collectionKey(collection)}`}
+          >
+            {collection}
+          </option>
+        ))}
+      </select>
+      <span
+        className='text-xs text-muted-foreground'
+        data-testid='wishlist-table-collection-selected'
+      >
+        {activeWorkspaceCollection}
+      </span>
+      <Button
+        type='button'
+        variant='outline'
+        className='h-8 px-2 text-xs'
+        data-testid='wishlist-table-add-collection'
+        onClick={() => {
+          setInlineCollectionValidationMessage('')
+          setInlineCollectionInputOpen((open) => !open)
+        }}
+      >
+        + New Collection
+      </Button>
+      {inlineCollectionInputOpen ? (
+        <div
+          className='flex flex-wrap items-center gap-2'
+          data-testid='wishlist-table-new-collection-form'
+        >
+          <Input
+            className='h-8 w-[12rem]'
+            data-testid='wishlist-table-new-collection-name'
+            placeholder='Collection name'
+            aria-invalid={inlineCollectionValidationMessage ? 'true' : 'false'}
+            value={inlineCollectionName}
+            onChange={(event) => {
+              setInlineCollectionName(event.target.value)
+              if (inlineCollectionValidationMessage) {
+                setInlineCollectionValidationMessage('')
+              }
+            }}
+          />
+          <Button
+            type='button'
+            className='h-8 px-3'
+            data-testid='wishlist-table-new-collection-save'
+            onClick={async () => {
+              const created = await addCollection(inlineCollectionName)
+              if (!created) {
+                setInlineCollectionValidationMessage(
+                  'Collection name is required.'
+                )
+                return
+              }
+              setInlineCollectionValidationMessage('')
+              setInlineCollectionName('')
+              setInlineCollectionInputOpen(false)
+            }}
+          >
+            Save
+          </Button>
+          {inlineCollectionValidationMessage ? (
+            <span
+              className='text-sm text-destructive'
+              data-testid='wishlist-table-new-collection-validation'
+              role='alert'
+            >
+              {inlineCollectionValidationMessage}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  ) : undefined
+
   return (
     <>
       <Header fixed>
@@ -718,99 +810,10 @@ export function Tasks({
             ))}
           </div>
         ) : null}
-        {isWishlistRoute ? (
-          <div
-            className='rounded-md border p-3'
-            data-testid='wishlist-inline-picker'
-          >
-            <div className='grid gap-2 md:grid-cols-[minmax(0,1fr)_auto_auto] md:items-center'>
-              <select
-                className='h-9 rounded-md border bg-background px-2 text-sm'
-                value={activeWorkspaceCollection}
-                onChange={(event) => {
-                  void setActiveWorkspaceCollection(event.target.value)
-                }}
-              >
-                {workspaceCollections.map((collection) => (
-                  <option
-                    key={collection}
-                    value={collection}
-                    data-testid={`wishlist-inline-picker-option-${collectionKey(collection)}`}
-                  >
-                    {collection}
-                  </option>
-                ))}
-              </select>
-              <span
-                className='text-sm text-muted-foreground'
-                data-testid='wishlist-inline-picker-selected'
-              >
-                {activeWorkspaceCollection}
-              </span>
-              <Button
-                type='button'
-                variant='outline'
-                data-testid='wishlist-inline-add-new'
-                onClick={() => {
-                  setInlineCollectionValidationMessage('')
-                  setInlineCollectionInputOpen((open) => !open)
-                }}
-              >
-                + New Collection
-              </Button>
-            </div>
-            {inlineCollectionInputOpen ? (
-              <div className='mt-2'>
-                <div className='flex gap-2'>
-                  <Input
-                    data-testid='wishlist-inline-new-name'
-                    placeholder='Collection name'
-                    aria-invalid={
-                      inlineCollectionValidationMessage ? 'true' : 'false'
-                    }
-                    value={inlineCollectionName}
-                    onChange={(event) => {
-                      setInlineCollectionName(event.target.value)
-                      if (inlineCollectionValidationMessage) {
-                        setInlineCollectionValidationMessage('')
-                      }
-                    }}
-                  />
-                  <Button
-                    type='button'
-                    data-testid='wishlist-inline-save'
-                    onClick={async () => {
-                      const created = await addCollection(inlineCollectionName)
-                      if (!created) {
-                        setInlineCollectionValidationMessage(
-                          'Collection name is required.'
-                        )
-                        return
-                      }
-                      setInlineCollectionValidationMessage('')
-                      setInlineCollectionName('')
-                      setInlineCollectionInputOpen(false)
-                    }}
-                  >
-                    Save
-                  </Button>
-                </div>
-                {inlineCollectionValidationMessage ? (
-                  <p
-                    className='mt-2 text-sm text-destructive'
-                    data-testid='wishlist-inline-validation'
-                    role='alert'
-                  >
-                    {inlineCollectionValidationMessage}
-                  </p>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
         <TasksTable
           data={displayedData}
           routePath={routePath}
+          wishlistCollectionFilter={wishlistCollectionFilter}
           onEditRow={(task) => {
             setCurrentDialogRow(task)
             setDialogOpen('update')


### PR DESCRIPTION
## Summary
- Moves the Wishlist collection picker into the shared table toolbar as a compact filter control.
- Removes the old standalone bordered picker block while keeping compact + New Collection flow in the table filter area.
- Updates Wishlist Cypress coverage to assert the compact filter surface and filtering behavior.

## Validation
- npx.cmd eslint ui.web/src/components/data-table/toolbar.tsx ui.web/src/features/tasks/index.tsx ui.web/src/features/tasks/components/tasks-table.tsx ui.web/src/features/tasks/components/data-table-row-actions.tsx ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- git diff --check

Closes #648