### PR TITLE
#641 Move inventory barcodes into item modal

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts
@@ -1,0 +1,76 @@
+describe('inventory barcode modal', () => {
+  function signIn() {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path: '/inventory/' })
+    })
+  }
+
+  it('opens item-scoped barcodes from page and row actions without inline barcodes section', () => {
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-barcode-alpha',
+            part_number: 'PN-BARCODE-A',
+            title: 'Barcode Alpha',
+            status: 'active',
+            category: 'Cars',
+            brand: 'AFX',
+          },
+          {
+            id: 'item-barcode-bravo',
+            part_number: 'PN-BARCODE-B',
+            title: 'Barcode Bravo',
+            status: 'active',
+            category: 'Trains',
+            brand: 'Tyco',
+          },
+        ],
+      },
+    }).as('items')
+
+    cy.intercept('GET', '/api/barcodes/1234567890123', {
+      statusCode: 200,
+      body: {
+        matches: [
+          {
+            id: 'barcode-alpha-1',
+            item_id: 'item-barcode-alpha',
+            barcode: '1234567890123',
+            created_at: '2026-04-25T10:00:00Z',
+          },
+        ],
+      },
+    }).as('lookupAlpha')
+
+    signIn()
+    cy.wait('@items')
+
+    cy.get('[data-testid="inventory-barcodes-section"]').should('not.exist')
+
+    cy.get('[data-testid="inventory-barcodes-action"]').click()
+    cy.get('[data-testid="inventory-barcodes-dialog"]')
+      .should('be.visible')
+      .and('contain', 'Barcode Alpha')
+    cy.get('[data-testid="inventory-barcodes-lookup-input"]').type('1234567890123')
+    cy.get('[data-testid="inventory-barcodes-lookup-button"]').click()
+    cy.wait('@lookupAlpha')
+    cy.get('[data-testid="inventory-barcodes-match-row"]')
+      .should('have.length', 1)
+      .first()
+      .should('contain', 'item-barcode-alpha')
+    cy.get('[data-testid="inventory-barcodes-dialog-close"]').click()
+    cy.get('[data-testid="inventory-barcodes-dialog"]').should('not.exist')
+
+    cy.get(
+      '[data-testid="inventory-item-row-item-barcode-bravo"] [data-testid="inventory-row-barcodes-action"]'
+    ).click()
+    cy.get('[data-testid="inventory-barcodes-dialog"]')
+      .should('be.visible')
+      .and('contain', 'Barcode Bravo')
+    cy.get('[data-testid="collection-selected-item"]').should('contain', 'PN-BARCODE-B')
+  })
+})

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-barcodes/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-barcodes/spec.cy.ts
@@ -7,6 +7,12 @@ describe('UI-SCREEN-INVENTORY-BARCODES', () => {
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
   }
 
+  function openBarcodesModal() {
+    cy.get('[data-testid="inventory-row-barcodes-action"]').first().click()
+    cy.get('[data-testid="inventory-barcodes-dialog"]').should('be.visible')
+    cy.get('[data-testid="inventory-barcodes-panel"]').should('be.visible')
+  }
+
   it('UI-SCREEN-INVENTORY-BARCODES-001 adds barcode and updates local lookup results', () => {
     cy.intercept('GET', '/api/items', {
       statusCode: 200,
@@ -45,7 +51,7 @@ describe('UI-SCREEN-INVENTORY-BARCODES', () => {
 
     signIn()
     cy.wait('@items')
-    cy.get('[data-testid="inventory-barcodes-section"]').should('be.visible')
+    openBarcodesModal()
     cy.get('[data-testid="inventory-barcodes-add-input"]').type('9780201379624')
     cy.get('[data-testid="inventory-barcodes-add-button"]').click()
     cy.wait('@addBarcode')
@@ -80,6 +86,7 @@ describe('UI-SCREEN-INVENTORY-BARCODES', () => {
 
     signIn()
     cy.wait('@items')
+    openBarcodesModal()
     cy.get('[data-testid="inventory-barcodes-lookup-input"]').clear().type('0000000000000')
     cy.get('[data-testid="inventory-barcodes-lookup-button"]').click()
     cy.wait('@lookupNoMatch')
@@ -132,6 +139,7 @@ describe('UI-SCREEN-INVENTORY-BARCODES', () => {
 
     signIn()
     cy.wait('@items')
+    openBarcodesModal()
     cy.get('[data-testid="inventory-barcodes-lookup-input"]').clear().type('9999999999999')
     cy.get('[data-testid="inventory-barcodes-lookup-button"]').click()
     cy.get('[data-testid="inventory-barcodes-lookup-loading"]').should('be.visible')

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -8,8 +8,9 @@ import {
   useRef,
   useState,
 } from 'react'
-import { createPortal } from 'react-dom'
 import { ChevronRight, Ellipsis, GripVertical, Plus } from 'lucide-react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -19,14 +20,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
-import { LanguageSwitch } from '@/components/language-switch'
-import { Main } from '@/components/layout/main'
-import { ProfileDropdown } from '@/components/profile-dropdown'
-import { Search } from '@/components/search'
-import { ThemeSwitch } from '@/components/theme-switch'
-import { Input } from '@/components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -40,6 +33,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
 import {
   Sheet,
   SheetContent,
@@ -48,18 +42,22 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
-import { TasksTable } from '@/features/tasks/components/tasks-table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { LanguageSwitch } from '@/components/language-switch'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import { useWorkspaceCollections } from '@/features/collections/use-workspace-collections'
 import {
   TasksDialogs,
   type TasksDialogType,
 } from '@/features/tasks/components/tasks-dialogs'
 import { TasksProvider } from '@/features/tasks/components/tasks-provider'
-import { tasks } from '@/features/tasks/data/tasks'
+import { TasksTable } from '@/features/tasks/components/tasks-table'
 import { type Task } from '@/features/tasks/data/schema'
-import {
-  useWorkspaceCollections,
-} from '@/features/collections/use-workspace-collections'
-import { cn } from '@/lib/utils'
+import { tasks } from '@/features/tasks/data/tasks'
 
 type CollectionWorkspaceProps = {
   title?: string
@@ -149,7 +147,10 @@ function folderDropTargetsEqual(
   return left.nodeID === right.nodeID
 }
 
-function findFolderNodeByID(nodes: FolderNode[], id: string): FolderNode | null {
+function findFolderNodeByID(
+  nodes: FolderNode[],
+  id: string
+): FolderNode | null {
   for (const node of nodes) {
     if (node.id === id) {
       return node
@@ -206,16 +207,76 @@ const initialFolderTree: FolderNode[] = [
     secondaryLabel: 'Priority targets',
     statusBadge: 'Goal',
   },
-  { id: 'store-1', name: 'Store 1', category: 'Store', itemCount: 18, secondaryLabel: 'Aisle A' },
-  { id: 'store-2', name: 'Store 2', category: 'Store', itemCount: 14, secondaryLabel: 'Aisle B' },
-  { id: 'store-3', name: 'Store 3', category: 'Store', itemCount: 11, secondaryLabel: 'Aisle C' },
-  { id: 'store-4', name: 'Store 4', category: 'Store', itemCount: 9, secondaryLabel: 'Overflow shelf' },
-  { id: 'store-5', name: 'Store 5', category: 'Store', itemCount: 8, secondaryLabel: 'Back room' },
-  { id: 'store-6', name: 'Store 6', category: 'Store', itemCount: 10, secondaryLabel: 'Bin 6' },
-  { id: 'store-7', name: 'Store 7', category: 'Store', itemCount: 6, secondaryLabel: 'Bin 7' },
-  { id: 'store-8', name: 'Store 8', category: 'Store', itemCount: 5, secondaryLabel: 'Bin 8' },
-  { id: 'store-9', name: 'Store 9', category: 'Store', itemCount: 4, secondaryLabel: 'Bin 9' },
-  { id: 'store-10', name: 'Store 10', category: 'Store', itemCount: 3, secondaryLabel: 'Bin 10' },
+  {
+    id: 'store-1',
+    name: 'Store 1',
+    category: 'Store',
+    itemCount: 18,
+    secondaryLabel: 'Aisle A',
+  },
+  {
+    id: 'store-2',
+    name: 'Store 2',
+    category: 'Store',
+    itemCount: 14,
+    secondaryLabel: 'Aisle B',
+  },
+  {
+    id: 'store-3',
+    name: 'Store 3',
+    category: 'Store',
+    itemCount: 11,
+    secondaryLabel: 'Aisle C',
+  },
+  {
+    id: 'store-4',
+    name: 'Store 4',
+    category: 'Store',
+    itemCount: 9,
+    secondaryLabel: 'Overflow shelf',
+  },
+  {
+    id: 'store-5',
+    name: 'Store 5',
+    category: 'Store',
+    itemCount: 8,
+    secondaryLabel: 'Back room',
+  },
+  {
+    id: 'store-6',
+    name: 'Store 6',
+    category: 'Store',
+    itemCount: 10,
+    secondaryLabel: 'Bin 6',
+  },
+  {
+    id: 'store-7',
+    name: 'Store 7',
+    category: 'Store',
+    itemCount: 6,
+    secondaryLabel: 'Bin 7',
+  },
+  {
+    id: 'store-8',
+    name: 'Store 8',
+    category: 'Store',
+    itemCount: 5,
+    secondaryLabel: 'Bin 8',
+  },
+  {
+    id: 'store-9',
+    name: 'Store 9',
+    category: 'Store',
+    itemCount: 4,
+    secondaryLabel: 'Bin 9',
+  },
+  {
+    id: 'store-10',
+    name: 'Store 10',
+    category: 'Store',
+    itemCount: 3,
+    secondaryLabel: 'Bin 10',
+  },
   {
     id: 'warehouses',
     name: 'Warehouses',
@@ -224,23 +285,113 @@ const initialFolderTree: FolderNode[] = [
     secondaryLabel: 'Bulk storage',
     statusBadge: 'Cold',
     children: [
-      { id: 'warehouse-1', name: 'Warehouse 1', category: 'Warehouse', itemCount: 15, secondaryLabel: 'Pallet zone A' },
-      { id: 'warehouse-2', name: 'Warehouse 2', category: 'Warehouse', itemCount: 13, secondaryLabel: 'Pallet zone B' },
-      { id: 'warehouse-3', name: 'Warehouse 3', category: 'Warehouse', itemCount: 11, secondaryLabel: 'Pallet zone C' },
+      {
+        id: 'warehouse-1',
+        name: 'Warehouse 1',
+        category: 'Warehouse',
+        itemCount: 15,
+        secondaryLabel: 'Pallet zone A',
+      },
+      {
+        id: 'warehouse-2',
+        name: 'Warehouse 2',
+        category: 'Warehouse',
+        itemCount: 13,
+        secondaryLabel: 'Pallet zone B',
+      },
+      {
+        id: 'warehouse-3',
+        name: 'Warehouse 3',
+        category: 'Warehouse',
+        itemCount: 11,
+        secondaryLabel: 'Pallet zone C',
+      },
     ],
   },
-  { id: 'archive-a', name: 'Archive A', category: 'Archive', itemCount: 2, secondaryLabel: 'Retired stock' },
-  { id: 'archive-b', name: 'Archive B', category: 'Archive', itemCount: 2, secondaryLabel: 'Retired stock' },
-  { id: 'archive-c', name: 'Archive C', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-d', name: 'Archive D', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-e', name: 'Archive E', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-f', name: 'Archive F', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-g', name: 'Archive G', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-h', name: 'Archive H', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-i', name: 'Archive I', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-j', name: 'Archive J', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-k', name: 'Archive K', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
-  { id: 'archive-l', name: 'Archive L', category: 'Archive', itemCount: 1, secondaryLabel: 'Retired stock' },
+  {
+    id: 'archive-a',
+    name: 'Archive A',
+    category: 'Archive',
+    itemCount: 2,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-b',
+    name: 'Archive B',
+    category: 'Archive',
+    itemCount: 2,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-c',
+    name: 'Archive C',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-d',
+    name: 'Archive D',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-e',
+    name: 'Archive E',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-f',
+    name: 'Archive F',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-g',
+    name: 'Archive G',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-h',
+    name: 'Archive H',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-i',
+    name: 'Archive I',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-j',
+    name: 'Archive J',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-k',
+    name: 'Archive K',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
+  {
+    id: 'archive-l',
+    name: 'Archive L',
+    category: 'Archive',
+    itemCount: 1,
+    secondaryLabel: 'Retired stock',
+  },
 ]
 
 function emptyInventoryItemDraft(): InventoryItemDraft {
@@ -281,7 +432,10 @@ function countFolderNodes(nodes: FolderNode[]): number {
   }, 0)
 }
 
-function flattenFolderOptions(nodes: FolderNode[], level = 0): Array<FolderNode & { level: number }> {
+function flattenFolderOptions(
+  nodes: FolderNode[],
+  level = 0
+): Array<FolderNode & { level: number }> {
   return nodes.flatMap((node) => [
     { ...node, level },
     ...flattenFolderOptions(node.children ?? [], level + 1),
@@ -366,7 +520,9 @@ function folderNodeContainsID(node: FolderNode, targetID: string): boolean {
   if (node.id === targetID) {
     return true
   }
-  return (node.children ?? []).some((child) => folderNodeContainsID(child, targetID))
+  return (node.children ?? []).some((child) =>
+    folderNodeContainsID(child, targetID)
+  )
 }
 
 function moveFolderNode(
@@ -450,7 +606,10 @@ function moveFolderNodeRelative(
   return insertFolderNodeRelative(next, targetID, removed, position)
 }
 
-function moveFolderNodeToRoot(nodes: FolderNode[], draggedID: string): FolderNode[] {
+function moveFolderNodeToRoot(
+  nodes: FolderNode[],
+  draggedID: string
+): FolderNode[] {
   const { removed, next } = removeFolderNode(nodes, draggedID)
   if (!removed) {
     return nodes
@@ -495,7 +654,10 @@ function inventoryWorkspaceSettingsStorageKey(profileID: string): string {
   return `${inventoryWorkspaceSettingsStorageKeyPrefix}${profileID.trim()}`
 }
 
-function folderTreeContainsName(nodes: FolderNode[], targetName: string): boolean {
+function folderTreeContainsName(
+  nodes: FolderNode[],
+  targetName: string
+): boolean {
   return nodes.some(
     (node) =>
       node.name === targetName ||
@@ -527,16 +689,23 @@ function sanitizeFolderNodes(value: unknown): FolderNode[] {
       }
 
       const id = typeof candidate.id === 'string' ? candidate.id.trim() : ''
-      const name = typeof candidate.name === 'string' ? candidate.name.trim() : ''
+      const name =
+        typeof candidate.name === 'string' ? candidate.name.trim() : ''
       if (id === '' || name === '') {
         return []
       }
 
       const node: FolderNode = { id, name }
-      if (typeof candidate.category === 'string' && candidate.category.trim() !== '') {
+      if (
+        typeof candidate.category === 'string' &&
+        candidate.category.trim() !== ''
+      ) {
         node.category = candidate.category.trim()
       }
-      if (typeof candidate.itemCount === 'number' && Number.isFinite(candidate.itemCount)) {
+      if (
+        typeof candidate.itemCount === 'number' &&
+        Number.isFinite(candidate.itemCount)
+      ) {
         node.itemCount = candidate.itemCount
       }
       if (
@@ -545,11 +714,16 @@ function sanitizeFolderNodes(value: unknown): FolderNode[] {
       ) {
         node.secondaryLabel = candidate.secondaryLabel.trim()
       }
-      if (typeof candidate.statusBadge === 'string' && candidate.statusBadge.trim() !== '') {
+      if (
+        typeof candidate.statusBadge === 'string' &&
+        candidate.statusBadge.trim() !== ''
+      ) {
         node.statusBadge = candidate.statusBadge.trim()
       }
 
-      const children = Array.isArray(candidate.children) ? walk(candidate.children) : []
+      const children = Array.isArray(candidate.children)
+        ? walk(candidate.children)
+        : []
       if (children.length > 0) {
         node.children = children
       }
@@ -558,10 +732,14 @@ function sanitizeFolderNodes(value: unknown): FolderNode[] {
     })
 
   const sanitized = walk(value)
-  return findFolderNodeByID(sanitized, 'all-items') ? sanitized : initialFolderTree
+  return findFolderNodeByID(sanitized, 'all-items')
+    ? sanitized
+    : initialFolderTree
 }
 
-function parsePersistedWorkspaceSnapshot(value: string | null): FolderNode[] | null {
+function parsePersistedWorkspaceSnapshot(
+  value: string | null
+): FolderNode[] | null {
   if (!value) {
     return null
   }
@@ -581,7 +759,9 @@ function parsePersistedWorkspaceSnapshot(value: string | null): FolderNode[] | n
   return null
 }
 
-function loadPersistedWorkspaceSnapshot(profileID: string): FolderNode[] | null {
+function loadPersistedWorkspaceSnapshot(
+  profileID: string
+): FolderNode[] | null {
   if (typeof window === 'undefined') {
     return null
   }
@@ -619,7 +799,10 @@ async function loadProfileWorkspaceSnapshot(
   )
 }
 
-function savePersistedWorkspaceSnapshot(profileID: string, folderTree: FolderNode[]) {
+function savePersistedWorkspaceSnapshot(
+  profileID: string,
+  folderTree: FolderNode[]
+) {
   if (typeof window === 'undefined') {
     return
   }
@@ -711,7 +894,9 @@ function loadInventoryItemFolderAssignments(): Record<string, string> {
   }
 
   try {
-    const raw = window.localStorage.getItem(inventoryItemFolderAssignmentsStorageKey)
+    const raw = window.localStorage.getItem(
+      inventoryItemFolderAssignmentsStorageKey
+    )
     if (!raw) {
       return {}
     }
@@ -801,9 +986,9 @@ export function Collection({
     Record<string, string>
   >(() => loadInventoryItemFolderAssignments())
   const [folderCreateOpen, setFolderCreateOpen] = useState(false)
-  const [folderCreateParentID, setFolderCreateParentID] = useState<string | null>(
-    null
-  )
+  const [folderCreateParentID, setFolderCreateParentID] = useState<
+    string | null
+  >(null)
   const [folderCreateName, setFolderCreateName] = useState('')
   const [draggedFolderID, setDraggedFolderID] = useState<string | null>(null)
   const [dragTarget, setDragTarget] = useState<FolderDropTarget | null>(null)
@@ -819,28 +1004,40 @@ export function Collection({
     lastTarget: FolderDropTarget | null
   } | null>(null)
   const [folderPropertiesOpen, setFolderPropertiesOpen] = useState(false)
-  const [folderPropertiesID, setFolderPropertiesID] = useState<string | null>(null)
+  const [folderPropertiesID, setFolderPropertiesID] = useState<string | null>(
+    null
+  )
   const [folderPropertiesName, setFolderPropertiesName] = useState('')
-  const [folderPropertiesCategory, setFolderPropertiesCategory] = useState('General')
-  const [folderPropertiesSecondaryLabel, setFolderPropertiesSecondaryLabel] = useState('')
-  const [folderPropertiesStatusBadge, setFolderPropertiesStatusBadge] = useState('')
+  const [folderPropertiesCategory, setFolderPropertiesCategory] =
+    useState('General')
+  const [folderPropertiesSecondaryLabel, setFolderPropertiesSecondaryLabel] =
+    useState('')
+  const [folderPropertiesStatusBadge, setFolderPropertiesStatusBadge] =
+    useState('')
   const treeItemRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [inventoryPhotos, setInventoryPhotos] = useState<InventoryPhoto[]>([])
   const [photosDialogOpen, setPhotosDialogOpen] = useState(false)
+  const [barcodesDialogOpen, setBarcodesDialogOpen] = useState(false)
   const [photosLoading, setPhotosLoading] = useState(false)
   const [photosError, setPhotosError] = useState<string | null>(null)
   const [photosBusy, setPhotosBusy] = useState(false)
-  const [photoRebuildError, setPhotoRebuildError] = useState<string | null>(null)
-  const [photoRebuildSuccess, setPhotoRebuildSuccess] = useState<string | null>(null)
+  const [photoRebuildError, setPhotoRebuildError] = useState<string | null>(
+    null
+  )
+  const [photoRebuildSuccess, setPhotoRebuildSuccess] = useState<string | null>(
+    null
+  )
   const [cameraError, setCameraError] = useState<string | null>(null)
   const [cameraSuccess, setCameraSuccess] = useState<string | null>(null)
   const [activeProfileID, setActiveProfileID] = useState('')
   const [workspaceSnapshotReady, setWorkspaceSnapshotReady] = useState(false)
   const [selectedItemID, setSelectedItemID] = useState('')
   const [selectedItemLabel, setSelectedItemLabel] = useState('')
-  const [itemEditorMode, setItemEditorMode] = useState<'create' | 'edit'>('edit')
+  const [itemEditorMode, setItemEditorMode] = useState<'create' | 'edit'>(
+    'edit'
+  )
   const [itemEditorOpen, setItemEditorOpen] = useState(false)
   const [itemDraft, setItemDraft] = useState<InventoryItemDraft>(
     emptyInventoryItemDraft
@@ -856,8 +1053,12 @@ export function Collection({
   const [barcodeAddBusy, setBarcodeAddBusy] = useState(false)
   const [barcodeLookupBusy, setBarcodeLookupBusy] = useState(false)
   const [barcodeAddError, setBarcodeAddError] = useState<string | null>(null)
-  const [barcodeAddSuccess, setBarcodeAddSuccess] = useState<string | null>(null)
-  const [barcodeLookupError, setBarcodeLookupError] = useState<string | null>(null)
+  const [barcodeAddSuccess, setBarcodeAddSuccess] = useState<string | null>(
+    null
+  )
+  const [barcodeLookupError, setBarcodeLookupError] = useState<string | null>(
+    null
+  )
   const [barcodeMatches, setBarcodeMatches] = useState<BarcodeMatch[]>([])
   const [barcodeLookupCompleted, setBarcodeLookupCompleted] = useState(false)
   const [lastLookupBarcode, setLastLookupBarcode] = useState('')
@@ -936,6 +1137,25 @@ export function Collection({
     [selectInventoryItem]
   )
 
+  const openInventoryBarcodesForItem = useCallback(
+    (item: InventoryItem | null) => {
+      setBarcodeAddError(null)
+      setBarcodeAddSuccess(null)
+      setBarcodeLookupError(null)
+      setBarcodeLookupCompleted(false)
+      setBarcodeMatches([])
+      if (!item) {
+        selectInventoryItem(null)
+        setBarcodeAddError('Select an inventory item before managing barcodes.')
+        setBarcodesDialogOpen(true)
+        return
+      }
+      selectInventoryItem(item)
+      setBarcodesDialogOpen(true)
+    },
+    [selectInventoryItem]
+  )
+
   const resolveInventoryItemFromTask = useCallback(
     (task: Task) =>
       inventoryItems.find((item) => item.id === task.itemID) ??
@@ -955,66 +1175,72 @@ export function Collection({
     setFolderPropertiesOpen(true)
   }, [])
 
-  const loadInventoryItems = useCallback(async (preferredSelectedItemID?: string) => {
-    if (routePath !== '/_authenticated/inventory/') {
-      setInventoryItems([])
-      setTableData(tasks)
+  const loadInventoryItems = useCallback(
+    async (preferredSelectedItemID?: string) => {
+      if (routePath !== '/_authenticated/inventory/') {
+        setInventoryItems([])
+        setTableData(tasks)
+        setLoadError(null)
+        selectInventoryItem(null)
+        return
+      }
+      setLoading(true)
       setLoadError(null)
-      selectInventoryItem(null)
-      return
-    }
-    setLoading(true)
-    setLoadError(null)
-    try {
-      const response = await fetch('/api/items')
-      if (!response.ok) {
-        throw new Error(`items_api_${response.status}`)
+      try {
+        const response = await fetch('/api/items')
+        if (!response.ok) {
+          throw new Error(`items_api_${response.status}`)
+        }
+        const payload = (await response.json()) as {
+          items?: Array<{
+            id?: string
+            part_number?: string
+            title?: string
+            status?: string
+            category?: string
+            brand?: string
+            priority?: string
+            description?: string
+          }>
+        }
+        const items = (payload.items ?? [])
+          .map((item) => ({
+            id: item.id?.trim() ?? '',
+            part_number: item.part_number?.trim() ?? '',
+            title: item.title?.trim() || 'Untitled item',
+            status: item.status?.trim() || 'active',
+            category: item.category?.trim() || 'General',
+            brand: item.brand?.trim() || 'Unknown',
+            priority: item.priority?.trim() || 'medium',
+            description: item.description?.trim() ?? '',
+          }))
+          .filter((item) => item.id !== '')
+        const mapped: Task[] = items.map(inventoryItemToTask)
+        const targetItem =
+          items.find(
+            (item) =>
+              item.id ===
+              (preferredSelectedItemID?.trim() ||
+                selectedItemIDRef.current.trim())
+          ) ??
+          items[0] ??
+          null
+        setInventoryItems(items)
+        setTableData(mapped)
+        selectInventoryItem(targetItem)
+      } catch {
+        setLoadError(
+          'Inventory failed to load. Retry and confirm runtime API availability.'
+        )
+        setInventoryItems([])
+        setTableData([])
+        selectInventoryItem(null)
+      } finally {
+        setLoading(false)
       }
-      const payload = (await response.json()) as {
-        items?: Array<{
-          id?: string
-          part_number?: string
-          title?: string
-          status?: string
-          category?: string
-          brand?: string
-          priority?: string
-          description?: string
-        }>
-      }
-      const items = (payload.items ?? [])
-        .map((item) => ({
-          id: item.id?.trim() ?? '',
-          part_number: item.part_number?.trim() ?? '',
-          title: item.title?.trim() || 'Untitled item',
-          status: item.status?.trim() || 'active',
-          category: item.category?.trim() || 'General',
-          brand: item.brand?.trim() || 'Unknown',
-          priority: item.priority?.trim() || 'medium',
-          description: item.description?.trim() ?? '',
-        }))
-        .filter((item) => item.id !== '')
-      const mapped: Task[] = items.map(inventoryItemToTask)
-      const targetItem =
-        items.find(
-          (item) =>
-            item.id ===
-            (preferredSelectedItemID?.trim() || selectedItemIDRef.current.trim())
-        ) ?? items[0] ?? null
-      setInventoryItems(items)
-      setTableData(mapped)
-      selectInventoryItem(targetItem)
-    } catch {
-      setLoadError(
-        'Inventory failed to load. Retry and confirm runtime API availability.'
-      )
-      setInventoryItems([])
-      setTableData([])
-      selectInventoryItem(null)
-    } finally {
-      setLoading(false)
-    }
-  }, [routePath, selectInventoryItem])
+    },
+    [routePath, selectInventoryItem]
+  )
 
   useEffect(() => {
     void loadInventoryItems()
@@ -1142,7 +1368,9 @@ export function Collection({
         if (draggedID === target.nodeID) {
           return
         }
-        setFolderTree((previous) => moveFolderNode(previous, draggedID, target.nodeID))
+        setFolderTree((previous) =>
+          moveFolderNode(previous, draggedID, target.nodeID)
+        )
         setExpandedNodeIDs((previous) => {
           const next = new Set(previous)
           next.add(target.nodeID)
@@ -1153,7 +1381,12 @@ export function Collection({
           return
         }
         setFolderTree((previous) =>
-          moveFolderNodeRelative(previous, draggedID, target.nodeID, target.kind)
+          moveFolderNodeRelative(
+            previous,
+            draggedID,
+            target.nodeID,
+            target.kind
+          )
         )
       } else {
         setFolderTree((previous) => moveFolderNodeToRoot(previous, draggedID))
@@ -1165,7 +1398,8 @@ export function Collection({
   )
 
   const draggedFolderNode = useMemo(
-    () => (draggedFolderID ? findFolderNodeByID(folderTree, draggedFolderID) : null),
+    () =>
+      draggedFolderID ? findFolderNodeByID(folderTree, draggedFolderID) : null,
     [draggedFolderID, folderTree]
   )
 
@@ -1188,7 +1422,11 @@ export function Collection({
   }, [dragTarget, draggedFolderNode, folderTree])
 
   const resolvePointerFolderDropTarget = useCallback(
-    (clientX: number, clientY: number, draggedID: string): FolderDropTarget | null => {
+    (
+      clientX: number,
+      clientY: number,
+      draggedID: string
+    ): FolderDropTarget | null => {
       if (typeof document === 'undefined') {
         return null
       }
@@ -1290,7 +1528,11 @@ export function Collection({
 
     const updateDragTarget = (clientX: number, clientY: number) => {
       setDragPreviewPosition(resolveFolderDragPreviewPosition(clientX, clientY))
-      const nextTarget = resolvePointerFolderDropTarget(clientX, clientY, draggedFolderID)
+      const nextTarget = resolvePointerFolderDropTarget(
+        clientX,
+        clientY,
+        draggedFolderID
+      )
       pointerDrag.lastTarget = nextTarget
       setDragTarget((previous) =>
         folderDropTargetsEqual(previous, nextTarget) ? previous : nextTarget
@@ -1331,7 +1573,11 @@ export function Collection({
 
       const target =
         pointerDrag.lastTarget ??
-        resolvePointerFolderDropTarget(event.clientX, event.clientY, draggedFolderID)
+        resolvePointerFolderDropTarget(
+          event.clientX,
+          event.clientY,
+          draggedFolderID
+        )
       if (target) {
         moveDraggedFolder(draggedFolderID, target)
       }
@@ -1522,7 +1768,10 @@ export function Collection({
                   )
                 }
                 onDrop={(event) =>
-                  handleFolderHTMLDrop({ kind: 'before', nodeID: node.id }, event)
+                  handleFolderHTMLDrop(
+                    { kind: 'before', nodeID: node.id },
+                    event
+                  )
                 }
                 className={cn(
                   'mx-2 mb-1 h-2 rounded-full border border-dashed transition-colors',
@@ -1579,35 +1828,54 @@ export function Collection({
                 tabIndex={isActive ? 0 : -1}
                 aria-level={level}
                 aria-selected={isActive ? 'true' : 'false'}
-                aria-expanded={hasChildren ? (expanded ? 'true' : 'false') : undefined}
+                aria-expanded={
+                  hasChildren ? (expanded ? 'true' : 'false') : undefined
+                }
                 data-testid={`folder-tree-item-${node.id}`}
                 data-active={isActive ? 'true' : 'false'}
                 data-node-kind={hasChildren ? 'branch' : 'leaf'}
-                data-node-expanded={hasChildren ? (expanded ? 'true' : 'false') : undefined}
+                data-node-expanded={
+                  hasChildren ? (expanded ? 'true' : 'false') : undefined
+                }
                 data-draggable-row={node.id !== 'all-items' ? 'true' : 'false'}
                 data-invalid-drop-target={
                   hasInvalidFolderDropTarget ? 'true' : 'false'
                 }
                 className={cn(
-                  'relative flex min-w-0 flex-1 items-start rounded-md bg-transparent px-3 py-2 text-left text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-1',
+                  'relative flex min-w-0 flex-1 items-start rounded-md bg-transparent px-3 py-2 text-left text-sm focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-1 focus-visible:outline-none',
                   isChildDropTarget && 'bg-primary/20'
                 )}
                 onClick={() => setActiveFolder(node.name)}
                 onKeyDown={(event) => handleTreeItemKeyDown(node, event)}
                 onDragEnter={(event) => {
-                  if (handleFolderHTMLDragOver({ kind: 'child', nodeID: node.id }, event)) {
+                  if (
+                    handleFolderHTMLDragOver(
+                      { kind: 'child', nodeID: node.id },
+                      event
+                    )
+                  ) {
                     return
                   }
                   handleInventoryItemFolderDragOver(node, event)
                 }}
                 onDragOver={(event) => {
-                  if (handleFolderHTMLDragOver({ kind: 'child', nodeID: node.id }, event)) {
+                  if (
+                    handleFolderHTMLDragOver(
+                      { kind: 'child', nodeID: node.id },
+                      event
+                    )
+                  ) {
                     return
                   }
                   handleInventoryItemFolderDragOver(node, event)
                 }}
                 onDrop={(event) => {
-                  if (handleFolderHTMLDrop({ kind: 'child', nodeID: node.id }, event)) {
+                  if (
+                    handleFolderHTMLDrop(
+                      { kind: 'child', nodeID: node.id },
+                      event
+                    )
+                  ) {
                     return
                   }
                   handleInventoryItemFolderDrop(node, event)
@@ -1635,9 +1903,9 @@ export function Collection({
                 <span
                   className={cn(
                     'relative flex min-w-0 flex-1 items-start',
-                  isActive
-                    ? 'text-accent-foreground font-semibold'
-                    : 'text-foreground/90'
+                    isActive
+                      ? 'font-semibold text-accent-foreground'
+                      : 'text-foreground/90'
                   )}
                 >
                   <span className='min-w-0 flex-1'>
@@ -1662,8 +1930,7 @@ export function Collection({
                 data-testid={`folder-tree-trailing-${node.id}`}
                 className={cn(
                   'relative flex shrink-0 items-center gap-2 pe-1',
-                  hasInvalidFolderDropTarget &&
-                    'text-foreground/70',
+                  hasInvalidFolderDropTarget && 'text-foreground/70',
                   isChildDropTarget && 'text-primary'
                 )}
               >
@@ -1671,7 +1938,7 @@ export function Collection({
                   {typeof node.itemCount === 'number' ? (
                     <span
                       data-testid={`folder-tree-count-${node.id}`}
-                      className='text-xs font-medium tabular-nums text-muted-foreground'
+                      className='text-xs font-medium text-muted-foreground tabular-nums'
                     >
                       {node.itemCount}
                     </span>
@@ -1775,7 +2042,9 @@ export function Collection({
                     'inline-flex h-8 w-8 shrink-0 cursor-grab items-center justify-center rounded-sm text-muted-foreground/70 transition-colors group-hover:text-foreground active:cursor-grabbing',
                     draggedFolderID === node.id && 'text-foreground'
                   )}
-                  onPointerDown={(event) => startFolderPointerDrag(node.id, event)}
+                  onPointerDown={(event) =>
+                    startFolderPointerDrag(node.id, event)
+                  }
                   onDragStart={(event) => startFolderHTMLDrag(node, event)}
                   onDragEnd={clearFolderHTMLDrag}
                   onMouseDown={(event) => event.stopPropagation()}
@@ -1795,13 +2064,22 @@ export function Collection({
                   hasInvalidFolderDropTarget ? 'true' : 'false'
                 }
                 onDragEnter={(event) =>
-                  handleFolderHTMLDragOver({ kind: 'after', nodeID: node.id }, event)
+                  handleFolderHTMLDragOver(
+                    { kind: 'after', nodeID: node.id },
+                    event
+                  )
                 }
                 onDragOver={(event) =>
-                  handleFolderHTMLDragOver({ kind: 'after', nodeID: node.id }, event)
+                  handleFolderHTMLDragOver(
+                    { kind: 'after', nodeID: node.id },
+                    event
+                  )
                 }
                 onDrop={(event) =>
-                  handleFolderHTMLDrop({ kind: 'after', nodeID: node.id }, event)
+                  handleFolderHTMLDrop(
+                    { kind: 'after', nodeID: node.id },
+                    event
+                  )
                 }
                 className={cn(
                   'mx-2 mt-1 h-2 rounded-full border border-dashed transition-colors',
@@ -1861,7 +2139,9 @@ export function Collection({
   const activeFolderIsAvailable = folderFilterOptions.some(
     (folder) => folder.name === activeFolder
   )
-  const activeFolderFilterValue = activeFolderIsAvailable ? activeFolder : 'All Items'
+  const activeFolderFilterValue = activeFolderIsAvailable
+    ? activeFolder
+    : 'All Items'
   const isInventoryRoute = routePath === '/_authenticated/inventory/'
   const selectedInventoryItem = useMemo(
     () => inventoryItems.find((item) => item.id === selectedItemID) ?? null,
@@ -1985,7 +2265,9 @@ export function Collection({
         return
       }
       setInventoryPhotos([])
-      setPhotosError('Photos could not be loaded for this item. Retry to continue.')
+      setPhotosError(
+        'Photos could not be loaded for this item. Retry to continue.'
+      )
     } finally {
       if (inventoryPhotoRequestIDRef.current === requestID) {
         setPhotosLoading(false)
@@ -2186,7 +2468,9 @@ export function Collection({
         }
         await loadInventoryPhotos()
       } catch {
-        setPhotosError('Photo upload failed. Retry with a supported image file.')
+        setPhotosError(
+          'Photo upload failed. Retry with a supported image file.'
+        )
       } finally {
         setPhotosBusy(false)
       }
@@ -2215,7 +2499,9 @@ export function Collection({
         }
         await loadInventoryPhotos()
       } catch {
-        setPhotosError('Unable to set primary photo right now. Retry this action.')
+        setPhotosError(
+          'Unable to set primary photo right now. Retry this action.'
+        )
       } finally {
         setPhotosBusy(false)
       }
@@ -2257,11 +2543,14 @@ export function Collection({
       if (!selectedItemID || !photoID) {
         return
       }
-      const currentIndex = inventoryPhotos.findIndex((photo) => photo.id === photoID)
+      const currentIndex = inventoryPhotos.findIndex(
+        (photo) => photo.id === photoID
+      )
       if (currentIndex < 0) {
         return
       }
-      const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
+      const targetIndex =
+        direction === 'up' ? currentIndex - 1 : currentIndex + 1
       if (targetIndex < 0 || targetIndex >= inventoryPhotos.length) {
         return
       }
@@ -2373,7 +2662,9 @@ export function Collection({
     setBarcodeMatches([])
     setLastLookupBarcode(barcode)
     try {
-      const response = await fetch(`/api/barcodes/${encodeURIComponent(barcode)}`)
+      const response = await fetch(
+        `/api/barcodes/${encodeURIComponent(barcode)}`
+      )
       if (!response.ok) {
         throw new Error(`lookup_barcode_${response.status}`)
       }
@@ -2517,7 +2808,7 @@ export function Collection({
                 </div>
                 <div className='flex shrink-0 items-center gap-2 text-xs'>
                   {typeof draggedFolderNode.itemCount === 'number' ? (
-                    <span className='font-medium tabular-nums text-muted-foreground'>
+                    <span className='font-medium text-muted-foreground tabular-nums'>
                       {draggedFolderNode.itemCount}
                     </span>
                   ) : null}
@@ -2557,7 +2848,9 @@ export function Collection({
         className='h-8 min-w-[11rem] rounded-md border bg-background px-2 text-sm'
         data-testid='inventory-collection-filter-select'
         value={activeFolderFilterValue}
-        onChange={(event) => handleInventoryCollectionFilterChange(event.target.value)}
+        onChange={(event) =>
+          handleInventoryCollectionFilterChange(event.target.value)
+        }
       >
         {folderFilterOptions.map((folder) => (
           <option key={folder.id} value={folder.name}>
@@ -2590,7 +2883,7 @@ export function Collection({
             className='max-h-[22rem] overflow-auto rounded-md border p-2'
             data-testid='inventory-folder-browser-menu'
           >
-            <div className='min-w-full w-max space-y-2'>
+            <div className='w-max min-w-full space-y-2'>
               {draggedFolderID ? (
                 <div
                   role='presentation'
@@ -2601,7 +2894,9 @@ export function Collection({
                   onDragOver={(event) =>
                     handleFolderHTMLDragOver({ kind: 'root' }, event)
                   }
-                  onDrop={(event) => handleFolderHTMLDrop({ kind: 'root' }, event)}
+                  onDrop={(event) =>
+                    handleFolderHTMLDrop({ kind: 'root' }, event)
+                  }
                   className='rounded-md border border-dashed border-primary/40 bg-primary/10 px-3 py-2 text-xs text-primary'
                 >
                   Drop here to move folder to the root level
@@ -2655,18 +2950,32 @@ export function Collection({
           </div>
           <div className='flex gap-2'>
             {isInventoryRoute ? (
-              <Button
-                type='button'
-                variant='outline'
-                data-testid='inventory-photos-action'
-                onClick={() =>
-                  openInventoryPhotosForItem(
-                    selectedInventoryItem ?? inventoryItems[0] ?? null
-                  )
-                }
-              >
-                Photos
-              </Button>
+              <>
+                <Button
+                  type='button'
+                  variant='outline'
+                  data-testid='inventory-barcodes-action'
+                  onClick={() =>
+                    openInventoryBarcodesForItem(
+                      selectedInventoryItem ?? inventoryItems[0] ?? null
+                    )
+                  }
+                >
+                  Barcodes
+                </Button>
+                <Button
+                  type='button'
+                  variant='outline'
+                  data-testid='inventory-photos-action'
+                  onClick={() =>
+                    openInventoryPhotosForItem(
+                      selectedInventoryItem ?? inventoryItems[0] ?? null
+                    )
+                  }
+                >
+                  Photos
+                </Button>
+              </>
             ) : null}
             <Button
               type='button'
@@ -2719,7 +3028,10 @@ export function Collection({
               data-testid='folder-tree-card-content'
               className='flex min-h-0 flex-1 flex-col gap-2'
             >
-              <div data-testid='folder-tree-toolbar' className='flex justify-end gap-2'>
+              <div
+                data-testid='folder-tree-toolbar'
+                className='flex justify-end gap-2'
+              >
                 <Button
                   type='button'
                   variant='outline'
@@ -2728,7 +3040,9 @@ export function Collection({
                   data-testid='folder-tree-sort-root-az'
                   aria-label='Sort root folders A to Z'
                   onClick={() => {
-                    setFolderTree((previous) => sortRootFolderNodesAlphabetically(previous))
+                    setFolderTree((previous) =>
+                      sortRootFolderNodesAlphabetically(previous)
+                    )
                   }}
                 >
                   A/Z
@@ -2752,10 +3066,10 @@ export function Collection({
                 role='tree'
                 aria-label='Inventory folders'
                 data-testid='inventory-folder-tree-legacy'
-                className='min-h-[26rem] max-h-[42rem] flex-1 overflow-x-auto overflow-y-auto rounded-md border p-2'
+                className='max-h-[42rem] min-h-[26rem] flex-1 overflow-x-auto overflow-y-auto rounded-md border p-2'
               >
                 <div
-                  className='min-w-full w-max space-y-2'
+                  className='w-max min-w-full space-y-2'
                   data-testid='inventory-folder-tree-scroll-region'
                 >
                   {draggedFolderID ? (
@@ -2793,14 +3107,18 @@ export function Collection({
                 <DialogContent>
                   <DialogHeader>
                     <DialogTitle>
-                      {folderCreateParentID ? 'Add Child Folder' : 'Add Root Folder'}
+                      {folderCreateParentID
+                        ? 'Add Child Folder'
+                        : 'Add Root Folder'}
                     </DialogTitle>
                   </DialogHeader>
                   <Input
                     data-testid='folder-tree-name-input'
                     placeholder='Folder name'
                     value={folderCreateName}
-                    onChange={(event) => setFolderCreateName(event.target.value)}
+                    onChange={(event) =>
+                      setFolderCreateName(event.target.value)
+                    }
                   />
                   <DialogFooter>
                     <Button
@@ -2831,7 +3149,11 @@ export function Collection({
                           if (!folderCreateParentID) {
                             return [...previous, newNode]
                           }
-                          return addChildFolder(previous, folderCreateParentID, newNode)
+                          return addChildFolder(
+                            previous,
+                            folderCreateParentID,
+                            newNode
+                          )
                         })
                         if (folderCreateParentID) {
                           setExpandedNodeIDs((previous) => {
@@ -2868,23 +3190,32 @@ export function Collection({
                   <SheetHeader className='text-start'>
                     <SheetTitle>Folder Properties</SheetTitle>
                     <SheetDescription>
-                      Update the selected folder title, category, secondary label, and status badge.
+                      Update the selected folder title, category, secondary
+                      label, and status badge.
                     </SheetDescription>
                   </SheetHeader>
                   <div className='grid gap-4 py-4'>
                     <div className='grid gap-2'>
-                      <label className='text-sm font-medium' htmlFor='folder-properties-name'>
+                      <label
+                        className='text-sm font-medium'
+                        htmlFor='folder-properties-name'
+                      >
                         Title
                       </label>
                       <Input
                         id='folder-properties-name'
                         data-testid='folder-properties-name-input'
                         value={folderPropertiesName}
-                        onChange={(event) => setFolderPropertiesName(event.target.value)}
+                        onChange={(event) =>
+                          setFolderPropertiesName(event.target.value)
+                        }
                       />
                     </div>
                     <div className='grid gap-2'>
-                      <label className='text-sm font-medium' htmlFor='folder-properties-category'>
+                      <label
+                        className='text-sm font-medium'
+                        htmlFor='folder-properties-category'
+                      >
                         Category
                       </label>
                       <select
@@ -2892,7 +3223,9 @@ export function Collection({
                         data-testid='folder-properties-category-select'
                         className='h-9 rounded-md border bg-background px-2 text-sm'
                         value={folderPropertiesCategory}
-                        onChange={(event) => setFolderPropertiesCategory(event.target.value)}
+                        onChange={(event) =>
+                          setFolderPropertiesCategory(event.target.value)
+                        }
                       >
                         {folderCategoryOptions.map((category) => (
                           <option key={category} value={category}>
@@ -2902,7 +3235,10 @@ export function Collection({
                       </select>
                     </div>
                     <div className='grid gap-2'>
-                      <label className='text-sm font-medium' htmlFor='folder-properties-secondary-label'>
+                      <label
+                        className='text-sm font-medium'
+                        htmlFor='folder-properties-secondary-label'
+                      >
                         Secondary label
                       </label>
                       <Input
@@ -2916,7 +3252,10 @@ export function Collection({
                       />
                     </div>
                     <div className='grid gap-2'>
-                      <label className='text-sm font-medium' htmlFor='folder-properties-status-badge'>
+                      <label
+                        className='text-sm font-medium'
+                        htmlFor='folder-properties-status-badge'
+                      >
                         Status badge
                       </label>
                       <Input
@@ -2924,7 +3263,9 @@ export function Collection({
                         data-testid='folder-properties-status-badge-input'
                         placeholder='Cold'
                         value={folderPropertiesStatusBadge}
-                        onChange={(event) => setFolderPropertiesStatusBadge(event.target.value)}
+                        onChange={(event) =>
+                          setFolderPropertiesStatusBadge(event.target.value)
+                        }
                       />
                     </div>
                   </div>
@@ -2946,14 +3287,21 @@ export function Collection({
                           return
                         }
                         setFolderTree((previous) =>
-                          updateFolderNodeByID(previous, folderPropertiesID, (node) => ({
-                            ...node,
-                            name,
-                            category: folderPropertiesCategory.trim() || 'General',
-                            secondaryLabel:
-                              folderPropertiesSecondaryLabel.trim() || undefined,
-                            statusBadge: folderPropertiesStatusBadge.trim() || undefined,
-                          }))
+                          updateFolderNodeByID(
+                            previous,
+                            folderPropertiesID,
+                            (node) => ({
+                              ...node,
+                              name,
+                              category:
+                                folderPropertiesCategory.trim() || 'General',
+                              secondaryLabel:
+                                folderPropertiesSecondaryLabel.trim() ||
+                                undefined,
+                              statusBadge:
+                                folderPropertiesStatusBadge.trim() || undefined,
+                            })
+                          )
                         )
                         setActiveFolder(name)
                         setFolderPropertiesOpen(false)
@@ -2974,7 +3322,9 @@ export function Collection({
             <CardContent className='space-y-4'>
               <p className='text-sm text-muted-foreground'>
                 Folders: <strong>{summary.folders}</strong>{' '}
-                <span className='mx-2'>Items: <strong>{summary.items}</strong></span>
+                <span className='mx-2'>
+                  Items: <strong>{summary.items}</strong>
+                </span>
                 Active Brand: <strong>{summary.activeBrand}</strong>{' '}
                 <span className='mx-2'>
                   Active Category: <strong>{summary.activeCategory}</strong>
@@ -3025,7 +3375,9 @@ export function Collection({
                 onRecordFocus={(itemID, recordID) => {
                   const matchedItem =
                     inventoryItems.find((item) => item.id === itemID) ??
-                    inventoryItems.find((item) => item.part_number === recordID) ??
+                    inventoryItems.find(
+                      (item) => item.part_number === recordID
+                    ) ??
                     null
                   setItemEditorMode('edit')
                   setItemSaveError(null)
@@ -3039,6 +3391,10 @@ export function Collection({
                 onPhotoRow={(task) => {
                   const matchedItem = resolveInventoryItemFromTask(task)
                   openInventoryPhotosForItem(matchedItem)
+                }}
+                onBarcodeRow={(task) => {
+                  const matchedItem = resolveInventoryItemFromTask(task)
+                  openInventoryBarcodesForItem(matchedItem)
                 }}
               />
               {isInventoryRoute ? (
@@ -3063,7 +3419,9 @@ export function Collection({
                       >
                         <DialogHeader>
                           <DialogTitle>
-                            {itemEditorMode === 'create' ? 'Create Item' : 'Edit Item'}
+                            {itemEditorMode === 'create'
+                              ? 'Create Item'
+                              : 'Edit Item'}
                           </DialogTitle>
                         </DialogHeader>
                         <p
@@ -3250,7 +3608,10 @@ export function Collection({
                       </div>
                     </DialogContent>
                   </Dialog>
-                  <Dialog open={photosDialogOpen} onOpenChange={setPhotosDialogOpen}>
+                  <Dialog
+                    open={photosDialogOpen}
+                    onOpenChange={setPhotosDialogOpen}
+                  >
                     <DialogContent
                       className='max-h-[86vh] overflow-y-auto sm:max-w-4xl'
                       data-testid='inventory-photos-dialog'
@@ -3283,7 +3644,8 @@ export function Collection({
                           </Button>
                         </div>
                         <div className='sr-only'>
-                          Review item media and inspect photos in fullscreen mode.
+                          Review item media and inspect photos in fullscreen
+                          mode.
                         </div>
                         <div className='flex flex-wrap items-center gap-2'>
                           <Button
@@ -3316,7 +3678,9 @@ export function Collection({
                             Rebuild Photos
                           </Button>
                           {photosBusy ? (
-                            <span className='text-xs text-muted-foreground'>Working...</span>
+                            <span className='text-xs text-muted-foreground'>
+                              Working...
+                            </span>
                           ) : null}
                         </div>
                         {cameraError ? (
@@ -3341,7 +3705,9 @@ export function Collection({
                             data-testid='inventory-photo-rebuild-error'
                           >
                             <p className='font-medium'>Photo rebuild failed.</p>
-                            <p className='mt-1 text-muted-foreground'>{photoRebuildError}</p>
+                            <p className='mt-1 text-muted-foreground'>
+                              {photoRebuildError}
+                            </p>
                             <Button
                               className='mt-3'
                               size='sm'
@@ -3374,8 +3740,12 @@ export function Collection({
                             className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
                             data-testid='inventory-photos-error'
                           >
-                            <p className='font-medium'>Photos are unavailable.</p>
-                            <p className='mt-1 text-muted-foreground'>{photosError}</p>
+                            <p className='font-medium'>
+                              Photos are unavailable.
+                            </p>
+                            <p className='mt-1 text-muted-foreground'>
+                              {photosError}
+                            </p>
                             <Button
                               className='mt-3'
                               size='sm'
@@ -3387,15 +3757,20 @@ export function Collection({
                             </Button>
                           </div>
                         ) : null}
-                        {!photosLoading && !photosError && inventoryPhotos.length === 0 ? (
+                        {!photosLoading &&
+                        !photosError &&
+                        inventoryPhotos.length === 0 ? (
                           <div
                             className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'
                             data-testid='inventory-photos-empty'
                           >
-                            No photos yet for the selected item. Upload an image to begin.
+                            No photos yet for the selected item. Upload an image
+                            to begin.
                           </div>
                         ) : null}
-                        {!photosLoading && !photosError && inventoryPhotos.length > 0 ? (
+                        {!photosLoading &&
+                        !photosError &&
+                        inventoryPhotos.length > 0 ? (
                           <>
                             <div className='grid grid-cols-1 gap-3 md:grid-cols-3'>
                               {inventoryPhotos.map((photo, index) => (
@@ -3413,7 +3788,9 @@ export function Collection({
                                     alt={photo.filename}
                                     className='h-32 w-full object-cover'
                                   />
-                                  <div className='p-2 text-sm'>{photo.filename}</div>
+                                  <div className='p-2 text-sm'>
+                                    {photo.filename}
+                                  </div>
                                 </button>
                               ))}
                             </div>
@@ -3440,7 +3817,9 @@ export function Collection({
                                       size='sm'
                                       variant='outline'
                                       data-testid='inventory-photo-move-up'
-                                      onClick={() => void handleReorderPhotos(photo.id, 'up')}
+                                      onClick={() =>
+                                        void handleReorderPhotos(photo.id, 'up')
+                                      }
                                       disabled={photosBusy || index === 0}
                                     >
                                       Move Up
@@ -3449,9 +3828,15 @@ export function Collection({
                                       size='sm'
                                       variant='outline'
                                       data-testid='inventory-photo-move-down'
-                                      onClick={() => void handleReorderPhotos(photo.id, 'down')}
+                                      onClick={() =>
+                                        void handleReorderPhotos(
+                                          photo.id,
+                                          'down'
+                                        )
+                                      }
                                       disabled={
-                                        photosBusy || index === inventoryPhotos.length - 1
+                                        photosBusy ||
+                                        index === inventoryPhotos.length - 1
                                       }
                                     >
                                       Move Down
@@ -3460,7 +3845,9 @@ export function Collection({
                                       size='sm'
                                       variant='outline'
                                       data-testid='inventory-photo-set-primary'
-                                      onClick={() => void handleSetPrimaryPhoto(photo.id)}
+                                      onClick={() =>
+                                        void handleSetPrimaryPhoto(photo.id)
+                                      }
                                     >
                                       Set Primary
                                     </Button>
@@ -3468,7 +3855,9 @@ export function Collection({
                                       size='sm'
                                       variant='outline'
                                       data-testid='inventory-photo-delete'
-                                      onClick={() => void handleDeletePhoto(photo.id)}
+                                      onClick={() =>
+                                        void handleDeletePhoto(photo.id)
+                                      }
                                     >
                                       Delete
                                     </Button>
@@ -3481,143 +3870,181 @@ export function Collection({
                       </section>
                     </DialogContent>
                   </Dialog>
-                  <section
-                    className='space-y-3 rounded-md border p-4'
-                    data-testid='inventory-barcodes-section'
+                  <Dialog
+                    open={barcodesDialogOpen}
+                    onOpenChange={setBarcodesDialogOpen}
                   >
-                    <div>
-                      <h3 className='text-base font-semibold'>Barcodes</h3>
-                      <p className='text-sm text-muted-foreground'>
-                        Add barcodes to the selected item, run local lookup, and
-                        continue with external fallback when there is no local
-                        match.
-                      </p>
-                    </div>
-                    <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
-                      <div className='space-y-2'>
-                        <Input
-                          placeholder='Enter barcode to attach'
-                          data-testid='inventory-barcodes-add-input'
-                          value={barcodeAddInput}
-                          onChange={(event) =>
-                            setBarcodeAddInput(event.target.value)
-                          }
-                        />
-                        <Button
-                          data-testid='inventory-barcodes-add-button'
-                          onClick={() => void handleAddBarcode()}
-                          disabled={barcodeAddBusy || selectedItemID === ''}
-                        >
-                          Add Barcode
-                        </Button>
-                        {barcodeAddError ? (
-                          <div
-                            className='rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm'
-                            data-testid='inventory-barcodes-add-error'
-                          >
-                            {barcodeAddError}
-                          </div>
-                        ) : null}
-                        {barcodeAddSuccess ? (
-                          <div
-                            className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-2 text-sm'
-                            data-testid='inventory-barcodes-add-success'
-                          >
-                            {barcodeAddSuccess}
-                          </div>
-                        ) : null}
-                      </div>
-                      <div className='space-y-2'>
-                        <Input
-                          placeholder='Lookup barcode'
-                          data-testid='inventory-barcodes-lookup-input'
-                          value={barcodeLookupInput}
-                          onChange={(event) =>
-                            setBarcodeLookupInput(event.target.value)
-                          }
-                        />
-                        <Button
-                          data-testid='inventory-barcodes-lookup-button'
-                          variant='outline'
-                          onClick={() => void lookupBarcode(barcodeLookupInput)}
-                          disabled={barcodeLookupBusy}
-                        >
-                          Lookup Barcode
-                        </Button>
-                      </div>
-                    </div>
-                    {barcodeLookupBusy ? (
-                      <div
-                        className='rounded-md border p-3 text-sm text-muted-foreground'
-                        data-testid='inventory-barcodes-lookup-loading'
+                    <DialogContent
+                      className='max-h-[86vh] overflow-y-auto sm:max-w-4xl'
+                      data-testid='inventory-barcodes-dialog'
+                    >
+                      <section
+                        className='space-y-3'
+                        data-testid='inventory-barcodes-panel'
                       >
-                        Looking up barcode...
-                      </div>
-                    ) : null}
-                    {barcodeLookupError ? (
-                      <div
-                        className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
-                        data-testid='inventory-barcodes-lookup-error'
-                      >
-                        <p className='font-medium'>Barcode lookup failed.</p>
-                        <p className='mt-1 text-muted-foreground'>
-                          {barcodeLookupError}
-                        </p>
-                        <Button
-                          className='mt-3'
-                          size='sm'
-                          variant='outline'
-                          data-testid='inventory-barcodes-lookup-retry'
-                          onClick={() => void lookupBarcode(lastLookupBarcode)}
-                        >
-                          Retry
-                        </Button>
-                      </div>
-                    ) : null}
-                    {barcodeLookupCompleted &&
-                    !barcodeLookupBusy &&
-                    !barcodeLookupError &&
-                    barcodeMatches.length === 0 ? (
-                      <div
-                        className='rounded-md border border-dashed p-3 text-sm'
-                        data-testid='inventory-barcodes-lookup-empty'
-                      >
-                        <p className='font-medium'>No local barcode match.</p>
-                        <p className='mt-1 text-muted-foreground'>
-                          Continue with an external provider search.
-                        </p>
-                        {externalSearchHref ? (
-                          <a
-                            className='mt-2 inline-flex text-sm text-primary underline'
-                            href={externalSearchHref}
-                            target='_blank'
-                            rel='noreferrer'
-                            data-testid='inventory-barcodes-external-search-link'
-                          >
-                            Search eBay
-                          </a>
-                        ) : null}
-                      </div>
-                    ) : null}
-                    {barcodeMatches.length > 0 ? (
-                      <div className='space-y-2'>
-                        {barcodeMatches.map((match) => (
-                          <div
-                            key={match.id}
-                            className='rounded-md border p-2 text-sm'
-                            data-testid='inventory-barcodes-match-row'
-                          >
-                            <p>
-                              <strong>Barcode:</strong> {match.barcode}
-                            </p>
-                            <p>
-                              <strong>Item:</strong> {match.item_id}
+                        <div className='flex flex-wrap items-start justify-between gap-3'>
+                          <div>
+                            <DialogHeader>
+                              <DialogTitle>Barcodes</DialogTitle>
+                            </DialogHeader>
+                            <p
+                              className='text-sm text-muted-foreground'
+                              data-testid='inventory-barcodes-item-context'
+                            >
+                              {selectedInventoryItem
+                                ? `Managing barcodes for ${selectedInventoryItem.title}`
+                                : 'Select an inventory item before managing barcodes.'}
                             </p>
                           </div>
-                        ))}
-                      </div>
-                    ) : null}
-                  </section>
+                          <Button
+                            type='button'
+                            variant='outline'
+                            data-testid='inventory-barcodes-dialog-close'
+                            onClick={() => setBarcodesDialogOpen(false)}
+                          >
+                            Close
+                          </Button>
+                        </div>
+                        <div className='sr-only'>
+                          Add barcodes to the selected item, run local lookup,
+                          and continue with external fallback when there is no
+                          local match.
+                        </div>
+                        <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+                          <div className='space-y-2'>
+                            <Input
+                              placeholder='Enter barcode to attach'
+                              data-testid='inventory-barcodes-add-input'
+                              value={barcodeAddInput}
+                              onChange={(event) =>
+                                setBarcodeAddInput(event.target.value)
+                              }
+                            />
+                            <Button
+                              data-testid='inventory-barcodes-add-button'
+                              onClick={() => void handleAddBarcode()}
+                              disabled={barcodeAddBusy || selectedItemID === ''}
+                            >
+                              Add Barcode
+                            </Button>
+                            {barcodeAddError ? (
+                              <div
+                                className='rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm'
+                                data-testid='inventory-barcodes-add-error'
+                              >
+                                {barcodeAddError}
+                              </div>
+                            ) : null}
+                            {barcodeAddSuccess ? (
+                              <div
+                                className='rounded-md border border-emerald-500/40 bg-emerald-500/10 p-2 text-sm'
+                                data-testid='inventory-barcodes-add-success'
+                              >
+                                {barcodeAddSuccess}
+                              </div>
+                            ) : null}
+                          </div>
+                          <div className='space-y-2'>
+                            <Input
+                              placeholder='Lookup barcode'
+                              data-testid='inventory-barcodes-lookup-input'
+                              value={barcodeLookupInput}
+                              onChange={(event) =>
+                                setBarcodeLookupInput(event.target.value)
+                              }
+                            />
+                            <Button
+                              data-testid='inventory-barcodes-lookup-button'
+                              variant='outline'
+                              onClick={() =>
+                                void lookupBarcode(barcodeLookupInput)
+                              }
+                              disabled={barcodeLookupBusy}
+                            >
+                              Lookup Barcode
+                            </Button>
+                          </div>
+                        </div>
+                        {barcodeLookupBusy ? (
+                          <div
+                            className='rounded-md border p-3 text-sm text-muted-foreground'
+                            data-testid='inventory-barcodes-lookup-loading'
+                          >
+                            Looking up barcode...
+                          </div>
+                        ) : null}
+                        {barcodeLookupError ? (
+                          <div
+                            className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
+                            data-testid='inventory-barcodes-lookup-error'
+                          >
+                            <p className='font-medium'>
+                              Barcode lookup failed.
+                            </p>
+                            <p className='mt-1 text-muted-foreground'>
+                              {barcodeLookupError}
+                            </p>
+                            <Button
+                              className='mt-3'
+                              size='sm'
+                              variant='outline'
+                              data-testid='inventory-barcodes-lookup-retry'
+                              onClick={() =>
+                                void lookupBarcode(lastLookupBarcode)
+                              }
+                            >
+                              Retry
+                            </Button>
+                          </div>
+                        ) : null}
+                        {barcodeLookupCompleted &&
+                        !barcodeLookupBusy &&
+                        !barcodeLookupError &&
+                        barcodeMatches.length === 0 ? (
+                          <div
+                            className='rounded-md border border-dashed p-3 text-sm'
+                            data-testid='inventory-barcodes-lookup-empty'
+                          >
+                            <p className='font-medium'>
+                              No local barcode match.
+                            </p>
+                            <p className='mt-1 text-muted-foreground'>
+                              Continue with an external provider search.
+                            </p>
+                            {externalSearchHref ? (
+                              <a
+                                className='mt-2 inline-flex text-sm text-primary underline'
+                                href={externalSearchHref}
+                                target='_blank'
+                                rel='noreferrer'
+                                data-testid='inventory-barcodes-external-search-link'
+                              >
+                                Search eBay
+                              </a>
+                            ) : null}
+                          </div>
+                        ) : null}
+                        {barcodeMatches.length > 0 ? (
+                          <div className='space-y-2'>
+                            {barcodeMatches.map((match) => (
+                              <div
+                                key={match.id}
+                                className='rounded-md border p-2 text-sm'
+                                data-testid='inventory-barcodes-match-row'
+                              >
+                                <p>
+                                  <strong>Barcode:</strong> {match.barcode}
+                                </p>
+                                <p>
+                                  <strong>Item:</strong> {match.item_id}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
+                      </section>
+                    </DialogContent>
+                  </Dialog>
                   <section
                     className='space-y-3 rounded-md border p-4'
                     data-testid='inventory-ai-assist-section'
@@ -3625,7 +4052,8 @@ export function Collection({
                     <div>
                       <h3 className='text-base font-semibold'>AI Assist</h3>
                       <p className='text-sm text-muted-foreground'>
-                        Generate title and photo suggestions with explicit confirm-before-apply.
+                        Generate title and photo suggestions with explicit
+                        confirm-before-apply.
                       </p>
                     </div>
                     <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
@@ -3634,7 +4062,9 @@ export function Collection({
                           placeholder='Paste listing title'
                           data-testid='inventory-ai-title-input'
                           value={aiTitleInput}
-                          onChange={(event) => setAITitleInput(event.target.value)}
+                          onChange={(event) =>
+                            setAITitleInput(event.target.value)
+                          }
                         />
                         <Button
                           data-testid='inventory-ai-suggest-title'
@@ -3649,7 +4079,9 @@ export function Collection({
                           placeholder='Paste photo URL'
                           data-testid='inventory-ai-photo-url-input'
                           value={aiPhotoURLInput}
-                          onChange={(event) => setAIPhotoURLInput(event.target.value)}
+                          onChange={(event) =>
+                            setAIPhotoURLInput(event.target.value)
+                          }
                         />
                         <Button
                           data-testid='inventory-ai-suggest-photo'
@@ -3696,7 +4128,8 @@ export function Collection({
                         data-testid='inventory-ai-suggestion'
                       >
                         <p>
-                          <strong>Part:</strong> {aiSuggestion.part_number || 'n/a'}
+                          <strong>Part:</strong>{' '}
+                          {aiSuggestion.part_number || 'n/a'}
                         </p>
                         <p>
                           <strong>Brand:</strong> {aiSuggestion.brand || 'n/a'}
@@ -3745,7 +4178,9 @@ export function Collection({
             data-testid='inventory-photo-fullscreen'
           >
             <DialogHeader>
-              <DialogTitle>{selectedPhoto?.filename ?? 'Photo Viewer'}</DialogTitle>
+              <DialogTitle>
+                {selectedPhoto?.filename ?? 'Photo Viewer'}
+              </DialogTitle>
             </DialogHeader>
             {selectedPhoto ? (
               <img

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -1,5 +1,5 @@
 import { type ColumnDef } from '@tanstack/react-table'
-import { ImageIcon } from 'lucide-react'
+import { BarcodeIcon, ImageIcon } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -8,12 +8,15 @@ import { labels, priorities, statuses } from '../data/data'
 import { type Task } from '../data/schema'
 import { DataTableRowActions } from './data-table-row-actions'
 
-export type TasksRoutePath = '/_authenticated/inventory/' | '/_authenticated/wishlist/'
+export type TasksRoutePath =
+  | '/_authenticated/inventory/'
+  | '/_authenticated/wishlist/'
 
 type TasksColumnsOptions = {
   routePath: TasksRoutePath
   onEditRow?: (task: Task) => void
   onPhotoRow?: (task: Task) => void
+  onBarcodeRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   wishlistActionItemID?: string | null
@@ -32,6 +35,7 @@ export function getTasksColumns({
   routePath,
   onEditRow,
   onPhotoRow,
+  onBarcodeRow,
   onDeleteRow,
   onWishlistMarkOwned,
   wishlistActionItemID,
@@ -69,7 +73,9 @@ export function getTasksColumns({
       header: ({ column }) => (
         <DataTableColumnHeader
           column={column}
-          title={isInventoryRoute ? 'Part #' : isWishlistRoute ? 'Item ID' : 'Task'}
+          title={
+            isInventoryRoute ? 'Part #' : isWishlistRoute ? 'Item ID' : 'Task'
+          }
         />
       ),
       cell: ({ row }) => <div className='w-[120px]'>{row.getValue('id')}</div>,
@@ -90,9 +96,13 @@ export function getTasksColumns({
 
         return (
           <div className='flex min-w-0 flex-col gap-1'>
-            {!isInventoryRoute && !isWishlistRoute && label ? <Badge variant='outline'>{label.label}</Badge> : null}
+            {!isInventoryRoute && !isWishlistRoute && label ? (
+              <Badge variant='outline'>{label.label}</Badge>
+            ) : null}
             <div className='flex space-x-2'>
-              <span className='truncate font-medium'>{row.getValue('title')}</span>
+              <span className='truncate font-medium'>
+                {row.getValue('title')}
+              </span>
             </div>
             {isWishlistRoute && row.original.notes ? (
               <span className='truncate text-xs text-muted-foreground'>
@@ -108,7 +118,13 @@ export function getTasksColumns({
       header: ({ column }) => (
         <DataTableColumnHeader
           column={column}
-          title={isInventoryRoute ? 'Condition' : isWishlistRoute ? 'Watch Status' : 'Status'}
+          title={
+            isInventoryRoute
+              ? 'Condition'
+              : isWishlistRoute
+                ? 'Watch Status'
+                : 'Status'
+          }
         />
       ),
       meta: { className: 'ps-1', tdClassName: 'ps-4' },
@@ -116,7 +132,9 @@ export function getTasksColumns({
         if (isInventoryRoute) {
           return (
             <div className='flex min-w-[100px] items-center gap-2'>
-              <span className='capitalize'>{String(row.getValue('status'))}</span>
+              <span className='capitalize'>
+                {String(row.getValue('status'))}
+              </span>
             </div>
           )
         }
@@ -155,7 +173,13 @@ export function getTasksColumns({
       header: ({ column }) => (
         <DataTableColumnHeader
           column={column}
-          title={isInventoryRoute ? 'Category' : isWishlistRoute ? 'Target Priority' : 'Priority'}
+          title={
+            isInventoryRoute
+              ? 'Category'
+              : isWishlistRoute
+                ? 'Target Priority'
+                : 'Priority'
+          }
         />
       ),
       meta: { className: 'ps-1', tdClassName: 'ps-3' },
@@ -193,20 +217,36 @@ export function getTasksColumns({
       cell: ({ row }) => (
         <div className='flex items-center justify-end gap-1'>
           {isInventoryRoute ? (
-            <Button
-              type='button'
-              variant='ghost'
-              size='icon'
-              className='h-8 w-8'
-              data-testid='inventory-row-photos-action'
-              aria-label={`Open photos for ${row.original.title}`}
-              onClick={(event) => {
-                event.stopPropagation()
-                onPhotoRow?.(row.original)
-              }}
-            >
-              <ImageIcon className='h-4 w-4' />
-            </Button>
+            <>
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon'
+                className='h-8 w-8'
+                data-testid='inventory-row-barcodes-action'
+                aria-label={`Open barcodes for ${row.original.title}`}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onBarcodeRow?.(row.original)
+                }}
+              >
+                <BarcodeIcon className='h-4 w-4' />
+              </Button>
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon'
+                className='h-8 w-8'
+                data-testid='inventory-row-photos-action'
+                aria-label={`Open photos for ${row.original.title}`}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onPhotoRow?.(row.original)
+                }}
+              >
+                <ImageIcon className='h-4 w-4' />
+              </Button>
+            </>
           ) : null}
           <DataTableRowActions
             row={row}

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -26,15 +26,6 @@ import { useTableUrlState } from '@/hooks/use-table-url-state'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-import { DataTablePagination, DataTableToolbar } from '@/components/data-table'
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -43,6 +34,15 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { DataTablePagination, DataTableToolbar } from '@/components/data-table'
 import { useProfileSettings } from '@/features/settings/use-profile-settings'
 import { priorities, statuses } from '../data/data'
 import { type Task } from '../data/schema'
@@ -58,10 +58,14 @@ type DataTableProps = {
   onRecordFocus?: (itemID: string, recordID: string, title: string) => void
   onEditRow?: (task: Task) => void
   onPhotoRow?: (task: Task) => void
+  onBarcodeRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   onWishlistBulkStatusChange?: (tasks: Task[], status: string) => Promise<void>
-  onWishlistBulkPriorityChange?: (tasks: Task[], priority: string) => Promise<void>
+  onWishlistBulkPriorityChange?: (
+    tasks: Task[],
+    priority: string
+  ) => Promise<void>
   onWishlistBulkDelete?: (tasks: Task[]) => Promise<void>
   onWishlistExport?: (tasks: Task[]) => void
   wishlistActionItemID?: string | null
@@ -97,7 +101,9 @@ function titleCaseWords(value: string) {
     .join(' ')
 }
 
-function parseInventorySavedViews(value: string | undefined): InventorySavedView[] {
+function parseInventorySavedViews(
+  value: string | undefined
+): InventorySavedView[] {
   if (!value) {
     return []
   }
@@ -114,7 +120,8 @@ function parseInventorySavedViews(value: string | undefined): InventorySavedView
       }
       const candidate = entry as Record<string, unknown>
       const id = typeof candidate.id === 'string' ? candidate.id.trim() : ''
-      const name = typeof candidate.name === 'string' ? candidate.name.trim() : ''
+      const name =
+        typeof candidate.name === 'string' ? candidate.name.trim() : ''
       if (!id || !name) {
         return []
       }
@@ -134,7 +141,9 @@ function parseInventorySavedViews(value: string | undefined): InventorySavedView
             }
             const sortCandidate = sortEntry as Record<string, unknown>
             const columnID =
-              typeof sortCandidate.id === 'string' ? sortCandidate.id.trim() : ''
+              typeof sortCandidate.id === 'string'
+                ? sortCandidate.id.trim()
+                : ''
             if (!columnID) {
               return []
             }
@@ -198,6 +207,7 @@ export function TasksTable({
   onRecordFocus,
   onEditRow,
   onPhotoRow,
+  onBarcodeRow,
   onDeleteRow,
   onWishlistMarkOwned,
   onWishlistBulkStatusChange,
@@ -215,11 +225,20 @@ export function TasksTable({
         routePath,
         onEditRow,
         onPhotoRow,
+        onBarcodeRow,
         onDeleteRow,
         onWishlistMarkOwned,
         wishlistActionItemID,
       }),
-    [routePath, onEditRow, onPhotoRow, onDeleteRow, onWishlistMarkOwned, wishlistActionItemID]
+    [
+      routePath,
+      onEditRow,
+      onPhotoRow,
+      onBarcodeRow,
+      onDeleteRow,
+      onWishlistMarkOwned,
+      wishlistActionItemID,
+    ]
   )
 
   const route =
@@ -254,7 +273,9 @@ export function TasksTable({
   const [editOpen, setEditOpen] = useState(false)
   const [saveViewDialogOpen, setSaveViewDialogOpen] = useState(false)
   const [saveViewName, setSaveViewName] = useState('')
-  const [savedViewFeedback, setSavedViewFeedback] = useState<string | null>(null)
+  const [savedViewFeedback, setSavedViewFeedback] = useState<string | null>(
+    null
+  )
   const [savedViewError, setSavedViewError] = useState<string | null>(null)
   const [activeSavedViewID, setActiveSavedViewID] = useState('')
   const clickTimerRef = useRef<number | null>(null)
@@ -368,7 +389,9 @@ export function TasksTable({
       return false
     }
     return Boolean(
-      target.closest('button, a, input, select, textarea, [role="checkbox"], [data-sidebar="menu-action"]')
+      target.closest(
+        'button, a, input, select, textarea, [role="checkbox"], [data-sidebar="menu-action"]'
+      )
     )
   }
 
@@ -399,10 +422,7 @@ export function TasksTable({
     }, 180)
   }
 
-  const handleRowDoubleClick = (
-    id: string,
-    event: MouseEvent<HTMLElement>
-  ) => {
+  const handleRowDoubleClick = (id: string, event: MouseEvent<HTMLElement>) => {
     if (isInteractiveTarget(event.target)) {
       return
     }
@@ -436,7 +456,9 @@ export function TasksTable({
     if (nextIndex < 0 || nextIndex >= visibleRecordIDs.length) {
       return
     }
-    setSelectedRecordContext(visibleRecordIDs[nextIndex] ?? selectedRecordID ?? '')
+    setSelectedRecordContext(
+      visibleRecordIDs[nextIndex] ?? selectedRecordID ?? ''
+    )
   }
 
   const currentInventoryViewSnapshot = useMemo(() => {
@@ -466,7 +488,8 @@ export function TasksTable({
     async (nextViews: InventorySavedView[]) => {
       await saveInventoryProfileSettings({
         ...inventoryProfileSettings,
-        [inventorySavedViewsSettingsKey]: serializeInventorySavedViews(nextViews),
+        [inventorySavedViewsSettingsKey]:
+          serializeInventorySavedViews(nextViews),
       })
     },
     [inventoryProfileSettings, saveInventoryProfileSettings]
@@ -521,7 +544,9 @@ export function TasksTable({
       setSaveViewName('')
       setSavedViewFeedback(`Saved view: ${name}`)
     } catch {
-      setSavedViewError('Saved view failed to persist. Retry once profile settings are available.')
+      setSavedViewError(
+        'Saved view failed to persist. Retry once profile settings are available.'
+      )
     }
   }, [
     activeInventoryProfileId,
@@ -536,7 +561,9 @@ export function TasksTable({
     if (!activeSavedViewID) {
       return
     }
-    const currentView = inventorySavedViews.find((view) => view.id === activeSavedViewID)
+    const currentView = inventorySavedViews.find(
+      (view) => view.id === activeSavedViewID
+    )
     if (!currentView) {
       return
     }
@@ -548,13 +575,11 @@ export function TasksTable({
       setActiveSavedViewID('')
       setSavedViewFeedback(`Deleted saved view: ${currentView.name}`)
     } catch {
-      setSavedViewError('Saved view failed to delete. Retry once profile settings are available.')
+      setSavedViewError(
+        'Saved view failed to delete. Retry once profile settings are available.'
+      )
     }
-  }, [
-    activeSavedViewID,
-    inventorySavedViews,
-    persistInventorySavedViews,
-  ])
+  }, [activeSavedViewID, inventorySavedViews, persistInventorySavedViews])
 
   useEffect(() => {
     if (
@@ -565,12 +590,13 @@ export function TasksTable({
     }
   }, [activeSavedViewID, inventorySavedViews])
 
-  const statusFilterOptions = routePath === '/_authenticated/wishlist/'
-    ? [
-        { label: 'Watching', value: 'wishlist' },
-        { label: 'Below target', value: 'discovered' },
-      ]
-    : statuses
+  const statusFilterOptions =
+    routePath === '/_authenticated/wishlist/'
+      ? [
+          { label: 'Watching', value: 'wishlist' },
+          { label: 'Below target', value: 'discovered' },
+        ]
+      : statuses
 
   const inventoryConditionFilterOptions = useMemo(() => {
     if (!isInventoryRoute) {
@@ -578,9 +604,7 @@ export function TasksTable({
     }
     return Array.from(
       new Set(
-        data
-          .map((task) => task.status.trim())
-          .filter((status) => status !== '')
+        data.map((task) => task.status.trim()).filter((status) => status !== '')
       )
     )
       .sort((left, right) => left.localeCompare(right))
@@ -596,9 +620,7 @@ export function TasksTable({
     }
     return Array.from(
       new Set(
-        data
-          .map((task) => task.label.trim())
-          .filter((label) => label !== '')
+        data.map((task) => task.label.trim()).filter((label) => label !== '')
       )
     )
       .sort((left, right) => left.localeCompare(right))
@@ -658,7 +680,9 @@ export function TasksTable({
                     setSavedViewError(null)
                     return
                   }
-                  const nextView = inventorySavedViews.find((view) => view.id === nextID)
+                  const nextView = inventorySavedViews.find(
+                    (view) => view.id === nextID
+                  )
                   if (!nextView) {
                     return
                   }
@@ -677,7 +701,10 @@ export function TasksTable({
                 size='sm'
                 variant='outline'
                 data-testid='inventory-saved-view-save'
-                disabled={inventoryProfileSettingsLoading || inventoryProfileSettingsSaving}
+                disabled={
+                  inventoryProfileSettingsLoading ||
+                  inventoryProfileSettingsSaving
+                }
                 onClick={() => {
                   setSaveViewDialogOpen(true)
                   setSavedViewFeedback(null)
@@ -686,8 +713,9 @@ export function TasksTable({
                     previous !== ''
                       ? previous
                       : activeSavedViewID !== ''
-                        ? inventorySavedViews.find((view) => view.id === activeSavedViewID)?.name ??
-                          ''
+                        ? (inventorySavedViews.find(
+                            (view) => view.id === activeSavedViewID
+                          )?.name ?? '')
                         : ''
                   )
                 }}
@@ -711,12 +739,18 @@ export function TasksTable({
             </>
           ) : null}
           {savedViewFeedback ? (
-            <p className='text-xs text-muted-foreground' data-testid='inventory-saved-view-feedback'>
+            <p
+              className='text-xs text-muted-foreground'
+              data-testid='inventory-saved-view-feedback'
+            >
               {savedViewFeedback}
             </p>
           ) : null}
           {savedViewError ? (
-            <p className='text-xs text-destructive' data-testid='inventory-saved-view-error'>
+            <p
+              className='text-xs text-destructive'
+              data-testid='inventory-saved-view-error'
+            >
               {savedViewError}
             </p>
           ) : null}
@@ -783,7 +817,8 @@ export function TasksTable({
                       Boolean(row.original.itemID)
                     }
                     className={cn(
-                      currentRecordID === (row.original.itemID ?? row.original.id)
+                      currentRecordID ===
+                        (row.original.itemID ?? row.original.id)
                         ? 'bg-primary/5'
                         : undefined
                     )}
@@ -796,7 +831,10 @@ export function TasksTable({
                         return
                       }
                       event.dataTransfer.effectAllowed = 'move'
-                      event.dataTransfer.setData(inventoryItemDragDataType, itemID)
+                      event.dataTransfer.setData(
+                        inventoryItemDragDataType,
+                        itemID
+                      )
                       event.dataTransfer.setData('text/plain', itemID)
                     }}
                     onClick={(event) => handleRowClick(row.original.id, event)}
@@ -853,10 +891,7 @@ export function TasksTable({
                 data-state={row.getIsSelected() && 'selected'}
                 onDragStart={(event) => {
                   const itemID = row.original.itemID
-                  if (
-                    routePath !== '/_authenticated/inventory/' ||
-                    !itemID
-                  ) {
+                  if (routePath !== '/_authenticated/inventory/' || !itemID) {
                     return
                   }
                   event.dataTransfer.effectAllowed = 'move'
@@ -893,7 +928,8 @@ export function TasksTable({
                   <span>Priority: {row.original.priority}</span>
                   <span>Type: {row.original.label}</span>
                 </div>
-                {routePath === '/_authenticated/wishlist/' && row.original.notes ? (
+                {routePath === '/_authenticated/wishlist/' &&
+                row.original.notes ? (
                   <p className='text-xs text-muted-foreground'>
                     Notes: {row.original.notes}
                   </p>
@@ -987,11 +1023,15 @@ export function TasksTable({
           <DialogHeader>
             <DialogTitle>Save Inventory View</DialogTitle>
             <DialogDescription>
-              Save the current inventory search, filters, sorting, and layout for this profile.
+              Save the current inventory search, filters, sorting, and layout
+              for this profile.
             </DialogDescription>
           </DialogHeader>
           <div className='space-y-2'>
-            <label className='text-sm font-medium' htmlFor='inventory-saved-view-name'>
+            <label
+              className='text-sm font-medium'
+              htmlFor='inventory-saved-view-name'
+            >
               View name
             </label>
             <Input


### PR DESCRIPTION
## Summary
- move Inventory Barcodes out of the inline page section and into an item-scoped modal
- add a page-level Barcodes action plus row-level barcode quick action
- update barcode Cypress coverage for modal-first add, lookup, empty fallback, and retry flows

## Validation
- npx eslint src/features/collection/index.tsx src/features/tasks/components/tasks-columns.tsx src/features/tasks/components/tasks-table.tsx cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts cypress/e2e/inventory/ui-screen-inventory-barcodes/spec.cy.ts
- git diff --check
- pwsh -NoLogo -NoProfile -File ./scripts/build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File ./cypress.ps1 -Spec cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File ./cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-barcodes/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File ./cypress.ps1 -Spec cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- npm --prefix ui.web run lint: blocked by pre-existing repo errors in setup-wizard-first-run/spec.cy.ts and sidebar-data.ts

Closes #641