### PR TITLE
#634 Compact workspace page action headers

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -265,7 +265,7 @@ describe('ui-screen-collections', () => {
     })
   })
 
-  it('UI-SCREEN-COLLECTIONS-012 reflects inventory inline collection create inside the collections manager', () => {
+  it('UI-SCREEN-COLLECTIONS-012 keeps inventory collection create in the compact folder filter', () => {
     cy.e2eReset()
     cy.e2eSetSetupState('present')
     cy.intercept('GET', '/api/profiles/*/settings').as('loadCollectionSettings')
@@ -275,25 +275,24 @@ describe('ui-screen-collections', () => {
     })
     cy.wait('@loadCollectionSettings')
 
-    cy.get('[data-testid="collection-inline-add-new"]').click()
-    cy.get('[data-testid="collection-inline-new-name"]').type('Inventory Sync Shelf')
-    cy.get('[data-testid="collection-inline-save"]').click()
+    cy.get('[data-testid="inventory-collection-add-root"]').click()
+    cy.get('[data-testid="folder-tree-name-input"]').type('Inventory Sync Shelf')
+    cy.get('[data-testid="folder-tree-create-submit"]').click()
     cy.wait('@saveCollectionSettings')
-    cy.get('[data-testid="collection-inline-picker-selected"]').should(
+    cy.get('[data-testid="inventory-collection-filter-selected"]').should(
       'contain.text',
       'Inventory Sync Shelf'
     )
 
-    cy.visit('/collections/')
+    cy.reload()
     cy.wait('@loadCollectionSettings')
-    cy.get('[data-testid="collections-row-inventory-sync-shelf"]').should('be.visible')
-    cy.get('[data-testid="collections-selected-name"]').should(
+    cy.get('[data-testid="inventory-collection-filter-selected"]').should(
       'contain.text',
       'Inventory Sync Shelf'
     )
   })
 
-  it('UI-SCREEN-COLLECTIONS-013 reflects wishlist inline collection create inside the collections manager', () => {
+  it('UI-SCREEN-COLLECTIONS-013 reflects wishlist table collection create inside the collections manager', () => {
     cy.e2eReset()
     cy.e2eSetSetupState('present')
     cy.intercept('GET', '/api/profiles/*/settings').as('loadCollectionSettings')
@@ -303,11 +302,11 @@ describe('ui-screen-collections', () => {
     })
     cy.wait('@loadCollectionSettings')
 
-    cy.get('[data-testid="wishlist-inline-add-new"]').click()
-    cy.get('[data-testid="wishlist-inline-new-name"]').type('Wishlist Sync Shelf')
-    cy.get('[data-testid="wishlist-inline-save"]').click()
+    cy.get('[data-testid="wishlist-table-add-collection"]').click()
+    cy.get('[data-testid="wishlist-table-new-collection-name"]').type('Wishlist Sync Shelf')
+    cy.get('[data-testid="wishlist-table-new-collection-save"]').click()
     cy.wait('@saveCollectionSettings')
-    cy.get('[data-testid="wishlist-inline-picker-selected"]').should(
+    cy.get('[data-testid="wishlist-table-collection-selected"]').should(
       'contain.text',
       'Wishlist Sync Shelf'
     )
@@ -321,7 +320,7 @@ describe('ui-screen-collections', () => {
     )
   })
 
-  it('UI-SCREEN-COLLECTIONS-014 propagates rename into inventory and wishlist pickers', () => {
+  it('UI-SCREEN-COLLECTIONS-014 propagates rename into the wishlist table collection filter', () => {
     signInToCollections()
 
     cy.get('[data-testid="collections-row-store-2"]').click()
@@ -330,16 +329,24 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-edit-submit"]').click()
     cy.contains('Store 2 renamed to Store 2 Routed.').should('be.visible')
 
-    cy.visit('/inventory/')
-    cy.get('[data-testid="collection-inline-picker-option-store-2-routed"]').should('be.visible')
-    cy.get('[data-testid="collection-inline-picker-option-store-2"]').should('not.exist')
-
     cy.visit('/wishlist/')
-    cy.get('[data-testid="wishlist-inline-picker-option-store-2-routed"]').should('be.visible')
-    cy.get('[data-testid="wishlist-inline-picker-option-store-2"]').should('not.exist')
+    cy.get('[data-testid="wishlist-table-collection-select"]').select('Store 2 Routed')
+    cy.get('[data-testid="wishlist-table-collection-selected"]').should(
+      'contain.text',
+      'Store 2 Routed'
+    )
+    cy.get('[data-testid="wishlist-table-collection-select"] option').then(
+      ($options) => {
+        const optionLabels = [...$options].map((option) =>
+          option.textContent?.trim()
+        )
+        expect(optionLabels).to.include('Store 2 Routed')
+        expect(optionLabels).not.to.include('Store 2')
+      }
+    )
   })
 
-  it('UI-SCREEN-COLLECTIONS-015 propagates delete fallback into inventory and wishlist pickers', () => {
+  it('UI-SCREEN-COLLECTIONS-015 falls wishlist table collection context back after delete', () => {
     signInToCollections()
     cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
 
@@ -348,13 +355,13 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-row-delete-store-1"]').scrollIntoView().click({ force: true })
     cy.get('[data-testid="collections-delete-submit"]').click()
     cy.contains('Store 1 removed from workspace collections.').should('be.visible')
-
-    cy.visit('/inventory/')
-    cy.get('[data-testid="collection-inline-picker-selected"]').should('contain.text', 'All Items')
-    cy.get('[data-testid="collection-inline-picker-option-store-1"]').should('not.exist')
+    cy.wait('@saveCollectionSettings')
 
     cy.visit('/wishlist/')
-    cy.get('[data-testid="wishlist-inline-picker-selected"]').should('contain.text', 'All Items')
-    cy.get('[data-testid="wishlist-inline-picker-option-store-1"]').should('not.exist')
+    cy.wait('@loadCollectionSettings')
+    cy.get('[data-testid="wishlist-table-collection-selected"]').should(
+      'contain.text',
+      'All Items'
+    )
   })
 })

--- a/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
@@ -1,0 +1,140 @@
+describe('workspace header action lanes', () => {
+  const inventoryItems = [
+    {
+      id: 'item-header-alpha',
+      part_number: 'PN-HEAD-A',
+      title: 'Header Alpha',
+      status: 'active',
+      category: 'Cars',
+      brand: 'AFX',
+      priority: 'medium',
+      description: 'Header action coverage item',
+    },
+  ]
+
+  function bootstrap(path: string) {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, { path })
+    })
+  }
+
+  function assertWorkspaceStartsBelowHeader(
+    headerTestID: string,
+    workspaceTestID: string
+  ) {
+    cy.get(`[data-testid="${headerTestID}"]`).then(($header) => {
+      const headerBottom = $header[0].getBoundingClientRect().bottom
+      cy.get(`[data-testid="${workspaceTestID}"]`).then(($workspace) => {
+        const workspaceTop = $workspace[0].getBoundingClientRect().top
+        expect(workspaceTop - headerBottom).to.be.within(0, 32)
+      })
+    })
+  }
+
+  it('keeps Inventory actions in a compact page header without duplicate workspace chrome', () => {
+    cy.viewport(1280, 800)
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: { items: inventoryItems },
+    }).as('items')
+
+    bootstrap('/inventory/')
+    cy.wait('@items')
+
+    cy.get('[data-testid="inventory-page-header"]')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('Inventory').should('be.visible')
+        cy.get('[data-testid="inventory-header-context"]').should(
+          'contain.text',
+          'All Items'
+        )
+        cy.get('[data-testid="inventory-new-action"]').should('be.visible')
+        cy.get('[data-testid="inventory-create-menu-trigger"]').should(
+          'be.visible'
+        )
+      })
+    cy.contains('Browse, organize, and update the items you already own.').should(
+      'not.exist'
+    )
+    cy.get('[data-testid="collection-context-label"]').should('not.exist')
+    assertWorkspaceStartsBelowHeader('inventory-page-header', 'inventory-workspace')
+  })
+
+  it('keeps Wishlist actions in the same compact header pattern', () => {
+    cy.viewport(1280, 800)
+    cy.intercept('GET', '/api/wishlist', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'wish-header-alpha',
+            item_id: 'item-header-wishlist',
+            priority: 'high',
+            below_target_now: true,
+          },
+        ],
+      },
+    }).as('wishlistItems')
+    cy.intercept('GET', '/api/items?status=wishlist', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-header-wishlist',
+            title: 'Wishlist Header Alpha',
+            part_number: 'WISH-HEAD-A',
+            status: 'wishlist',
+            category: 'Cards',
+            priority: 'high',
+          },
+        ],
+      },
+    }).as('wishlistCatalog')
+    cy.intercept('GET', '/api/profiles/*/settings').as('profileSettings')
+
+    bootstrap('/wishlist/')
+    cy.wait('@wishlistItems')
+    cy.wait('@wishlistCatalog')
+    cy.wait('@profileSettings')
+
+    cy.get('[data-testid="wishlist-page-header"]')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('Wishlist').should('be.visible')
+        cy.get('[data-testid="wishlist-new-action"]').should('be.visible')
+        cy.get('[data-testid="wishlist-create-menu-trigger"]').should(
+          'be.visible'
+        )
+      })
+    cy.contains(
+      'Track wanted items, target prices, and planning decisions before they become owned inventory.'
+    ).should('not.exist')
+    assertWorkspaceStartsBelowHeader(
+      'wishlist-page-header',
+      'wishlist-workspace'
+    )
+  })
+
+  it('keeps Collections actions in the same compact header pattern', () => {
+    cy.viewport(1280, 800)
+    bootstrap('/collections/')
+
+    cy.get('[data-testid="collections-page-header"]')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('Collections').should('be.visible')
+        cy.get('[data-testid="collections-page-icon"]').should('be.visible')
+        cy.get('[data-testid="collections-new-action"]').should('be.visible')
+      })
+    cy.contains(
+      'Manage collection rows and item placement from the shared Cabinet table surface.'
+    ).should('not.exist')
+    assertWorkspaceStartsBelowHeader(
+      'collections-page-header',
+      'collections-workspace'
+    )
+  })
+})

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -65,8 +65,19 @@ describe("ui-screen-wishlist", () => {
   function openWishlistRowActions(rowText: string) {
     cy.contains("tr", rowText)
       .find('[data-testid="task-row-actions-trigger"]')
+      .scrollIntoView()
       .should("be.visible")
-      .trigger("pointerdown", { button: 0, force: true });
+      .then(($trigger) => {
+        const button = $trigger[0];
+        const view = button.ownerDocument.defaultView;
+        button.dispatchEvent(
+          new view!.PointerEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            pointerType: "mouse",
+          })
+        );
+      });
     cy.get('[role="menu"]').should("be.visible");
   }
 
@@ -74,9 +85,13 @@ describe("ui-screen-wishlist", () => {
     signInToWishlist();
 
     cy.contains("Wishlist").should("be.visible");
+    cy.get('[data-testid="wishlist-page-header"]').within(() => {
+      cy.get('[data-testid="wishlist-new-action"]').should("be.visible");
+      cy.get('[data-testid="wishlist-create-menu-trigger"]').should("be.visible");
+    });
     cy.contains(
       "Track wanted items, target prices, and planning decisions before they become owned inventory."
-    ).should("be.visible");
+    ).should("not.exist");
     cy.contains("wishlist.description").should("not.exist");
     cy.get("table").should("be.visible");
     cy.contains("button", "Cards").click();

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -1084,7 +1084,6 @@ function resolveFolderDragPreviewPosition(clientX: number, clientY: number) {
 
 export function Collection({
   title = 'Collection',
-  description = 'Command your inventory and move from folders to item actions quickly.',
   routePath,
 }: CollectionWorkspaceProps) {
   const [tableData, setTableData] = useState<Task[]>(tasks)
@@ -3144,19 +3143,24 @@ export function Collection({
         </div>
       </Header>
 
-      <Main className='space-y-4'>
-        <div className='flex flex-wrap items-end justify-between gap-3'>
-          <div className='space-y-2'>
-            <h1 className='text-2xl font-bold tracking-tight'>{title}</h1>
-            <p className='text-muted-foreground'>{description}</p>
-            <p
-              className='text-xs text-muted-foreground'
-              data-testid='collection-context-label'
+      <Main className='space-y-3'>
+        <div
+          className='flex flex-wrap items-center justify-between gap-2'
+          data-testid='inventory-page-header'
+        >
+          <div className='flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
+            <h1 className='text-xl font-bold tracking-tight'>{title}</h1>
+            <span
+              className='text-xs font-medium text-muted-foreground'
+              data-testid='inventory-header-context'
             >
-              Collection context: {activeFolder}
-            </p>
+              Collection: {activeFolder}
+            </span>
           </div>
-          <div className='flex gap-2'>
+          <div
+            className='flex flex-wrap items-center justify-end gap-2'
+            data-testid='inventory-header-actions'
+          >
             {isInventoryRoute ? (
               <>
                 <Button
@@ -3224,7 +3228,7 @@ export function Collection({
           </div>
         </div>
 
-        <div className='grid grid-cols-1 gap-4'>
+        <div className='grid grid-cols-1 gap-4' data-testid='inventory-workspace'>
           <Card className='hidden'>
             <CardHeader>
               <CardTitle>Folders</CardTitle>

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -331,16 +331,20 @@ export function Collections() {
         </div>
       </Header>
 
-      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
-        <div className='mb-6 flex flex-wrap items-end justify-between gap-3'>
-          <div>
-            <div className='flex items-center gap-2'>
-              <Tag className='h-5 w-5 text-muted-foreground' data-testid='collections-page-icon' />
-              <h1 className='text-2xl font-bold tracking-tight'>Collections</h1>
-            </div>
-            <p className='text-muted-foreground'>
-              Manage collection rows and item placement from the shared Cabinet table surface.
-            </p>
+      <Main className='flex flex-1 flex-col gap-3 sm:gap-4'>
+        <div
+          className='flex flex-wrap items-center justify-between gap-2'
+          data-testid='collections-page-header'
+        >
+          <div className='flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1'>
+            <Tag
+              className='h-5 w-5 text-muted-foreground'
+              data-testid='collections-page-icon'
+            />
+            <h1 className='text-xl font-bold tracking-tight'>Collections</h1>
+            <span className='text-xs font-medium text-muted-foreground'>
+              {selectedCollectionName}
+            </span>
           </div>
           <Button data-testid='collections-new-action' onClick={() => setCreateOpen(true)}>
             <Plus className='mr-2 h-4 w-4' />
@@ -348,7 +352,10 @@ export function Collections() {
           </Button>
         </div>
 
-        <div className='grid gap-6 lg:grid-cols-[1.5fr,1fr]'>
+        <div
+          className='grid gap-6 lg:grid-cols-[1.5fr,1fr]'
+          data-testid='collections-workspace'
+        >
           <Card data-testid='collections-section'>
             <CardHeader>
               <CardTitle>Collections table</CardTitle>

--- a/ui.web/src/features/settings/use-profile-settings.ts
+++ b/ui.web/src/features/settings/use-profile-settings.ts
@@ -14,7 +14,7 @@ export function useProfileSettings() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
-  const saveInFlightRef = useRef<Promise<Record<string, string>> | null>(null)
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -57,11 +57,8 @@ export function useProfileSettings() {
       if (!activeProfileId) {
         throw new Error('active_profile_missing')
       }
-      if (saveInFlightRef.current) {
-        return saveInFlightRef.current
-      }
 
-      const request = (async () => {
+      const runSave = async () => {
         setSaving(true)
         try {
           const response = await fetch(`/api/profiles/${activeProfileId}/settings`, {
@@ -78,14 +75,14 @@ export function useProfileSettings() {
         } finally {
           setSaving(false)
         }
-      })()
-
-      saveInFlightRef.current = request
-      try {
-        return await request
-      } finally {
-        saveInFlightRef.current = null
       }
+
+      const request = saveQueueRef.current.then(runSave, runSave)
+      saveQueueRef.current = request.then(
+        () => undefined,
+        () => undefined
+      )
+      return await request
     },
     [activeProfileId]
   )

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -167,7 +167,10 @@ function TasksHeaderActions({
   onImport: () => void
 }) {
   return (
-    <div className='flex items-center gap-2'>
+    <div
+      className='flex flex-wrap items-center justify-end gap-2'
+      data-testid='wishlist-header-actions'
+    >
       <Button
         type='button'
         data-testid='wishlist-new-action'
@@ -214,7 +217,6 @@ function TasksHeaderActions({
 
 export function Tasks({
   title = 'Tasks',
-  description = "Here's a list of your tasks for this month!",
   routePath = '/_authenticated/inventory/',
 }: TasksProps) {
   const {
@@ -757,11 +759,18 @@ export function Tasks({
         </div>
       </Header>
 
-      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
-        <div className='flex flex-wrap items-end justify-between gap-2'>
-          <div>
-            <h2 className='text-2xl font-bold tracking-tight'>{title}</h2>
-            <p className='text-muted-foreground'>{description}</p>
+      <Main className='flex flex-1 flex-col gap-3 sm:gap-4'>
+        <div
+          className='flex flex-wrap items-center justify-between gap-2'
+          data-testid={isWishlistRoute ? 'wishlist-page-header' : undefined}
+        >
+          <div className='flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
+            <h2 className='text-xl font-bold tracking-tight'>{title}</h2>
+            {isWishlistRoute ? (
+              <span className='text-xs font-medium text-muted-foreground'>
+                Planning list
+              </span>
+            ) : null}
           </div>
           <TasksHeaderActions
             isWishlistRoute={isWishlistRoute}
@@ -779,65 +788,72 @@ export function Tasks({
             }}
           />
         </div>
-        {isWishlistRoute ? (
-          <div
-            className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'
-            data-testid='wishlist-planning-summary'
-          >
-            {wishlistPlanningSummary.map((focus) => (
-              <button
-                key={focus.id}
-                type='button'
-                data-testid={`wishlist-planning-focus-${focus.id}`}
-                className={`rounded-lg border p-4 text-left transition-colors ${
-                  wishlistPlanningFocus === focus.id
-                    ? 'border-primary bg-primary/5'
-                    : 'hover:bg-accent/40'
-                }`}
-                aria-pressed={wishlistPlanningFocus === focus.id}
-                onClick={() => setWishlistPlanningFocus(focus.id)}
-              >
-                <div className='flex items-start justify-between gap-3'>
-                  <div>
-                    <p className='text-sm font-medium'>{focus.label}</p>
-                    <p className='mt-1 text-xs text-muted-foreground'>
-                      {focus.description}
-                    </p>
+        <div
+          className='flex flex-1 flex-col gap-4 sm:gap-6'
+          data-testid={isWishlistRoute ? 'wishlist-workspace' : undefined}
+        >
+          {isWishlistRoute ? (
+            <div
+              className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'
+              data-testid='wishlist-planning-summary'
+            >
+              {wishlistPlanningSummary.map((focus) => (
+                <button
+                  key={focus.id}
+                  type='button'
+                  data-testid={`wishlist-planning-focus-${focus.id}`}
+                  className={`rounded-lg border p-4 text-left transition-colors ${
+                    wishlistPlanningFocus === focus.id
+                      ? 'border-primary bg-primary/5'
+                      : 'hover:bg-accent/40'
+                  }`}
+                  aria-pressed={wishlistPlanningFocus === focus.id}
+                  onClick={() => setWishlistPlanningFocus(focus.id)}
+                >
+                  <div className='flex items-start justify-between gap-3'>
+                    <div>
+                      <p className='text-sm font-medium'>{focus.label}</p>
+                      <p className='mt-1 text-xs text-muted-foreground'>
+                        {focus.description}
+                      </p>
+                    </div>
+                    <span className='text-2xl font-semibold'>
+                      {focus.count}
+                    </span>
                   </div>
-                  <span className='text-2xl font-semibold'>{focus.count}</span>
-                </div>
-              </button>
-            ))}
-          </div>
-        ) : null}
-        <TasksTable
-          data={displayedData}
-          routePath={routePath}
-          customFilters={wishlistCollectionFilter}
-          onEditRow={(task) => {
-            setCurrentDialogRow(task)
-            setDialogOpen('update')
-          }}
-          onDeleteRow={(task) => {
-            setCurrentDialogRow(task)
-            setDialogOpen('delete')
-          }}
-          onWishlistMarkOwned={
-            isWishlistRoute ? handleWishlistMarkOwned : undefined
-          }
-          onWishlistBulkStatusChange={
-            isWishlistRoute ? handleWishlistBulkStatusChange : undefined
-          }
-          onWishlistBulkPriorityChange={
-            isWishlistRoute ? handleWishlistBulkPriorityChange : undefined
-          }
-          onWishlistBulkDelete={
-            isWishlistRoute ? handleWishlistBulkDelete : undefined
-          }
-          onWishlistExport={isWishlistRoute ? handleWishlistExport : undefined}
-          wishlistActionItemID={wishlistActionItemID}
-          isWishlistMutating={isWishlistMutating}
-        />
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <TasksTable
+            data={displayedData}
+            routePath={routePath}
+            customFilters={wishlistCollectionFilter}
+            onEditRow={(task) => {
+              setCurrentDialogRow(task)
+              setDialogOpen('update')
+            }}
+            onDeleteRow={(task) => {
+              setCurrentDialogRow(task)
+              setDialogOpen('delete')
+            }}
+            onWishlistMarkOwned={
+              isWishlistRoute ? handleWishlistMarkOwned : undefined
+            }
+            onWishlistBulkStatusChange={
+              isWishlistRoute ? handleWishlistBulkStatusChange : undefined
+            }
+            onWishlistBulkPriorityChange={
+              isWishlistRoute ? handleWishlistBulkPriorityChange : undefined
+            }
+            onWishlistBulkDelete={
+              isWishlistRoute ? handleWishlistBulkDelete : undefined
+            }
+            onWishlistExport={isWishlistRoute ? handleWishlistExport : undefined}
+            wishlistActionItemID={wishlistActionItemID}
+            isWishlistMutating={isWishlistMutating}
+          />
+        </div>
       </Main>
 
       <TasksDialogs


### PR DESCRIPTION
## Summary
- move Inventory, Wishlist, and Collections into compact page header/action lanes
- remove redundant subtitle/context chrome above the working surfaces while keeping compact active context where useful
- add Cypress coverage for Inventory/Wishlist/Collections header placement and workspace start position
- update stale Wishlist/Collections specs for the compact collection-filter model
- serialize profile settings saves so quick select/delete flows do not drop later saves

## Validation
- Red first: workspace-header-actions spec failed on missing compact page headers
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/workspace-header-actions/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- npx eslint focused files: passed with existing TanStack/React Compiler warning in collections/index.tsx
- git diff --check
- openspec validate --all --strict --no-interactive
- pre-push OpenSpec + fast API docs smoke passed

Follow-up: opened #665 for stale deleted collection options that can remain in compact filters.