### PR TITLE
#640 Move inventory photos into item modal

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts
@@ -1,0 +1,73 @@
+describe('inventory photo modal', () => {
+  function signIn() {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path: '/inventory/' })
+    })
+  }
+
+  it('opens item-scoped photos from page and row actions without inline photos section', () => {
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-photo-alpha',
+            part_number: 'PN-PHOTO-A',
+            title: 'Photo Alpha',
+            status: 'active',
+            category: 'Cars',
+            brand: 'AFX',
+          },
+          {
+            id: 'item-photo-bravo',
+            part_number: 'PN-PHOTO-B',
+            title: 'Photo Bravo',
+            status: 'active',
+            category: 'Trains',
+            brand: 'Tyco',
+          },
+        ],
+      },
+    }).as('items')
+
+    cy.intercept('GET', '/api/items/item-photo-alpha/photos', {
+      statusCode: 200,
+      body: {
+        photos: [{ id: 'alpha-photo-1', filename: 'alpha-one.jpg', is_primary: true }],
+      },
+    }).as('alphaPhotos')
+
+    cy.intercept('GET', '/api/items/item-photo-bravo/photos', {
+      statusCode: 200,
+      body: {
+        photos: [{ id: 'bravo-photo-1', filename: 'bravo-one.jpg', is_primary: true }],
+      },
+    }).as('bravoPhotos')
+
+    signIn()
+    cy.wait('@items')
+    cy.wait('@alphaPhotos')
+
+    cy.get('[data-testid="inventory-photos-section"]').should('not.exist')
+
+    cy.get('[data-testid="inventory-photos-action"]').click()
+    cy.get('[data-testid="inventory-photos-dialog"]')
+      .should('be.visible')
+      .and('contain', 'Photo Alpha')
+    cy.contains('[data-testid="inventory-photo-row"]', 'alpha-one.jpg').should('be.visible')
+    cy.get('[data-testid="inventory-photos-dialog-close"]').click()
+    cy.get('[data-testid="inventory-photos-dialog"]').should('not.exist')
+
+    cy.get(
+      '[data-testid="inventory-item-row-item-photo-bravo"] [data-testid="inventory-row-photos-action"]'
+    ).click()
+    cy.wait('@bravoPhotos')
+    cy.get('[data-testid="inventory-photos-dialog"]')
+      .should('be.visible')
+      .and('contain', 'Photo Bravo')
+    cy.contains('[data-testid="inventory-photo-row"]', 'bravo-one.jpg').should('be.visible')
+    cy.get('[data-testid="collection-selected-item"]').should('contain', 'PN-PHOTO-B')
+  })
+})

--- a/ui.web/cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts
@@ -35,6 +35,11 @@ describe('MOBILE-CAMERA-CAPTURE', () => {
     }).as('photos')
   })
 
+  function openPhotosModal() {
+    cy.get('[data-testid="inventory-photos-action"]').click()
+    cy.get('[data-testid="inventory-photos-dialog"]').should('be.visible')
+  }
+
   it('MOBILE-CAMERA-001 supports direct camera capture upload path', () => {
     cy.intercept('POST', '/api/items/item-camera-1/photos', {
       statusCode: 201,
@@ -54,6 +59,7 @@ describe('MOBILE-CAMERA-CAPTURE', () => {
     cy.wait('@items')
     cy.wait('@photos')
     cy.wait('@activeProfile')
+    openPhotosModal()
     cy.get('[data-testid="inventory-camera-take-photo"]').click()
     cy.wait('@uploadPhoto')
     cy.get('[data-testid="inventory-camera-success"]').should('be.visible')
@@ -67,6 +73,7 @@ describe('MOBILE-CAMERA-CAPTURE', () => {
     cy.wait('@items')
     cy.wait('@photos')
     cy.wait('@activeProfile')
+    openPhotosModal()
     cy.get('[data-testid="inventory-camera-take-photo"]').click()
     cy.get('[data-testid="inventory-camera-error"]').should('be.visible')
     cy.get('[data-testid="inventory-photo-upload-input"]').should('be.visible')

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -364,6 +364,8 @@ describe("inventory-management", () => {
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
     cy.contains("Created Inventory Item").should("be.visible");
 
+    cy.get('[data-testid="inventory-photos-action"]').click();
+    cy.get('[data-testid="inventory-photos-dialog"]').should("be.visible");
     cy.get('[data-testid="inventory-photo-upload-input"]').selectFile({
       contents: Cypress.Buffer.from("created-photo-binary"),
       fileName: "created-photo.jpg",
@@ -374,6 +376,8 @@ describe("inventory-management", () => {
     cy.contains('[data-testid="inventory-photo-row"]', "created-photo.jpg").should(
       "be.visible"
     );
+    cy.get('[data-testid="inventory-photos-dialog-close"]').click();
+    cy.get('[data-testid="inventory-photos-dialog"]').should("not.exist");
 
     cy.get('[data-testid="inventory-item-row-item-created-1"] [data-testid="task-row-actions-trigger"]').click();
     cy.contains('[role="menuitem"]', "Edit").click();
@@ -387,6 +391,8 @@ describe("inventory-management", () => {
     cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
     cy.contains("Created Inventory Item Updated").should("be.visible");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
+    cy.get('[data-testid="inventory-photos-action"]').click();
+    cy.get('[data-testid="inventory-photos-dialog"]').should("be.visible");
     cy.contains('[data-testid="inventory-photo-row"]', "created-photo.jpg").should(
       "be.visible"
     );

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
@@ -33,6 +33,18 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     )
   }
 
+  function openPhotosModal() {
+    cy.get('[data-testid="inventory-photos-action"]').click()
+    cy.get('[data-testid="inventory-photos-dialog"]').should('be.visible')
+    cy.get('[data-testid="inventory-photos-panel"]').should('be.visible')
+  }
+
+  function openFirstRowPhotosModal() {
+    cy.get('[data-testid="inventory-row-photos-action"]').first().click()
+    cy.get('[data-testid="inventory-photos-dialog"]').should('be.visible')
+    cy.get('[data-testid="inventory-photos-panel"]').should('be.visible')
+  }
+
   it('UI-SCREEN-INVENTORY-PHOTOS-001 supports upload + primary + delete lifecycle', () => {
     let listCall = 0
     cy.intercept('GET', '/api/items', {
@@ -90,7 +102,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     signIn()
     cy.wait('@items')
     cy.wait('@listPhotos')
-    cy.get('[data-testid="inventory-photos-section"]').should('be.visible')
+    openFirstRowPhotosModal()
     cy.get('[data-testid="inventory-photo-upload-input"]').selectFile({
       contents: Cypress.Buffer.from('fake image bytes'),
       fileName: 'new-photo.jpg',
@@ -119,12 +131,14 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
       },
     }).as('items')
     cy.intercept('GET', '/api/items/item-photo-2/photos', {
+      delay: 1500,
       statusCode: 500,
       body: { error: 'failed_to_list_photos' },
     }).as('photosError')
 
     signIn()
     cy.wait('@items')
+    openFirstRowPhotosModal()
     cy.get('[data-testid="inventory-photos-loading"]').should('be.visible')
     cy.wait('@photosError')
     cy.get('[data-testid="inventory-photos-error"]').should('be.visible')
@@ -150,7 +164,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     signIn()
     cy.wait('@items')
     cy.wait('@photos')
-    cy.get('[data-testid="inventory-photos-section"]').should('be.visible')
+    openPhotosModal()
     cy.get('[data-testid="inventory-photo-thumb"]').first().click()
     cy.get('[data-testid="inventory-photo-fullscreen"]').should('be.visible')
     cy.get('[data-testid="inventory-photo-next"]').click()
@@ -198,9 +212,12 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     signIn()
     cy.wait('@items')
 
-    cy.contains('td', 'PN-PHOTO-B').closest('tr').click()
+    cy.get(
+      '[data-testid="inventory-item-row-item-photo-b"] [data-testid="inventory-row-photos-action"]'
+    ).click()
     cy.wait('@itemBPhotos')
     cy.get('[data-testid="collection-selected-item"]').should('contain', 'PN-PHOTO-B')
+    cy.get('[data-testid="inventory-photos-dialog"]').should('be.visible')
     photoRowNames().should('deep.equal', ['item-b.jpg'])
 
     cy.wait('@itemAPhotos')
@@ -246,6 +263,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     signIn()
     cy.wait('@items')
     cy.wait('@reloadPhotos')
+    openPhotosModal()
 
     cy.contains('[data-testid="inventory-photo-row"]', 'reload-two.jpg')
       .find('[data-testid="inventory-photo-set-primary"]')
@@ -260,6 +278,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     cy.wait('@items')
     cy.wait('@reloadPhotos')
     cy.get('[data-testid="collection-selected-item"]').should('contain', 'PN-PHOTO-RELOAD')
+    openPhotosModal()
     cy.contains('[data-testid="inventory-photo-row"]', 'reload-two.jpg')
       .find('[data-testid="inventory-photo-primary-badge"]')
       .should('exist')
@@ -315,6 +334,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     signIn()
     cy.wait('@items')
     cy.wait('@orderedPhotos')
+    openPhotosModal()
 
     photoRowNames().should('deep.equal', [
       'order-one.jpg',
@@ -337,6 +357,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     cy.reload()
     cy.wait('@items')
     cy.wait('@orderedPhotos')
+    openPhotosModal()
     photoRowNames().should('deep.equal', [
       'order-two.jpg',
       'order-one.jpg',
@@ -385,6 +406,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
     signIn()
     cy.wait('@items')
     cy.wait('@rebuildPhotos')
+    openPhotosModal()
 
     cy.get('[data-testid="inventory-photo-rebuild"]').click()
     cy.wait('@rebuildRequest')
@@ -399,7 +421,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
   it('PHOTOS-MEDIA-009 persists uploaded photos through reload and keeps them profile-scoped', () => {
     bootstrapInventoryPhotos()
 
-    cy.get('[data-testid="inventory-photos-section"]').should('be.visible')
+    openFirstRowPhotosModal()
     cy.get('[data-testid="inventory-photo-upload-input"]').selectFile({
       contents: Cypress.Buffer.from(validPhotoJPEGBase64, 'base64'),
       fileName: 'profile-scoped-photo.jpg',
@@ -415,6 +437,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
 
     cy.reload()
     cy.wait('@inventoryItems')
+    openFirstRowPhotosModal()
     cy.wait('@inventoryPhotos')
     cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg').should(
       'be.visible'
@@ -448,6 +471,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
       },
     })
     cy.wait('@inventoryItems')
+    openFirstRowPhotosModal()
     cy.wait('@inventoryPhotos')
     cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg').should(
       'not.exist'
@@ -463,6 +487,7 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
       },
     })
     cy.wait('@inventoryItems')
+    openFirstRowPhotosModal()
     cy.wait('@inventoryPhotos')
     cy.contains('[data-testid="inventory-photo-row"]', 'profile-scoped-photo.jpg').should(
       'be.visible'

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -828,6 +828,7 @@ export function Collection({
   const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [inventoryPhotos, setInventoryPhotos] = useState<InventoryPhoto[]>([])
+  const [photosDialogOpen, setPhotosDialogOpen] = useState(false)
   const [photosLoading, setPhotosLoading] = useState(false)
   const [photosError, setPhotosError] = useState<string | null>(null)
   const [photosBusy, setPhotosBusy] = useState(false)
@@ -914,6 +915,35 @@ export function Collection({
       setItemEditorOpen(true)
     },
     [selectInventoryItem]
+  )
+
+  const openInventoryPhotosForItem = useCallback(
+    (item: InventoryItem | null) => {
+      setCameraError(null)
+      setCameraSuccess(null)
+      setPhotoRebuildError(null)
+      setPhotoRebuildSuccess(null)
+      setPhotosError(null)
+      if (!item) {
+        selectInventoryItem(null)
+        setPhotosError('Select an inventory item before managing photos.')
+        setPhotosDialogOpen(true)
+        return
+      }
+      selectInventoryItem(item)
+      setPhotosDialogOpen(true)
+    },
+    [selectInventoryItem]
+  )
+
+  const resolveInventoryItemFromTask = useCallback(
+    (task: Task) =>
+      inventoryItems.find((item) => item.id === task.itemID) ??
+      inventoryItems.find((item) => item.part_number === task.id) ??
+      inventoryItems.find((item) => item.part_number === task.partNumber) ??
+      inventoryItems.find((item) => item.title === task.title) ??
+      null,
+    [inventoryItems]
   )
 
   const openFolderProperties = useCallback((node: FolderNode) => {
@@ -2624,6 +2654,20 @@ export function Collection({
             </p>
           </div>
           <div className='flex gap-2'>
+            {isInventoryRoute ? (
+              <Button
+                type='button'
+                variant='outline'
+                data-testid='inventory-photos-action'
+                onClick={() =>
+                  openInventoryPhotosForItem(
+                    selectedInventoryItem ?? inventoryItems[0] ?? null
+                  )
+                }
+              >
+                Photos
+              </Button>
+            ) : null}
             <Button
               type='button'
               data-testid='inventory-new-action'
@@ -2989,11 +3033,12 @@ export function Collection({
                   selectInventoryItem(matchedItem)
                 }}
                 onEditRow={(task) => {
-                  const matchedItem =
-                    inventoryItems.find((item) => item.id === task.itemID) ??
-                    inventoryItems.find((item) => item.part_number === task.id) ??
-                    null
+                  const matchedItem = resolveInventoryItemFromTask(task)
                   openInventoryItemEditor(matchedItem)
+                }}
+                onPhotoRow={(task) => {
+                  const matchedItem = resolveInventoryItemFromTask(task)
+                  openInventoryPhotosForItem(matchedItem)
                 }}
               />
               {isInventoryRoute ? (
@@ -3205,207 +3250,237 @@ export function Collection({
                       </div>
                     </DialogContent>
                   </Dialog>
-                  <section
-                    className='space-y-3 rounded-md border p-4'
-                    data-testid='inventory-photos-section'
-                  >
-                    <div>
-                      <h3 className='text-base font-semibold'>Photos</h3>
-                      <p className='text-sm text-muted-foreground'>
-                        Review item media and inspect photos in fullscreen mode.
-                      </p>
-                    </div>
-                    <div className='flex flex-wrap items-center gap-2'>
-                      <Button
-                        type='button'
-                        variant='outline'
-                        data-testid='inventory-camera-take-photo'
-                        onClick={() => void handleTakePhoto()}
+                  <Dialog open={photosDialogOpen} onOpenChange={setPhotosDialogOpen}>
+                    <DialogContent
+                      className='max-h-[86vh] overflow-y-auto sm:max-w-4xl'
+                      data-testid='inventory-photos-dialog'
+                    >
+                      <section
+                        className='space-y-3'
+                        data-testid='inventory-photos-panel'
                       >
-                        Take Photo
-                      </Button>
-                      <input
-                        type='file'
-                        accept='image/*'
-                        data-testid='inventory-photo-upload-input'
-                        onChange={(event) => {
-                          const file = event.target.files?.[0] ?? null
-                          void handlePhotoUpload(file)
-                          event.currentTarget.value = ''
-                        }}
-                      />
-                      <Button
-                        type='button'
-                        variant='outline'
-                        data-testid='inventory-photo-rebuild'
-                        onClick={() => void handleRebuildPhotos()}
-                        disabled={photosBusy || selectedItemID === ''}
-                      >
-                        Rebuild Photos
-                      </Button>
-                      {photosBusy ? (
-                        <span className='text-xs text-muted-foreground'>Working...</span>
-                      ) : null}
-                    </div>
-                    {cameraError ? (
-                      <div
-                        className='rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm'
-                        data-testid='inventory-camera-error'
-                      >
-                        {cameraError}
-                      </div>
-                    ) : null}
-                    {cameraSuccess ? (
-                      <div
-                        className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-2 text-sm'
-                        data-testid='inventory-camera-success'
-                      >
-                        {cameraSuccess}
-                      </div>
-                    ) : null}
-                    {photoRebuildError ? (
-                      <div
-                        className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
-                        data-testid='inventory-photo-rebuild-error'
-                      >
-                        <p className='font-medium'>Photo rebuild failed.</p>
-                        <p className='mt-1 text-muted-foreground'>{photoRebuildError}</p>
-                        <Button
-                          className='mt-3'
-                          size='sm'
-                          variant='outline'
-                          data-testid='inventory-photo-rebuild-retry'
-                          onClick={() => void handleRebuildPhotos()}
-                        >
-                          Retry
-                        </Button>
-                      </div>
-                    ) : null}
-                    {photoRebuildSuccess ? (
-                      <div
-                        className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-2 text-sm'
-                        data-testid='inventory-photo-rebuild-success'
-                      >
-                        {photoRebuildSuccess}
-                      </div>
-                    ) : null}
-                    {photosLoading ? (
-                      <div
-                        className='rounded-md border p-3 text-sm text-muted-foreground'
-                        data-testid='inventory-photos-loading'
-                      >
-                        Loading photos...
-                      </div>
-                    ) : null}
-                    {photosError ? (
-                      <div
-                        className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
-                        data-testid='inventory-photos-error'
-                      >
-                        <p className='font-medium'>Photos are unavailable.</p>
-                        <p className='mt-1 text-muted-foreground'>{photosError}</p>
-                        <Button
-                          className='mt-3'
-                          size='sm'
-                          variant='outline'
-                          onClick={() => void loadInventoryPhotos()}
-                        >
-                          Retry
-                        </Button>
-                      </div>
-                    ) : null}
-                    {!photosLoading && !photosError && inventoryPhotos.length === 0 ? (
-                      <div
-                        className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'
-                        data-testid='inventory-photos-empty'
-                      >
-                        No photos yet for the selected item. Upload an image to begin.
-                      </div>
-                    ) : null}
-                    {!photosLoading && !photosError && inventoryPhotos.length > 0 ? (
-                      <>
-                        <div className='grid grid-cols-1 gap-3 md:grid-cols-3'>
-                          {inventoryPhotos.map((photo, index) => (
-                            <button
-                              key={photo.id}
-                              type='button'
-                              className='overflow-hidden rounded-md border text-left transition hover:border-primary/60'
-                              data-testid='inventory-photo-thumb'
-                              onClick={() => setSelectedPhotoIndex(index)}
+                        <div className='flex flex-wrap items-start justify-between gap-3'>
+                          <div>
+                            <DialogHeader>
+                              <DialogTitle>Photos</DialogTitle>
+                            </DialogHeader>
+                            <p
+                              className='text-sm text-muted-foreground'
+                              data-testid='inventory-photos-item-context'
                             >
-                              <img
-                                src={`/api/items/${encodeURIComponent(
-                                  selectedItemID
-                                )}/photos/${encodeURIComponent(photo.id)}/file?variant=preview`}
-                                alt={photo.filename}
-                                className='h-32 w-full object-cover'
-                              />
-                              <div className='p-2 text-sm'>{photo.filename}</div>
-                            </button>
-                          ))}
+                              {selectedInventoryItem
+                                ? `Managing photos for ${selectedInventoryItem.title}`
+                                : 'Select an inventory item before managing photos.'}
+                            </p>
+                          </div>
+                          <Button
+                            type='button'
+                            variant='outline'
+                            data-testid='inventory-photos-dialog-close'
+                            onClick={() => setPhotosDialogOpen(false)}
+                          >
+                            Close
+                          </Button>
                         </div>
-                        <div className='space-y-2'>
-                          {inventoryPhotos.map((photo, index) => (
-                            <div
-                              key={`row-${photo.id}`}
-                              className='flex flex-wrap items-center justify-between gap-2 rounded-md border p-2'
-                              data-testid='inventory-photo-row'
+                        <div className='sr-only'>
+                          Review item media and inspect photos in fullscreen mode.
+                        </div>
+                        <div className='flex flex-wrap items-center gap-2'>
+                          <Button
+                            type='button'
+                            variant='outline'
+                            data-testid='inventory-camera-take-photo'
+                            onClick={() => void handleTakePhoto()}
+                            disabled={!selectedItemID}
+                          >
+                            Take Photo
+                          </Button>
+                          <input
+                            type='file'
+                            accept='image/*'
+                            data-testid='inventory-photo-upload-input'
+                            disabled={!selectedItemID}
+                            onChange={(event) => {
+                              const file = event.target.files?.[0] ?? null
+                              void handlePhotoUpload(file)
+                              event.currentTarget.value = ''
+                            }}
+                          />
+                          <Button
+                            type='button'
+                            variant='outline'
+                            data-testid='inventory-photo-rebuild'
+                            onClick={() => void handleRebuildPhotos()}
+                            disabled={photosBusy || selectedItemID === ''}
+                          >
+                            Rebuild Photos
+                          </Button>
+                          {photosBusy ? (
+                            <span className='text-xs text-muted-foreground'>Working...</span>
+                          ) : null}
+                        </div>
+                        {cameraError ? (
+                          <div
+                            className='rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm'
+                            data-testid='inventory-camera-error'
+                          >
+                            {cameraError}
+                          </div>
+                        ) : null}
+                        {cameraSuccess ? (
+                          <div
+                            className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-2 text-sm'
+                            data-testid='inventory-camera-success'
+                          >
+                            {cameraSuccess}
+                          </div>
+                        ) : null}
+                        {photoRebuildError ? (
+                          <div
+                            className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
+                            data-testid='inventory-photo-rebuild-error'
+                          >
+                            <p className='font-medium'>Photo rebuild failed.</p>
+                            <p className='mt-1 text-muted-foreground'>{photoRebuildError}</p>
+                            <Button
+                              className='mt-3'
+                              size='sm'
+                              variant='outline'
+                              data-testid='inventory-photo-rebuild-retry'
+                              onClick={() => void handleRebuildPhotos()}
                             >
-                              <div className='flex items-center gap-2 text-sm'>
-                                <span>{photo.filename}</span>
-                                {photo.is_primary ? (
-                                  <span
-                                    className='rounded bg-primary/10 px-2 py-0.5 text-xs text-primary'
-                                    data-testid='inventory-photo-primary-badge'
-                                  >
-                                    Primary
-                                  </span>
-                                ) : null}
-                              </div>
-                              <div className='flex gap-2'>
-                                <Button
-                                  size='sm'
-                                  variant='outline'
-                                  data-testid='inventory-photo-move-up'
-                                  onClick={() => void handleReorderPhotos(photo.id, 'up')}
-                                  disabled={photosBusy || index === 0}
+                              Retry
+                            </Button>
+                          </div>
+                        ) : null}
+                        {photoRebuildSuccess ? (
+                          <div
+                            className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-2 text-sm'
+                            data-testid='inventory-photo-rebuild-success'
+                          >
+                            {photoRebuildSuccess}
+                          </div>
+                        ) : null}
+                        {photosLoading ? (
+                          <div
+                            className='rounded-md border p-3 text-sm text-muted-foreground'
+                            data-testid='inventory-photos-loading'
+                          >
+                            Loading photos...
+                          </div>
+                        ) : null}
+                        {photosError ? (
+                          <div
+                            className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
+                            data-testid='inventory-photos-error'
+                          >
+                            <p className='font-medium'>Photos are unavailable.</p>
+                            <p className='mt-1 text-muted-foreground'>{photosError}</p>
+                            <Button
+                              className='mt-3'
+                              size='sm'
+                              variant='outline'
+                              onClick={() => void loadInventoryPhotos()}
+                              disabled={!selectedItemID}
+                            >
+                              Retry
+                            </Button>
+                          </div>
+                        ) : null}
+                        {!photosLoading && !photosError && inventoryPhotos.length === 0 ? (
+                          <div
+                            className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'
+                            data-testid='inventory-photos-empty'
+                          >
+                            No photos yet for the selected item. Upload an image to begin.
+                          </div>
+                        ) : null}
+                        {!photosLoading && !photosError && inventoryPhotos.length > 0 ? (
+                          <>
+                            <div className='grid grid-cols-1 gap-3 md:grid-cols-3'>
+                              {inventoryPhotos.map((photo, index) => (
+                                <button
+                                  key={photo.id}
+                                  type='button'
+                                  className='overflow-hidden rounded-md border text-left transition hover:border-primary/60'
+                                  data-testid='inventory-photo-thumb'
+                                  onClick={() => setSelectedPhotoIndex(index)}
                                 >
-                                  Move Up
-                                </Button>
-                                <Button
-                                  size='sm'
-                                  variant='outline'
-                                  data-testid='inventory-photo-move-down'
-                                  onClick={() => void handleReorderPhotos(photo.id, 'down')}
-                                  disabled={
-                                    photosBusy || index === inventoryPhotos.length - 1
-                                  }
-                                >
-                                  Move Down
-                                </Button>
-                                <Button
-                                  size='sm'
-                                  variant='outline'
-                                  data-testid='inventory-photo-set-primary'
-                                  onClick={() => void handleSetPrimaryPhoto(photo.id)}
-                                >
-                                  Set Primary
-                                </Button>
-                                <Button
-                                  size='sm'
-                                  variant='outline'
-                                  data-testid='inventory-photo-delete'
-                                  onClick={() => void handleDeletePhoto(photo.id)}
-                                >
-                                  Delete
-                                </Button>
-                              </div>
+                                  <img
+                                    src={`/api/items/${encodeURIComponent(
+                                      selectedItemID
+                                    )}/photos/${encodeURIComponent(photo.id)}/file?variant=preview`}
+                                    alt={photo.filename}
+                                    className='h-32 w-full object-cover'
+                                  />
+                                  <div className='p-2 text-sm'>{photo.filename}</div>
+                                </button>
+                              ))}
                             </div>
-                          ))}
-                        </div>
-                      </>
-                    ) : null}
-                  </section>
+                            <div className='space-y-2'>
+                              {inventoryPhotos.map((photo, index) => (
+                                <div
+                                  key={`row-${photo.id}`}
+                                  className='flex flex-wrap items-center justify-between gap-2 rounded-md border p-2'
+                                  data-testid='inventory-photo-row'
+                                >
+                                  <div className='flex items-center gap-2 text-sm'>
+                                    <span>{photo.filename}</span>
+                                    {photo.is_primary ? (
+                                      <span
+                                        className='rounded bg-primary/10 px-2 py-0.5 text-xs text-primary'
+                                        data-testid='inventory-photo-primary-badge'
+                                      >
+                                        Primary
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                  <div className='flex gap-2'>
+                                    <Button
+                                      size='sm'
+                                      variant='outline'
+                                      data-testid='inventory-photo-move-up'
+                                      onClick={() => void handleReorderPhotos(photo.id, 'up')}
+                                      disabled={photosBusy || index === 0}
+                                    >
+                                      Move Up
+                                    </Button>
+                                    <Button
+                                      size='sm'
+                                      variant='outline'
+                                      data-testid='inventory-photo-move-down'
+                                      onClick={() => void handleReorderPhotos(photo.id, 'down')}
+                                      disabled={
+                                        photosBusy || index === inventoryPhotos.length - 1
+                                      }
+                                    >
+                                      Move Down
+                                    </Button>
+                                    <Button
+                                      size='sm'
+                                      variant='outline'
+                                      data-testid='inventory-photo-set-primary'
+                                      onClick={() => void handleSetPrimaryPhoto(photo.id)}
+                                    >
+                                      Set Primary
+                                    </Button>
+                                    <Button
+                                      size='sm'
+                                      variant='outline'
+                                      data-testid='inventory-photo-delete'
+                                      onClick={() => void handleDeletePhoto(photo.id)}
+                                    >
+                                      Delete
+                                    </Button>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </>
+                        ) : null}
+                      </section>
+                    </DialogContent>
+                  </Dialog>
                   <section
                     className='space-y-3 rounded-md border p-4'
                     data-testid='inventory-barcodes-section'

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -1,5 +1,7 @@
 import { type ColumnDef } from '@tanstack/react-table'
+import { ImageIcon } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { DataTableColumnHeader } from '@/components/data-table'
 import { labels, priorities, statuses } from '../data/data'
@@ -11,6 +13,7 @@ export type TasksRoutePath = '/_authenticated/inventory/' | '/_authenticated/wis
 type TasksColumnsOptions = {
   routePath: TasksRoutePath
   onEditRow?: (task: Task) => void
+  onPhotoRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   wishlistActionItemID?: string | null
@@ -28,6 +31,7 @@ function formatWishlistStatus(status: string) {
 export function getTasksColumns({
   routePath,
   onEditRow,
+  onPhotoRow,
   onDeleteRow,
   onWishlistMarkOwned,
   wishlistActionItemID,
@@ -187,14 +191,32 @@ export function getTasksColumns({
     {
       id: 'actions',
       cell: ({ row }) => (
-        <DataTableRowActions
-          row={row}
-          routePath={routePath}
-          onEditRow={onEditRow}
-          onDeleteRow={onDeleteRow}
-          onWishlistMarkOwned={onWishlistMarkOwned}
-          wishlistActionItemID={wishlistActionItemID}
-        />
+        <div className='flex items-center justify-end gap-1'>
+          {isInventoryRoute ? (
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              className='h-8 w-8'
+              data-testid='inventory-row-photos-action'
+              aria-label={`Open photos for ${row.original.title}`}
+              onClick={(event) => {
+                event.stopPropagation()
+                onPhotoRow?.(row.original)
+              }}
+            >
+              <ImageIcon className='h-4 w-4' />
+            </Button>
+          ) : null}
+          <DataTableRowActions
+            row={row}
+            routePath={routePath}
+            onEditRow={onEditRow}
+            onDeleteRow={onDeleteRow}
+            onWishlistMarkOwned={onWishlistMarkOwned}
+            wishlistActionItemID={wishlistActionItemID}
+          />
+        </div>
       ),
     },
   ]

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -57,6 +57,7 @@ type DataTableProps = {
   currentRecordID?: string
   onRecordFocus?: (itemID: string, recordID: string, title: string) => void
   onEditRow?: (task: Task) => void
+  onPhotoRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   onWishlistBulkStatusChange?: (tasks: Task[], status: string) => Promise<void>
@@ -196,6 +197,7 @@ export function TasksTable({
   currentRecordID,
   onRecordFocus,
   onEditRow,
+  onPhotoRow,
   onDeleteRow,
   onWishlistMarkOwned,
   onWishlistBulkStatusChange,
@@ -212,11 +214,12 @@ export function TasksTable({
       getTasksColumns({
         routePath,
         onEditRow,
+        onPhotoRow,
         onDeleteRow,
         onWishlistMarkOwned,
         wishlistActionItemID,
       }),
-    [routePath, onEditRow, onDeleteRow, onWishlistMarkOwned, wishlistActionItemID]
+    [routePath, onEditRow, onPhotoRow, onDeleteRow, onWishlistMarkOwned, wishlistActionItemID]
   )
 
   const route =


### PR DESCRIPTION
## Summary
- move Inventory Photos out of the inline page section and into an item-scoped modal
- add a page-level Photos action plus row-level quick photo buttons
- update inventory photo, camera, and item lifecycle Cypress coverage for the modal flow

## Validation
- npm --prefix ui.web run lint: blocked by pre-existing repo errors in setup-wizard-first-run/spec.cy.ts and sidebar-data.ts
- npx eslint src/features/collection/index.tsx src/features/tasks/components/tasks-columns.tsx src/features/tasks/components/tasks-table.tsx cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
- git diff --check
- pwsh -NoLogo -NoProfile -File ./scripts/build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File ./cypress.ps1 -Spec cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File ./cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File ./cypress.ps1 -Spec cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File ./cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90

Closes #640