### PR TITLE
#646 feat(inventory): assign rows to collections

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-assign-collection/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-assign-collection/spec.cy.ts
@@ -1,0 +1,51 @@
+describe("inventory assign to collection", () => {
+  const items = [
+    {
+      id: "item-assign-alpha",
+      part_number: "PN-ASSIGN-A",
+      title: "Assign Alpha",
+      status: "active",
+      category: "Cards",
+      brand: "Topps",
+      priority: "medium",
+      description: "Inventory row assignment coverage item",
+    },
+  ];
+
+  function signIn(path = "/inventory/") {
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.intercept("GET", "/api/items", {
+      statusCode: 200,
+      body: { items },
+    }).as("items");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path });
+    });
+    cy.wait("@items");
+  }
+
+  it("assigns an inventory row to a collection and reflects it on Collections", () => {
+    signIn();
+
+    cy.get(
+      '[data-testid="inventory-item-row-item-assign-alpha"] [data-testid="inventory-row-assign-collection-action"]'
+    ).click();
+    cy.get('[data-testid="inventory-assign-collection-dialog"]')
+      .should("be.visible")
+      .and("contain", "Assign Alpha");
+    cy.get('[data-testid="inventory-assign-collection-select"]').select("Store 1");
+    cy.get('[data-testid="inventory-assign-collection-submit"]').click();
+    cy.get('[data-testid="inventory-assign-collection-dialog"]').should("not.exist");
+    cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-ASSIGN-A");
+
+    cy.reload();
+    cy.wait("@items");
+    cy.get('[data-testid="inventory-collection-filter-select"]').select("Store 1");
+    cy.contains("Assign Alpha").should("be.visible");
+
+    cy.visit("/collections/");
+    cy.get('[data-testid="collections-row-store-1"]').click();
+    cy.get('[data-testid="collections-member-assign-alpha"]').should("be.visible");
+  });
+});

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -49,7 +49,10 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
-import { useWorkspaceCollections } from '@/features/collections/use-workspace-collections'
+import {
+  type WorkspaceCollectionItem,
+  useWorkspaceCollections,
+} from '@/features/collections/use-workspace-collections'
 import {
   TasksDialogs,
   type TasksDialogType,
@@ -1045,6 +1048,13 @@ export function Collection({
   const [itemSaveBusy, setItemSaveBusy] = useState(false)
   const [itemSaveError, setItemSaveError] = useState<string | null>(null)
   const [itemSaveSuccess, setItemSaveSuccess] = useState<string | null>(null)
+  const [assignCollectionOpen, setAssignCollectionOpen] = useState(false)
+  const [assignCollectionItem, setAssignCollectionItem] =
+    useState<InventoryItem | null>(null)
+  const [assignCollectionName, setAssignCollectionName] = useState('')
+  const [assignCollectionError, setAssignCollectionError] = useState<
+    string | null
+  >(null)
   const [tasksDialogOpen, setTasksDialogOpen] =
     useState<TasksDialogType | null>(null)
   const [tasksDialogRow, setTasksDialogRow] = useState<Task | null>(null)
@@ -1082,7 +1092,12 @@ export function Collection({
     workspaceCollections,
     activeWorkspaceCollection,
     setActiveWorkspaceCollection,
+    assignWorkspaceItemToCollection,
   } = useWorkspaceCollections()
+  const assignableWorkspaceCollections = useMemo(
+    () => workspaceCollections.filter((collection) => collection !== 'All Items'),
+    [workspaceCollections]
+  )
   const activeWorkspaceCollectionRef = useRef(activeWorkspaceCollection)
 
   const selectInventoryItem = useCallback((item: InventoryItem | null) => {
@@ -1155,6 +1170,75 @@ export function Collection({
     },
     [selectInventoryItem]
   )
+
+  const openInventoryAssignCollectionForItem = useCallback(
+    (item: InventoryItem | null) => {
+      setAssignCollectionError(null)
+      if (!item) {
+        selectInventoryItem(null)
+        setAssignCollectionItem(null)
+        setAssignCollectionName(assignableWorkspaceCollections[0] ?? '')
+        setAssignCollectionError(
+          'Select an inventory item before assigning a collection.'
+        )
+        setAssignCollectionOpen(true)
+        return
+      }
+
+      const currentAssignment = itemFolderAssignments[item.id]
+      const defaultCollection =
+        currentAssignment && currentAssignment !== 'All Items'
+          ? currentAssignment
+          : assignableWorkspaceCollections[0] ?? ''
+      selectInventoryItem(item)
+      setAssignCollectionItem(item)
+      setAssignCollectionName(defaultCollection)
+      setAssignCollectionOpen(true)
+    },
+    [
+      assignableWorkspaceCollections,
+      itemFolderAssignments,
+      selectInventoryItem,
+    ]
+  )
+
+  const handleAssignInventoryItemToCollection = useCallback(async () => {
+    if (!assignCollectionItem || !assignCollectionName) {
+      setAssignCollectionError('Choose an item and collection before saving.')
+      return
+    }
+
+    const workspaceItem: WorkspaceCollectionItem = {
+      id: assignCollectionItem.id,
+      name: assignCollectionItem.title || assignCollectionItem.part_number,
+      detail:
+        [assignCollectionItem.brand, assignCollectionItem.category]
+          .filter(Boolean)
+          .join(' - ') || 'Inventory item',
+      collectionName: assignCollectionName,
+    }
+    const updated = await assignWorkspaceItemToCollection(
+      workspaceItem,
+      assignCollectionName
+    )
+    if (!updated) {
+      setAssignCollectionError('Collection assignment could not be saved.')
+      return
+    }
+
+    setItemFolderAssignments((current) => ({
+      ...current,
+      [assignCollectionItem.id]: assignCollectionName,
+    }))
+    selectInventoryItem(assignCollectionItem)
+    setAssignCollectionOpen(false)
+    setAssignCollectionError(null)
+  }, [
+    assignCollectionItem,
+    assignCollectionName,
+    assignWorkspaceItemToCollection,
+    selectInventoryItem,
+  ])
 
   const resolveInventoryItemFromTask = useCallback(
     (task: Task) =>
@@ -3396,9 +3480,89 @@ export function Collection({
                   const matchedItem = resolveInventoryItemFromTask(task)
                   openInventoryBarcodesForItem(matchedItem)
                 }}
+                onAssignCollectionRow={(task) => {
+                  const matchedItem = resolveInventoryItemFromTask(task)
+                  openInventoryAssignCollectionForItem(matchedItem)
+                }}
               />
               {isInventoryRoute ? (
                 <>
+                  <Dialog
+                    open={assignCollectionOpen}
+                    onOpenChange={(open) => {
+                      setAssignCollectionOpen(open)
+                      if (!open) {
+                        setAssignCollectionError(null)
+                      }
+                    }}
+                  >
+                    <DialogContent data-testid='inventory-assign-collection-dialog'>
+                      <div className='space-y-4'>
+                        <DialogHeader>
+                          <DialogTitle>Assign to Collection</DialogTitle>
+                        </DialogHeader>
+                        <p className='text-sm text-muted-foreground'>
+                          {assignCollectionItem
+                            ? `Choose a collection for ${assignCollectionItem.title}.`
+                            : 'Choose an inventory item before assigning.'}
+                        </p>
+                        <div className='grid gap-2'>
+                          <label
+                            className='text-sm font-medium'
+                            htmlFor='inventory-assign-collection-select'
+                          >
+                            Collection
+                          </label>
+                          <select
+                            id='inventory-assign-collection-select'
+                            data-testid='inventory-assign-collection-select'
+                            className='h-9 rounded-md border bg-background px-2 text-sm'
+                            value={assignCollectionName}
+                            onChange={(event) =>
+                              setAssignCollectionName(event.target.value)
+                            }
+                          >
+                            {assignableWorkspaceCollections.map(
+                              (collection) => (
+                                <option key={collection} value={collection}>
+                                  {collection}
+                                </option>
+                              )
+                            )}
+                          </select>
+                        </div>
+                        {assignCollectionError ? (
+                          <div
+                            className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'
+                            data-testid='inventory-assign-collection-error'
+                          >
+                            {assignCollectionError}
+                          </div>
+                        ) : null}
+                        <DialogFooter>
+                          <Button
+                            type='button'
+                            variant='outline'
+                            onClick={() => setAssignCollectionOpen(false)}
+                          >
+                            Cancel
+                          </Button>
+                          <Button
+                            type='button'
+                            data-testid='inventory-assign-collection-submit'
+                            disabled={
+                              !assignCollectionItem || !assignCollectionName
+                            }
+                            onClick={() =>
+                              void handleAssignInventoryItemToCollection()
+                            }
+                          >
+                            Assign
+                          </Button>
+                        </DialogFooter>
+                      </div>
+                    </DialogContent>
+                  </Dialog>
                   <Dialog
                     open={itemEditorOpen}
                     onOpenChange={(open) => {

--- a/ui.web/src/features/collections/use-workspace-collections.ts
+++ b/ui.web/src/features/collections/use-workspace-collections.ts
@@ -396,6 +396,48 @@ export function useWorkspaceCollections() {
     }).then(() => updatedItem)
   }
 
+  const assignWorkspaceItemToCollection = (
+    item: WorkspaceCollectionItem,
+    collectionName: string
+  ): Promise<WorkspaceCollectionItem | null> => {
+    const normalizedCollection = normalizeCollectionName(collectionName)
+    if (
+      !item.id ||
+      !normalizedCollection ||
+      normalizedCollection === 'All Items'
+    ) {
+      return Promise.resolve(null)
+    }
+    if (
+      !workspaceCollections.some(
+        (collection) => collection === normalizedCollection
+      )
+    ) {
+      return Promise.resolve(null)
+    }
+
+    const normalizedItem = normalizeWorkspaceCollectionItem({
+      ...item,
+      collectionName: normalizedCollection,
+    })
+    const existingItem = workspaceItems.some(
+      (workspaceItem) => workspaceItem.id === normalizedItem.id
+    )
+    const updatedItems = existingItem
+      ? workspaceItems.map((workspaceItem) =>
+          workspaceItem.id === normalizedItem.id
+            ? normalizedItem
+            : workspaceItem
+        )
+      : [...workspaceItems, normalizedItem]
+
+    return persistWorkspaceCollectionsState({
+      collections: workspaceCollections,
+      activeCollection: activeWorkspaceCollection,
+      items: updatedItems,
+    }).then(() => normalizedItem)
+  }
+
   const unassignItemFromCollection = (
     itemID: string
   ): Promise<WorkspaceCollectionItem | null> => {
@@ -444,6 +486,7 @@ export function useWorkspaceCollections() {
     collectionSummaries,
     collectionItems,
     assignItemToCollection,
+    assignWorkspaceItemToCollection,
     unassignItemFromCollection,
   }
 }

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -1,5 +1,5 @@
 import { type ColumnDef } from '@tanstack/react-table'
-import { BarcodeIcon, ImageIcon } from 'lucide-react'
+import { BarcodeIcon, ImageIcon, TagsIcon } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -17,6 +17,7 @@ type TasksColumnsOptions = {
   onEditRow?: (task: Task) => void
   onPhotoRow?: (task: Task) => void
   onBarcodeRow?: (task: Task) => void
+  onAssignCollectionRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   wishlistActionItemID?: string | null
@@ -36,6 +37,7 @@ export function getTasksColumns({
   onEditRow,
   onPhotoRow,
   onBarcodeRow,
+  onAssignCollectionRow,
   onDeleteRow,
   onWishlistMarkOwned,
   wishlistActionItemID,
@@ -218,6 +220,20 @@ export function getTasksColumns({
         <div className='flex items-center justify-end gap-1'>
           {isInventoryRoute ? (
             <>
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon'
+                className='h-8 w-8'
+                data-testid='inventory-row-assign-collection-action'
+                aria-label={`Assign ${row.original.title} to a collection`}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onAssignCollectionRow?.(row.original)
+                }}
+              >
+                <TagsIcon className='h-4 w-4' />
+              </Button>
               <Button
                 type='button'
                 variant='ghost'

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -59,6 +59,7 @@ type DataTableProps = {
   onEditRow?: (task: Task) => void
   onPhotoRow?: (task: Task) => void
   onBarcodeRow?: (task: Task) => void
+  onAssignCollectionRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   onWishlistBulkStatusChange?: (tasks: Task[], status: string) => Promise<void>
@@ -208,6 +209,7 @@ export function TasksTable({
   onEditRow,
   onPhotoRow,
   onBarcodeRow,
+  onAssignCollectionRow,
   onDeleteRow,
   onWishlistMarkOwned,
   onWishlistBulkStatusChange,
@@ -226,6 +228,7 @@ export function TasksTable({
         onEditRow,
         onPhotoRow,
         onBarcodeRow,
+        onAssignCollectionRow,
         onDeleteRow,
         onWishlistMarkOwned,
         wishlistActionItemID,
@@ -235,6 +238,7 @@ export function TasksTable({
       onEditRow,
       onPhotoRow,
       onBarcodeRow,
+      onAssignCollectionRow,
       onDeleteRow,
       onWishlistMarkOwned,
       wishlistActionItemID,
@@ -780,8 +784,8 @@ export function TasksTable({
       </div>
 
       {viewMode === 'rows' ? (
-        <div className='overflow-hidden rounded-md border'>
-          <Table className='min-w-xl'>
+        <div className='overflow-x-auto rounded-md border'>
+          <Table className='min-w-[42rem]'>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>


### PR DESCRIPTION
## Summary
- add a row-level Inventory action for assigning an item to a collection
- persist assignments into Inventory filtering and the shared Collections workspace state
- keep mobile table layout stable with internal horizontal row scrolling

## Validation
- Initial red test: pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-assign-collection/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90 failed because the row assign action was missing
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1 -> passed
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-assign-collection/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90 -> passed
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90 -> passed
- 
px eslint src/features/collection/index.tsx src/features/collections/use-workspace-collections.ts src/features/tasks/components/tasks-columns.tsx src/features/tasks/components/tasks-table.tsx cypress/e2e/inventory/inventory-assign-collection/spec.cy.ts cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts -> passed
- git diff --check -> passed
- pre-push OpenSpec validation + API docs smoke -> passed

Closes #646