### PR TITLE
#651 fix(wishlist): persist manual watch status

### DIFF
--- a/internal/app/wishlist_planning_metadata_api_test.go
+++ b/internal/app/wishlist_planning_metadata_api_test.go
@@ -1,0 +1,106 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+
+	createProfile := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"Wishlist Metadata P1"}`), map[string]string{"Content-Type": "application/json"})
+	if createProfile.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", createProfile.Code, createProfile.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createProfile.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	if profile.ID == "" {
+		t.Fatal("expected profile id")
+	}
+
+	setActive := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profile.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if setActive.Code != http.StatusOK {
+		t.Fatalf("set active profile status=%d body=%s", setActive.Code, setActive.Body.String())
+	}
+
+	createItem := doRequest(t, a, http.MethodPost, "/api/items", strings.NewReader(`{"part_number":"WISH-META-001","title":"Wishlist Metadata Item","brand":"AFX","category":"Slot"}`), map[string]string{"Content-Type": "application/json"})
+	if createItem.Code != http.StatusCreated {
+		t.Fatalf("create item status=%d body=%s", createItem.Code, createItem.Body.String())
+	}
+	var item struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createItem.Body).Decode(&item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if item.ID == "" {
+		t.Fatal("expected item id")
+	}
+
+	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"manual watch state","below_target_now":true,"highlight_hit":true}`), map[string]string{"Content-Type": "application/json"})
+	if createWish.Code != http.StatusCreated {
+		t.Fatalf("create wishlist status=%d body=%s", createWish.Code, createWish.Body.String())
+	}
+	var created struct {
+		ID             string `json:"id"`
+		BelowTargetNow bool   `json:"below_target_now"`
+		HighlightHit   bool   `json:"highlight_hit"`
+	}
+	if err := json.NewDecoder(createWish.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created wishlist: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected wishlist id")
+	}
+	if !created.BelowTargetNow {
+		t.Fatalf("expected created wishlist to persist below_target_now=true, got %+v", created)
+	}
+	if !created.HighlightHit {
+		t.Fatalf("expected created wishlist to persist highlight_hit=true, got %+v", created)
+	}
+
+	updateWish := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+created.ID+`","item_id":"`+item.ID+`","target_price":42,"priority":"medium","notes":"updated manual watch state","below_target_now":false,"highlight_hit":false}`), map[string]string{"Content-Type": "application/json"})
+	if updateWish.Code != http.StatusOK {
+		t.Fatalf("update wishlist status=%d body=%s", updateWish.Code, updateWish.Body.String())
+	}
+
+	listWish := doRequest(t, a, http.MethodGet, "/api/wishlist", nil, nil)
+	if listWish.Code != http.StatusOK {
+		t.Fatalf("list wishlist status=%d body=%s", listWish.Code, listWish.Body.String())
+	}
+	var listPayload struct {
+		Items []struct {
+			ID             string `json:"id"`
+			BelowTargetNow bool   `json:"below_target_now"`
+			HighlightHit   bool   `json:"highlight_hit"`
+			Priority       string `json:"priority"`
+			Notes          string `json:"notes"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(listWish.Body).Decode(&listPayload); err != nil {
+		t.Fatalf("decode wishlist payload: %v", err)
+	}
+	if len(listPayload.Items) != 1 {
+		t.Fatalf("expected one wishlist entry, got %+v", listPayload.Items)
+	}
+	if listPayload.Items[0].BelowTargetNow {
+		t.Fatalf("expected updated wishlist below_target_now=false after round-trip, got %+v", listPayload.Items[0])
+	}
+	if listPayload.Items[0].HighlightHit {
+		t.Fatalf("expected updated wishlist highlight_hit=false after round-trip, got %+v", listPayload.Items[0])
+	}
+	if listPayload.Items[0].Priority != "medium" {
+		t.Fatalf("expected updated wishlist priority=medium, got %+v", listPayload.Items[0])
+	}
+	if listPayload.Items[0].Notes != "updated manual watch state" {
+		t.Fatalf("expected updated wishlist notes to persist, got %+v", listPayload.Items[0])
+	}
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -281,6 +281,7 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 			priority TEXT NOT NULL DEFAULT 'normal',
 			notes TEXT NOT NULL DEFAULT '',
 			highlight_hit INTEGER NOT NULL DEFAULT 1,
+			below_target_now INTEGER NOT NULL DEFAULT 0,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			FOREIGN KEY (item_id) REFERENCES canonical_items(id) ON DELETE CASCADE
@@ -547,6 +548,10 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "profile_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("ensure wishlist_entries.profile_id: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "below_target_now", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.below_target_now: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_wishlist_entries_profile_id ON wishlist_entries(profile_id);`); err != nil {
 		conn.Close()

--- a/internal/wishlist/service.go
+++ b/internal/wishlist/service.go
@@ -53,10 +53,14 @@ func (s *Service) CreateForProfile(ctx context.Context, profileID string, in Ent
 	if in.HighlightHit {
 		highlight = 1
 	}
+	belowTargetNow := 0
+	if in.BelowTargetNow {
+		belowTargetNow = 1
+	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, in.ID, trimmedProfileID, in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight)
+		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit, below_target_now)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, in.ID, trimmedProfileID, in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow)
 	if err != nil {
 		return Entry{}, fmt.Errorf("create wishlist entry: %w", err)
 	}
@@ -84,11 +88,15 @@ func (s *Service) UpdateForProfile(ctx context.Context, profileID string, in Ent
 	if in.HighlightHit {
 		highlight = 1
 	}
+	belowTargetNow := 0
+	if in.BelowTargetNow {
+		belowTargetNow = 1
+	}
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE wishlist_entries
-		SET target_price = ?, priority = ?, notes = ?, highlight_hit = ?, updated_at = CURRENT_TIMESTAMP
+		SET target_price = ?, priority = ?, notes = ?, highlight_hit = ?, below_target_now = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, in.TargetPrice, in.Priority, in.Notes, highlight, in.ID, trimmedProfileID, trimmedProfileID)
+	`, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, in.ID, trimmedProfileID, trimmedProfileID)
 	if err != nil {
 		return err
 	}
@@ -131,10 +139,11 @@ func (s *Service) GetByID(ctx context.Context, id string) (Entry, error) {
 func (s *Service) GetByIDForProfile(ctx context.Context, profileID, id string) (Entry, error) {
 	var e Entry
 	var highlight int
+	var belowTargetNow int
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, item_id, target_price, priority, notes, highlight_hit, created_at, updated_at
+		SELECT id, item_id, target_price, priority, notes, highlight_hit, below_target_now, created_at, updated_at
 		FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &e.CreatedAt, &e.UpdatedAt)
+	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &belowTargetNow, &e.CreatedAt, &e.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return Entry{}, fmt.Errorf("wishlist entry not found")
@@ -142,7 +151,7 @@ func (s *Service) GetByIDForProfile(ctx context.Context, profileID, id string) (
 		return Entry{}, err
 	}
 	e.HighlightHit = highlight == 1
-	e.BelowTargetNow = s.isBelowTarget(ctx, e.ItemID, e.TargetPrice)
+	e.BelowTargetNow = belowTargetNow == 1 || s.isBelowTarget(ctx, e.ItemID, e.TargetPrice)
 	return e, nil
 }
 

--- a/ui.web/cypress/e2e/wishlist/wishlist-watch-status-persistence/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-watch-status-persistence/spec.cy.ts
@@ -1,0 +1,60 @@
+describe("wishlist-watch-status-persistence", () => {
+  it("persists manual watch status changes across refresh", () => {
+    cy.intercept("GET", "/api/wishlist").as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist").as("catalogItems");
+    cy.intercept("GET", "/api/profiles/*/settings").as("profileSettings");
+
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.request("PUT", "/api/profiles/active", { profile_id })
+        .its("status")
+        .should("eq", 200);
+
+      cy.request("POST", "/api/items", {
+        title: "Wishlist Manual Status Seed",
+        part_number: "WISH-LIVE-001",
+        category: "Slot Cars",
+        priority: "medium",
+      }).then((itemResp) => {
+        expect(itemResp.status).to.eq(201);
+        cy.request("POST", "/api/wishlist", {
+          item_id: itemResp.body.id,
+          target_price: 42,
+          priority: "medium",
+          notes: "Seeded for status persistence",
+          below_target_now: false,
+          highlight_hit: false,
+        })
+          .its("status")
+          .should("eq", 201);
+      });
+
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: "/wishlist/",
+      });
+    });
+
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.wait("@profileSettings");
+    cy.wait("@profileSettings");
+
+    cy.get('button[aria-label="Switch to rows view"]').click();
+    cy.contains("Wishlist Manual Status Seed").should("be.visible");
+    cy.get('button[aria-label="Select all"]').click();
+    cy.get('button[aria-label="Update status"]').click();
+    cy.contains('[role="menuitem"]', "Below target").click({ force: true });
+
+    cy.contains("Wishlist Manual Status Seed")
+      .closest("tr")
+      .should("contain", "Below target");
+
+    cy.reload();
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("Wishlist Manual Status Seed")
+      .closest("tr")
+      .should("contain", "Below target");
+  });
+});


### PR DESCRIPTION
## Summary
- persist manual below_target_now state on wishlist create and update
- keep scanner-derived below-target behavior compatible when reading entries back
- add focused API and Cypress coverage for watch-status persistence through refresh

## Validation
- go test ./internal/app -run TestWishlistEndpointPersistsManualWatchStatusForActiveProfile -count=1
- go test ./internal/app -run Wishlist -count=1
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-watch-status-persistence/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- npx.cmd eslint ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts ui.web/cypress/e2e/wishlist/wishlist-watch-status-persistence/spec.cy.ts
- git diff --check