### PR TITLE
#639 Move Inventory item editor into modal

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
@@ -1,0 +1,121 @@
+describe("inventory item editor modal", () => {
+  function signIn() {
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path: "/inventory/" });
+    });
+  }
+
+  it("creates, cancels, edits, saves, and navigates inventory records in a modal", () => {
+    const items = [
+      {
+        id: "item-alpha",
+        part_number: "PN-ALPHA",
+        title: "Alpha Item",
+        status: "active",
+        category: "Cars",
+        brand: "AFX",
+        priority: "medium",
+        description: "Alpha description",
+      },
+      {
+        id: "item-bravo",
+        part_number: "PN-BRAVO",
+        title: "Bravo Item",
+        status: "active",
+        category: "Trains",
+        brand: "Tyco",
+        priority: "medium",
+        description: "Bravo description",
+      },
+    ];
+
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
+    }).as("itemsList");
+
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body).to.include({
+        part_number: "PN-CREATED",
+        title: "Created Modal Item",
+      });
+      const created = {
+        id: "item-created",
+        part_number: "PN-CREATED",
+        title: "Created Modal Item",
+        status: "active",
+        category: "Cars",
+        brand: "Aurora",
+        priority: "medium",
+        description: "Created from modal",
+      };
+      items.unshift(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createItem");
+
+    cy.intercept("PUT", "/api/items/item-bravo", (req) => {
+      expect(req.body).to.include({
+        title: "Bravo Item Updated",
+        brand: "Updated Brand",
+      });
+      const index = items.findIndex((item) => item.id === "item-bravo");
+      items[index] = {
+        ...items[index],
+        title: "Bravo Item Updated",
+        brand: "Updated Brand",
+      };
+      req.reply({ statusCode: 200, body: items[index] });
+    }).as("updateBravo");
+
+    signIn();
+    cy.wait("@itemsList");
+
+    cy.get('[data-testid="inventory-item-editor"]').should("not.exist");
+
+    cy.get('[data-testid="inventory-new-action"]').click();
+    cy.get('[data-testid="inventory-item-editor-dialog"]')
+      .should("be.visible")
+      .and("contain", "Create Item");
+    cy.get('[data-testid="inventory-item-editor-cancel"]').click();
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.contains("Created Modal Item").should("not.exist");
+
+    cy.get('[data-testid="inventory-new-action"]').click();
+    cy.get('[data-testid="inventory-item-part-number"]').clear().type("PN-CREATED");
+    cy.get('[data-testid="inventory-item-title"]').clear().type("Created Modal Item");
+    cy.get('[data-testid="inventory-item-brand"]').clear().type("Aurora");
+    cy.get('[data-testid="inventory-item-category"]').clear().type("Cars");
+    cy.get('[data-testid="inventory-item-description"]').clear().type("Created from modal");
+    cy.get('[data-testid="inventory-item-save"]').click();
+
+    cy.wait("@createItem");
+    cy.wait("@itemsList");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATED");
+    cy.contains("Created Modal Item").should("be.visible");
+
+    cy.get('[data-testid="inventory-item-row-item-alpha"] [data-testid="task-row-actions-trigger"]').click();
+    cy.contains('[role="menuitem"]', "Edit").click();
+    cy.get('[data-testid="inventory-item-editor-dialog"]')
+      .should("be.visible")
+      .and("contain", "Edit Item");
+    cy.get('[data-testid="inventory-item-title"]').should("have.value", "Alpha Item");
+
+    cy.get('[data-testid="inventory-item-editor-next"]').click();
+    cy.get('[data-testid="inventory-item-title"]').should("have.value", "Bravo Item");
+    cy.get('[data-testid="inventory-item-editor-previous"]').click();
+    cy.get('[data-testid="inventory-item-title"]').should("have.value", "Alpha Item");
+    cy.get('[data-testid="inventory-item-editor-next"]').click();
+    cy.get('[data-testid="inventory-item-title"]').should("have.value", "Bravo Item");
+    cy.get('[data-testid="inventory-item-brand"]').clear().type("Updated Brand");
+    cy.get('[data-testid="inventory-item-title"]').clear().type("Bravo Item Updated");
+    cy.get('[data-testid="inventory-item-save"]').click();
+
+    cy.wait("@updateBravo");
+    cy.wait("@itemsList");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.contains("Bravo Item Updated").should("be.visible");
+    cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-BRAVO");
+  });
+});

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -39,10 +39,12 @@ describe("inventory-management", () => {
     cy.contains("button", "New").should("be.visible");
     cy.contains("button", "Create").should("be.visible");
 
-    cy.contains("button", "Cards").click();
+    cy.get('button[aria-label="Switch to cards view"]').click();
     cy.contains("Status:").should("be.visible");
 
-    cy.contains("button", "Rows").click();
+    cy.get('button[aria-label="Switch to rows view"]')
+      .click()
+      .should("have.attr", "aria-pressed", "true");
     cy.get("table").should("be.visible");
     cy.contains("th", "Part #").should("be.visible");
     cy.contains("th", "Title").should("be.visible");
@@ -129,7 +131,7 @@ describe("inventory-management", () => {
     cy.wait("@itemsBulk");
     cy.contains("Items:").parent().contains("1200").should("be.visible");
     cy.contains("Page 1 of 120").should("exist");
-    cy.contains("button", "Cards").click();
+    cy.get('button[aria-label="Switch to cards view"]').click();
     cy.contains("Status:").should("be.visible");
     cy.contains("button", "Rows").click();
     cy.get("table").should("be.visible");
@@ -205,20 +207,39 @@ describe("inventory-management", () => {
   });
 
   it("UI-SCREEN-INVENTORY-ITEMS-007 opens create-item workflow from toolbar", () => {
-    cy.intercept("GET", "/api/items", {
-      statusCode: 200,
-      body: { items: [] },
+    const items: Array<{
+      id: string;
+      part_number: string;
+      title: string;
+      status: string;
+      category: string;
+    }> = [];
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
     }).as("itemsCreate");
+    cy.intercept("POST", "/api/items", (req) => {
+      const created = {
+        id: "item-inline-created",
+        part_number: req.body.part_number,
+        title: req.body.title,
+        status: "active",
+        category: "General",
+      };
+      items.push(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createToolbarItem");
 
     signIn();
     cy.wait("@itemsCreate");
 
     cy.get('[data-testid="inventory-create-menu-trigger"]').click();
     cy.get('[data-testid="inventory-create-menu-item"]').click();
-    cy.get('[data-testid="inventory-item-create-title"]').type("Inline Created Item");
-    cy.get('[data-testid="inventory-item-create-part-number"]').type("PN-CREATE-1");
+    cy.get('[data-testid="inventory-item-title"]').type("Inline Created Item");
+    cy.get('[data-testid="inventory-item-part-number"]').type("PN-CREATE-1");
     cy.get('[data-testid="inventory-item-create-submit"]').click();
 
+    cy.wait("@createToolbarItem");
+    cy.wait("@itemsCreate");
     cy.get('[data-testid="inventory-item-create-dialog"]').should("not.exist");
     cy.contains("Inline Created Item").should("be.visible");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
@@ -339,10 +360,7 @@ describe("inventory-management", () => {
     cy.wait("@createItem");
     cy.wait("@itemsList");
     cy.wait("@createdItemPhotos");
-    cy.get('[data-testid="inventory-item-save-success"]').should(
-      "contain",
-      "Item created"
-    );
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
     cy.contains("Created Inventory Item").should("be.visible");
 
@@ -357,22 +375,17 @@ describe("inventory-management", () => {
       "be.visible"
     );
 
+    cy.get('[data-testid="inventory-item-row-item-created-1"] [data-testid="task-row-actions-trigger"]').click();
+    cy.contains('[role="menuitem"]', "Edit").click();
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("be.visible");
     cy.get('[data-testid="inventory-item-title"]').clear().type("Created Inventory Item Updated");
     cy.get('[data-testid="inventory-item-brand"]').clear().type("Aurora");
     cy.get('[data-testid="inventory-item-save"]').click();
 
     cy.wait("@updateItem");
     cy.wait("@itemsList");
-    cy.wait("@createdItemPhotos");
-    cy.get('[data-testid="inventory-item-save-success"]').should(
-      "contain",
-      "Item changes saved"
-    );
-    cy.get('[data-testid="inventory-item-title"]').should(
-      "have.value",
-      "Created Inventory Item Updated"
-    );
-    cy.get('[data-testid="inventory-item-brand"]').should("have.value", "Aurora");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.contains("Created Inventory Item Updated").should("be.visible");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
     cy.contains('[data-testid="inventory-photo-row"]', "created-photo.jpg").should(
       "be.visible"
@@ -442,6 +455,7 @@ describe("inventory-management", () => {
     cy.wait("@inventoryProfileSettings");
     cy.wait("@inventorySavedViewsItems");
 
+    cy.contains("button", "Rows").click();
     cy.contains("button", "Condition").click();
     cy.contains('[cmdk-item]', "Used").click();
     cy.contains("button", "Category").click();

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -840,6 +840,7 @@ export function Collection({
   const [selectedItemID, setSelectedItemID] = useState('')
   const [selectedItemLabel, setSelectedItemLabel] = useState('')
   const [itemEditorMode, setItemEditorMode] = useState<'create' | 'edit'>('edit')
+  const [itemEditorOpen, setItemEditorOpen] = useState(false)
   const [itemDraft, setItemDraft] = useState<InventoryItemDraft>(
     emptyInventoryItemDraft
   )
@@ -897,7 +898,23 @@ export function Collection({
     setItemSaveError(null)
     setItemSaveSuccess(null)
     selectInventoryItem(null)
+    setItemEditorOpen(true)
   }, [selectInventoryItem])
+
+  const openInventoryItemEditor = useCallback(
+    (item: InventoryItem | null) => {
+      if (!item) {
+        return
+      }
+      setItemEditorMode('edit')
+      setItemDraft(inventoryItemToDraft(item))
+      setItemSaveError(null)
+      setItemSaveSuccess(null)
+      selectInventoryItem(item)
+      setItemEditorOpen(true)
+    },
+    [selectInventoryItem]
+  )
 
   const openFolderProperties = useCallback((node: FolderNode) => {
     setFolderPropertiesID(node.id)
@@ -1831,6 +1848,38 @@ export function Collection({
     })
   }, [activeFolder, isInventoryRoute, itemFolderAssignments, tableData])
   const selectedItemContext = selectedItemLabel || selectedItemID || 'None'
+  const selectedVisibleInventoryIndex = selectedItemID
+    ? visibleTableData.findIndex(
+        (row) => (row.itemID ?? row.id) === selectedItemID
+      )
+    : -1
+  const canNavigateToPreviousInventoryItem = selectedVisibleInventoryIndex > 0
+  const canNavigateToNextInventoryItem =
+    selectedVisibleInventoryIndex >= 0 &&
+    selectedVisibleInventoryIndex < visibleTableData.length - 1
+  const openAdjacentInventoryItem = useCallback(
+    (offset: number) => {
+      if (selectedVisibleInventoryIndex < 0) {
+        return
+      }
+      const nextRow = visibleTableData[selectedVisibleInventoryIndex + offset]
+      if (!nextRow) {
+        return
+      }
+      const nextID = nextRow.itemID ?? nextRow.id
+      const nextItem =
+        inventoryItems.find((item) => item.id === nextID) ??
+        inventoryItems.find((item) => item.part_number === nextRow.id) ??
+        null
+      openInventoryItemEditor(nextItem)
+    },
+    [
+      inventoryItems,
+      openInventoryItemEditor,
+      selectedVisibleInventoryIndex,
+      visibleTableData,
+    ]
+  )
   const selectedPhoto =
     selectedPhotoIndex === null ? null : inventoryPhotos[selectedPhotoIndex]
   const handleInventoryCollectionFilterChange = useCallback(
@@ -2033,6 +2082,7 @@ export function Collection({
   }, [itemEditorMode, selectedInventoryItem])
 
   const handleSaveItem = useCallback(async () => {
+    const wasCreateMode = itemEditorMode === 'create'
     const payload = {
       part_number: itemDraft.part_number.trim(),
       title: itemDraft.title.trim(),
@@ -2071,11 +2121,12 @@ export function Collection({
       const savedID = saved.id?.trim() ?? selectedItemID
       setItemEditorMode('edit')
       setItemSaveSuccess(
-        itemEditorMode === 'create'
+        wasCreateMode
           ? 'Item created and selected for follow-up media attach.'
           : 'Item changes saved and reloaded from the API.'
       )
       await loadInventoryItems(savedID)
+      setItemEditorOpen(false)
     } catch {
       setItemSaveError('Inventory save failed. Review the fields and retry.')
     } finally {
@@ -2937,172 +2988,223 @@ export function Collection({
                   setItemSaveSuccess(null)
                   selectInventoryItem(matchedItem)
                 }}
+                onEditRow={(task) => {
+                  const matchedItem =
+                    inventoryItems.find((item) => item.id === task.itemID) ??
+                    inventoryItems.find((item) => item.part_number === task.id) ??
+                    null
+                  openInventoryItemEditor(matchedItem)
+                }}
               />
               {isInventoryRoute ? (
                 <>
-                  <section
-                    className='space-y-3 rounded-md border p-4'
-                    data-testid='inventory-item-editor'
+                  <Dialog
+                    open={itemEditorOpen}
+                    onOpenChange={(open) => {
+                      setItemEditorOpen(open)
+                      if (!open) {
+                        setItemSaveError(null)
+                      }
+                    }}
                   >
-                    <div className='flex flex-wrap items-start justify-between gap-3'>
-                      <div>
-                        <h3 className='text-base font-semibold'>Item Save</h3>
-                        <p className='text-sm text-muted-foreground'>
-                          Create a new inventory item or edit the selected persisted item.
-                        </p>
-                      </div>
-                      <div className='flex gap-2'>
-                        <Button
-                          type='button'
-                          variant={itemEditorMode === 'create' ? 'default' : 'outline'}
-                          data-testid='inventory-item-create-mode'
-                          onClick={startCreateItem}
-                        >
-                          Create New
-                        </Button>
-                        <Button
-                          type='button'
-                          variant='outline'
-                          data-testid='inventory-item-edit-selected'
-                          disabled={!selectedInventoryItem}
-                          onClick={() => {
-                            if (!selectedInventoryItem) {
-                              return
-                            }
-                            setItemEditorMode('edit')
-                            setItemDraft(inventoryItemToDraft(selectedInventoryItem))
-                            setItemSaveError(null)
-                            setItemSaveSuccess(null)
-                          }}
-                        >
-                          Edit Selected
-                        </Button>
-                      </div>
-                    </div>
-                    <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
-                      <div className='space-y-2'>
-                        <label className='text-sm font-medium' htmlFor='inventory-item-part-number'>
-                          Part Number
-                        </label>
-                        <Input
-                          id='inventory-item-part-number'
-                          data-testid='inventory-item-part-number'
-                          value={itemDraft.part_number}
-                          onChange={(event) =>
-                            setItemDraft((current) => ({
-                              ...current,
-                              part_number: event.target.value,
-                            }))
-                          }
-                        />
-                      </div>
-                      <div className='space-y-2'>
-                        <label className='text-sm font-medium' htmlFor='inventory-item-title'>
-                          Title
-                        </label>
-                        <Input
-                          id='inventory-item-title'
-                          data-testid='inventory-item-title'
-                          value={itemDraft.title}
-                          onChange={(event) =>
-                            setItemDraft((current) => ({
-                              ...current,
-                              title: event.target.value,
-                            }))
-                          }
-                        />
-                      </div>
-                      <div className='space-y-2'>
-                        <label className='text-sm font-medium' htmlFor='inventory-item-brand'>
-                          Brand
-                        </label>
-                        <Input
-                          id='inventory-item-brand'
-                          data-testid='inventory-item-brand'
-                          value={itemDraft.brand}
-                          onChange={(event) =>
-                            setItemDraft((current) => ({
-                              ...current,
-                              brand: event.target.value,
-                            }))
-                          }
-                        />
-                      </div>
-                      <div className='space-y-2'>
-                        <label className='text-sm font-medium' htmlFor='inventory-item-category'>
-                          Category
-                        </label>
-                        <Input
-                          id='inventory-item-category'
-                          data-testid='inventory-item-category'
-                          value={itemDraft.category}
-                          onChange={(event) =>
-                            setItemDraft((current) => ({
-                              ...current,
-                              category: event.target.value,
-                            }))
-                          }
-                        />
-                      </div>
-                    </div>
-                    <div className='space-y-2'>
-                      <label className='text-sm font-medium' htmlFor='inventory-item-description'>
-                        Description
-                      </label>
-                      <Input
-                        id='inventory-item-description'
-                        data-testid='inventory-item-description'
-                        value={itemDraft.description}
-                        onChange={(event) =>
-                          setItemDraft((current) => ({
-                            ...current,
-                            description: event.target.value,
-                          }))
+                    <DialogContent data-testid='inventory-item-editor-dialog'>
+                      <div
+                        className='space-y-4'
+                        data-testid={
+                          itemEditorMode === 'create'
+                            ? 'inventory-item-create-dialog'
+                            : 'inventory-item-edit-dialog'
                         }
-                      />
-                    </div>
-                    <div className='flex flex-wrap items-center gap-2'>
-                      <Button
-                        type='button'
-                        data-testid='inventory-item-save'
-                        disabled={itemSaveBusy}
-                        onClick={() => void handleSaveItem()}
                       >
-                        {itemEditorMode === 'create' ? 'Create Item' : 'Save Changes'}
-                      </Button>
-                      {itemEditorMode === 'create' ? (
-                        <span
+                        <DialogHeader>
+                          <DialogTitle>
+                            {itemEditorMode === 'create' ? 'Create Item' : 'Edit Item'}
+                          </DialogTitle>
+                        </DialogHeader>
+                        <p
                           className='text-sm text-muted-foreground'
                           data-testid='inventory-item-editor-mode'
                         >
-                          Creating new item draft.
-                        </span>
-                      ) : (
-                        <span
-                          className='text-sm text-muted-foreground'
-                          data-testid='inventory-item-editor-mode'
-                        >
-                          Editing selected item: {selectedItemContext}
-                        </span>
-                      )}
-                    </div>
-                    {itemSaveError ? (
-                      <div
-                        className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
-                        data-testid='inventory-item-save-error'
-                      >
-                        {itemSaveError}
+                          {itemEditorMode === 'create'
+                            ? 'Creating new item draft.'
+                            : `Editing selected item: ${selectedItemContext}`}
+                        </p>
+                        <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+                          <div className='space-y-2'>
+                            <label
+                              className='text-sm font-medium'
+                              htmlFor='inventory-item-part-number'
+                            >
+                              Part Number
+                            </label>
+                            <Input
+                              id='inventory-item-part-number'
+                              data-testid='inventory-item-part-number'
+                              value={itemDraft.part_number}
+                              onChange={(event) =>
+                                setItemDraft((current) => ({
+                                  ...current,
+                                  part_number: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className='space-y-2'>
+                            <label
+                              className='text-sm font-medium'
+                              htmlFor='inventory-item-title'
+                            >
+                              Title
+                            </label>
+                            <Input
+                              id='inventory-item-title'
+                              data-testid='inventory-item-title'
+                              value={itemDraft.title}
+                              onChange={(event) =>
+                                setItemDraft((current) => ({
+                                  ...current,
+                                  title: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className='space-y-2'>
+                            <label
+                              className='text-sm font-medium'
+                              htmlFor='inventory-item-brand'
+                            >
+                              Brand
+                            </label>
+                            <Input
+                              id='inventory-item-brand'
+                              data-testid='inventory-item-brand'
+                              value={itemDraft.brand}
+                              onChange={(event) =>
+                                setItemDraft((current) => ({
+                                  ...current,
+                                  brand: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className='space-y-2'>
+                            <label
+                              className='text-sm font-medium'
+                              htmlFor='inventory-item-category'
+                            >
+                              Category
+                            </label>
+                            <Input
+                              id='inventory-item-category'
+                              data-testid='inventory-item-category'
+                              value={itemDraft.category}
+                              onChange={(event) =>
+                                setItemDraft((current) => ({
+                                  ...current,
+                                  category: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                        </div>
+                        <div className='space-y-2'>
+                          <label
+                            className='text-sm font-medium'
+                            htmlFor='inventory-item-description'
+                          >
+                            Description
+                          </label>
+                          <Input
+                            id='inventory-item-description'
+                            data-testid='inventory-item-description'
+                            value={itemDraft.description}
+                            onChange={(event) =>
+                              setItemDraft((current) => ({
+                                ...current,
+                                description: event.target.value,
+                              }))
+                            }
+                          />
+                        </div>
+                        {itemSaveError ? (
+                          <div
+                            className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
+                            data-testid='inventory-item-save-error'
+                          >
+                            {itemSaveError}
+                          </div>
+                        ) : null}
+                        {itemSaveSuccess ? (
+                          <div
+                            className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm'
+                            data-testid='inventory-item-save-success'
+                          >
+                            {itemSaveSuccess}
+                          </div>
+                        ) : null}
+                        <DialogFooter className='flex flex-wrap gap-2 sm:justify-between'>
+                          {itemEditorMode === 'edit' ? (
+                            <div className='flex flex-1 gap-2'>
+                              <Button
+                                type='button'
+                                variant='outline'
+                                data-testid='inventory-item-editor-previous'
+                                disabled={!canNavigateToPreviousInventoryItem}
+                                onClick={() => openAdjacentInventoryItem(-1)}
+                              >
+                                Previous
+                              </Button>
+                              <Button
+                                type='button'
+                                variant='outline'
+                                data-testid='inventory-item-editor-next'
+                                disabled={!canNavigateToNextInventoryItem}
+                                onClick={() => openAdjacentInventoryItem(1)}
+                              >
+                                Next
+                              </Button>
+                            </div>
+                          ) : null}
+                          <div className='flex gap-2'>
+                            <Button
+                              type='button'
+                              variant='outline'
+                              data-testid='inventory-item-editor-cancel'
+                              onClick={() => setItemEditorOpen(false)}
+                            >
+                              <span
+                                data-testid={
+                                  itemEditorMode === 'create'
+                                    ? 'inventory-item-create-cancel'
+                                    : undefined
+                                }
+                              >
+                                Cancel
+                              </span>
+                            </Button>
+                            <Button
+                              type='button'
+                              data-testid='inventory-item-save'
+                              disabled={itemSaveBusy}
+                              onClick={() => void handleSaveItem()}
+                            >
+                              <span
+                                data-testid={
+                                  itemEditorMode === 'create'
+                                    ? 'inventory-item-create-submit'
+                                    : undefined
+                                }
+                              >
+                                {itemEditorMode === 'create'
+                                  ? 'Create Item'
+                                  : 'Save Changes'}
+                              </span>
+                            </Button>
+                          </div>
+                        </DialogFooter>
                       </div>
-                    ) : null}
-                    {itemSaveSuccess ? (
-                      <div
-                        className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm'
-                        data-testid='inventory-item-save-success'
-                      >
-                        {itemSaveSuccess}
-                      </div>
-                    ) : null}
-                  </section>
+                    </DialogContent>
+                  </Dialog>
                   <section
                     className='space-y-3 rounded-md border p-4'
                     data-testid='inventory-photos-section'


### PR DESCRIPTION
## Summary
- Moves Inventory item create/edit from the inline page section into a shared modal.
- Opens create mode from `New` / `Create > New Item` and edit mode from table row actions.
- Adds previous/next navigation inside edit mode and keeps selection/table context after saves.
- Adds focused Cypress coverage for create, cancel, edit, save, previous, and next flows.
- Updates existing Inventory create/edit Cypress coverage for the modal flow.

## Validation
- `npx.cmd eslint ui.web/src/features/collection/index.tsx ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90` currently reports 9 passing / 1 failing; the remaining failure is existing saved-view reapply coverage and is tracked separately in #655.
- `git diff --check`
- Pre-push OpenSpec validation
- Pre-push fast API docs smoke test

Closes #639