### PR TITLE
#635 Capture real mobile camera photos

### DIFF
--- a/ui.web/cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts
@@ -1,15 +1,54 @@
 describe('MOBILE-CAMERA-CAPTURE', () => {
+  function uploadBodyText(body: unknown): string {
+    if (typeof body === 'string') {
+      return body
+    }
+    if (body instanceof ArrayBuffer) {
+      return new TextDecoder().decode(body)
+    }
+    if (ArrayBuffer.isView(body)) {
+      return new TextDecoder().decode(body)
+    }
+    return JSON.stringify(body)
+  }
+
   function signInWithCameraStub(
-    getUserMediaImpl: () => Promise<{ getTracks: () => Array<{ stop: () => void }> }>
+    getUserMediaImpl: (
+      constraints: MediaStreamConstraints
+    ) => Promise<{
+      getTracks: () => Array<{ kind: string; stop: () => void }>
+      getVideoTracks: () => Array<{ kind: string; stop: () => void }>
+    }>,
+    installImageCapture = true
   ) {
     cy.visit('/sign-in?redirect=%2Finventory%2F', {
       onBeforeLoad(win) {
+        const cameraConstraintCalls: MediaStreamConstraints[] = []
+        Object.defineProperty(win, '__cameraConstraintCalls', {
+          configurable: true,
+          value: cameraConstraintCalls,
+        })
         Object.defineProperty(win.navigator, 'mediaDevices', {
           configurable: true,
           value: {
-            getUserMedia: getUserMediaImpl,
+            getUserMedia: (constraints: MediaStreamConstraints) => {
+              cameraConstraintCalls.push(constraints)
+              return getUserMediaImpl(constraints)
+            },
           },
         })
+        if (installImageCapture) {
+          Object.defineProperty(win, 'ImageCapture', {
+            configurable: true,
+            value: class {
+              takePhoto() {
+                return Promise.resolve(
+                  new win.Blob(['real-camera-frame'], { type: 'image/jpeg' })
+                )
+              }
+            },
+          })
+        }
       },
     })
     cy.get('input[name="email"]').clear().type('e2e-camera@example.com')
@@ -41,19 +80,33 @@ describe('MOBILE-CAMERA-CAPTURE', () => {
   }
 
   it('MOBILE-CAMERA-001 supports direct camera capture upload path', () => {
-    cy.intercept('POST', '/api/items/item-camera-1/photos', {
-      statusCode: 201,
-      body: {
-        id: 'photo-camera-1',
-        item_id: 'item-camera-1',
-        original_path: '/media/originals/photo-camera-1.jpg',
-        thumbnail_path: '/media/thumbnails/photo-camera-1.jpg',
-        preview_path: '/media/previews/photo-camera-1.jpg',
-      },
+    cy.intercept('POST', '/api/items/item-camera-1/photos', (req) => {
+      const contentType = String(req.headers['content-type'] ?? '')
+      expect(contentType).to.include('multipart/form-data')
+
+      const bodyText = uploadBodyText(req.body)
+      expect(bodyText).to.match(
+        /name="file"; filename="camera-capture-\d+\.jpg"/
+      )
+      expect(bodyText).to.include('Content-Type: image/jpeg')
+      expect(bodyText).to.include('real-camera-frame')
+
+      req.reply({
+        statusCode: 201,
+        body: {
+          id: 'photo-camera-1',
+          item_id: 'item-camera-1',
+          original_path: '/media/originals/photo-camera-1.jpg',
+          thumbnail_path: '/media/thumbnails/photo-camera-1.jpg',
+          preview_path: '/media/previews/photo-camera-1.jpg',
+        },
+      })
     }).as('uploadPhoto')
 
+    const videoTrack = { kind: 'video', stop: () => {} }
     signInWithCameraStub(async () => ({
-      getTracks: () => [{ stop: () => {} }],
+      getTracks: () => [videoTrack],
+      getVideoTracks: () => [videoTrack],
     }))
 
     cy.wait('@items')
@@ -62,13 +115,22 @@ describe('MOBILE-CAMERA-CAPTURE', () => {
     openPhotosModal()
     cy.get('[data-testid="inventory-camera-take-photo"]').click()
     cy.wait('@uploadPhoto')
+    cy.window()
+      .its('__cameraConstraintCalls.0.video.facingMode.ideal')
+      .should('equal', 'environment')
     cy.get('[data-testid="inventory-camera-success"]').should('be.visible')
+    cy.get('[data-testid="inventory-photo-upload-input"]')
+      .should('have.attr', 'accept', 'image/*')
+      .and('have.attr', 'capture', 'environment')
   })
 
   it('MOBILE-CAMERA-002 shows deterministic fallback when camera access is denied', () => {
-    signInWithCameraStub(async () => {
-      throw new Error('Permission denied')
-    })
+    signInWithCameraStub(
+      async () => {
+        throw new Error('Permission denied')
+      },
+      false
+    )
 
     cy.wait('@items')
     cy.wait('@photos')

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -81,6 +81,117 @@ type BarcodeMatch = {
   created_at?: string
 }
 
+type CameraImageCapture = {
+  takePhoto: () => Promise<Blob>
+}
+
+type CameraImageCaptureConstructor = new (
+  track: MediaStreamTrack
+) => CameraImageCapture
+
+type CameraWindow = Window & {
+  ImageCapture?: CameraImageCaptureConstructor
+}
+
+function getCameraVideoTrack(stream: MediaStream) {
+  return stream.getVideoTracks()[0] ?? null
+}
+
+function createCameraPhotoFile(blob: Blob) {
+  return new File([blob], `camera-capture-${Date.now()}.jpg`, {
+    type: blob.type || 'image/jpeg',
+  })
+}
+
+function waitForVideoMetadata(video: HTMLVideoElement) {
+  if (video.videoWidth > 0 && video.videoHeight > 0) {
+    return Promise.resolve()
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    function cleanup() {
+      video.removeEventListener('loadedmetadata', onLoaded)
+      video.removeEventListener('error', onError)
+      window.clearTimeout(timeoutID)
+    }
+
+    function onLoaded() {
+      cleanup()
+      resolve()
+    }
+
+    function onError() {
+      cleanup()
+      reject(new Error('camera_video_unavailable'))
+    }
+
+    const timeoutID = window.setTimeout(() => {
+      cleanup()
+      resolve()
+    }, 1500)
+
+    video.addEventListener('loadedmetadata', onLoaded, { once: true })
+    video.addEventListener('error', onError, { once: true })
+  })
+}
+
+function canvasToJpegBlob(canvas: HTMLCanvasElement) {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error('camera_frame_encode_failed'))
+          return
+        }
+        resolve(blob)
+      },
+      'image/jpeg',
+      0.92
+    )
+  })
+}
+
+async function captureCameraPhotoBlob(stream: MediaStream) {
+  const videoTrack = getCameraVideoTrack(stream)
+  const imageCaptureConstructor =
+    typeof window !== 'undefined'
+      ? (window as CameraWindow).ImageCapture
+      : undefined
+
+  if (imageCaptureConstructor && videoTrack) {
+    return new imageCaptureConstructor(videoTrack).takePhoto()
+  }
+
+  const video = document.createElement('video')
+  video.muted = true
+  video.playsInline = true
+  video.srcObject = stream
+
+  try {
+    await video.play()
+  } catch {
+    // Some browsers block play() on detached media; loadedmetadata is enough.
+  }
+
+  try {
+    await waitForVideoMetadata(video)
+    const width = video.videoWidth || 1280
+    const height = video.videoHeight || 720
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const context = canvas.getContext('2d')
+    if (!context) {
+      throw new Error('camera_canvas_unavailable')
+    }
+    context.drawImage(video, 0, 0, width, height)
+    return await canvasToJpegBlob(canvas)
+  } finally {
+    video.pause()
+    video.srcObject = null
+  }
+}
+
 type InventoryItem = {
   id: string
   part_number: string
@@ -2723,15 +2834,16 @@ export function Collection({
     }
     let stream: MediaStream | null = null
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ video: true })
-      const file = new File(['camera-capture'], 'camera-capture.jpg', {
-        type: 'image/jpeg',
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: 'environment' } },
       })
+      const photoBlob = await captureCameraPhotoBlob(stream)
+      const file = createCameraPhotoFile(photoBlob)
       await handlePhotoUpload(file)
       setCameraSuccess('Camera capture uploaded successfully.')
     } catch {
       setCameraError(
-        'Camera permission was denied or unavailable. Use Upload File instead.'
+        'Camera permission was denied or unavailable. Use Upload File or your browser camera picker instead.'
       )
     } finally {
       if (stream) {
@@ -3845,6 +3957,7 @@ export function Collection({
                           <input
                             type='file'
                             accept='image/*'
+                            capture='environment'
                             data-testid='inventory-photo-upload-input'
                             disabled={!selectedItemID}
                             onChange={(event) => {


### PR DESCRIPTION
## Summary
- capture real camera image bytes for Inventory photos using ImageCapture with a canvas fallback
- prefer the rear camera via facingMode environment and native file input capture hint
- harden Cypress coverage for camera upload bytes and permission-denied fallback

## Validation
- Red first: mobile-camera-capture spec failed on placeholder camera-capture.jpg bytes
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- npx eslint src/features/collection/index.tsx cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts
- git diff --check
- openspec validate --all --strict --no-interactive
- pwsh -NoLogo -NoProfile -File .\\scripts\\validate-openapi.ps1
- pre-push OpenSpec + fast API docs smoke passed

Note: full go test ./... still has an unrelated existing docs migration failure in internal/app: docs/PRODUCT-OVERVIEW.md and docs/PRODUCT_OVERVIEW_PLAN.md remain in docs.