### PR TITLE
#665 fix(collections): prune deleted compact filter options

### DIFF
--- a/TASK_LIST.md
+++ b/TASK_LIST.md
@@ -1,6 +1,6 @@
 # TASK_LIST
 
-Last synced from GitHub issues: 2026-04-24 21:02 +10:00
+Last synced from GitHub issues: 2026-04-25 22:55 +10:00
 
 ## Status Legend
 - `OPEN`: issue is open and not yet complete.
@@ -8,17 +8,18 @@ Last synced from GitHub issues: 2026-04-24 21:02 +10:00
 - Work is executed one focused issue branch at a time, validated, merged into `develop`, then the demo is rebuilt and restarted.
 
 ## Current Execution Queue
-- [ ] #640 [OPEN] Move Inventory photos into item-scoped modal with row quick action
-- [ ] #641 [OPEN] Move Inventory barcodes into item-scoped modal with row quick action
-- [ ] #642 [OPEN] Add responsive Cypress coverage for Inventory table-first redesign
-- [ ] #646 [OPEN] Inventory: add assign-to-collection action on each item row
+- [ ] #665 [OPEN] Workspace collection deletes should remove stale options from compact filters
 - [ ] #643 [OPEN] Collections: implement two-table selected collection layout
 - [ ] #644 [OPEN] Collections: remove duplicate Selected collection section
 - [ ] #645 [OPEN] Collections: convert Collection members section into items table
-- [ ] #636 [OPEN] Make inventory collection-browser context menu actions visibly effective
-- [ ] #635 [OPEN] Implement real mobile camera photo capture for inventory items
-- [ ] #634 [OPEN] Unify page header actions and reclaim workspace height
 - [ ] #637 [OPEN] Epic: Redesign Inventory as a table-first collection browser
+- [x] #640 [DONE] Move Inventory photos into item-scoped modal with row quick action
+- [x] #641 [DONE] Move Inventory barcodes into item-scoped modal with row quick action
+- [x] #642 [DONE] Add responsive Cypress coverage for Inventory table-first redesign
+- [x] #646 [DONE] Inventory: add assign-to-collection action on each item row
+- [x] #636 [DONE] Make inventory collection-browser context menu actions visibly effective
+- [x] #635 [DONE] Implement real mobile camera photo capture for inventory items
+- [x] #634 [DONE] Unify page header actions and reclaim workspace height
 
 ## CI, Runtime, And Repository Hygiene
 - [ ] #553 [OPEN] Consolidate duplicated main gate GitHub Actions workflows

--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -346,16 +346,56 @@ describe('ui-screen-collections', () => {
     )
   })
 
-  it('UI-SCREEN-COLLECTIONS-015 falls wishlist table collection context back after delete', () => {
+  it('UI-SCREEN-COLLECTIONS-015 removes deleted collections from compact filters', () => {
     signInToCollections()
     cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
 
     cy.get('[data-testid="collections-row-store-1"]').click()
-    cy.wait('@saveCollectionSettings')
+    cy.wait('@saveCollectionSettings').then(({ request }) => {
+      const settings = (request.body.settings ?? {}) as Record<string, string>
+      const persisted = JSON.parse(settings[collectionsSettingsKey] ?? '{}') as {
+        activeCollection?: string
+      }
+      expect(persisted.activeCollection).to.equal('Store 1')
+    })
     cy.get('[data-testid="collections-row-delete-store-1"]').scrollIntoView().click({ force: true })
     cy.get('[data-testid="collections-delete-submit"]').click()
     cy.contains('Store 1 removed from workspace collections.').should('be.visible')
-    cy.wait('@saveCollectionSettings')
+    cy.wait('@saveCollectionSettings').then(({ request }) => {
+      const settings = (request.body.settings ?? {}) as Record<string, string>
+      const persisted = JSON.parse(settings[collectionsSettingsKey] ?? '{}') as {
+        collections?: string[]
+        activeCollection?: string
+      }
+      expect(persisted.activeCollection).to.equal('All Items')
+      expect(
+        persisted.collections ?? [],
+        `delete request collections: ${JSON.stringify(persisted.collections ?? [])}`
+      ).not.to.include('Store 1')
+    })
+    cy.request('/api/profiles/e2e-profile-001/settings').then((response) => {
+      const settings = (response.body.settings ?? {}) as Record<string, string>
+      const persisted = JSON.parse(settings[collectionsSettingsKey] ?? '{}') as {
+        collections?: string[]
+        activeCollection?: string
+      }
+      expect(persisted.activeCollection).to.equal('All Items')
+      expect(
+        persisted.collections ?? [],
+        `persisted collections: ${JSON.stringify(persisted.collections ?? [])}`
+      ).not.to.include('Store 1')
+    })
+
+    cy.visit('/inventory/')
+    cy.wait('@loadCollectionSettings')
+    cy.get('[data-testid="inventory-collection-filter-selected"]').should(
+      'contain.text',
+      'All Items'
+    )
+    cy.get('[data-testid="inventory-collection-filter-select"] option').then(($options) => {
+      const optionLabels = [...$options].map((option) => option.textContent?.trim())
+      expect(optionLabels).not.to.include('Store 1')
+    })
 
     cy.visit('/wishlist/')
     cy.wait('@loadCollectionSettings')
@@ -363,5 +403,9 @@ describe('ui-screen-collections', () => {
       'contain.text',
       'All Items'
     )
+    cy.get('[data-testid="wishlist-table-collection-select"] option').then(($options) => {
+      const optionLabels = [...$options].map((option) => option.textContent?.trim())
+      expect(optionLabels).not.to.include('Store 1')
+    })
   })
 })

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -77,6 +77,19 @@ describe("ui-screen-wishlist", () => {
             pointerType: "mouse",
           })
         );
+        button.dispatchEvent(
+          new view!.PointerEvent("pointerup", {
+            bubbles: true,
+            button: 0,
+            pointerType: "mouse",
+          })
+        );
+        button.dispatchEvent(
+          new view!.MouseEvent("click", {
+            bubbles: true,
+            button: 0,
+          })
+        );
       });
     cy.get('[role="menu"]').should("be.visible");
   }

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -546,22 +546,22 @@ function countFolderNodes(nodes: FolderNode[]): number {
   }, 0)
 }
 
-function flattenFolderOptions(
-  nodes: FolderNode[],
-  level = 0
-): Array<FolderNode & { level: number }> {
-  return nodes.flatMap((node) => [
-    { ...node, level },
-    ...flattenFolderOptions(node.children ?? [], level + 1),
-  ])
-}
-
 function slugifyFolderName(value: string): string {
   return value
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
+}
+
+function buildWorkspaceCollectionFilterOptions(
+  collections: string[]
+): Array<FolderNode & { level: number }> {
+  return collections.map((name) => ({
+    id: slugifyFolderName(name) || 'collection',
+    name,
+    level: 0,
+  }))
 }
 
 function buildUniqueFolderID(name: string, nodes: FolderNode[]): string {
@@ -1203,6 +1203,7 @@ export function Collection({
     workspaceCollections,
     activeWorkspaceCollection,
     setActiveWorkspaceCollection,
+    addCollection,
     assignWorkspaceItemToCollection,
   } = useWorkspaceCollections()
   const assignableWorkspaceCollections = useMemo(
@@ -1353,16 +1354,14 @@ export function Collection({
 
   const selectInventoryFolder = useCallback(
     (nextFolder: string) => {
-      const safeFolder = folderTreeContainsName(folderTree, nextFolder)
+      const safeFolder = workspaceCollections.includes(nextFolder)
         ? nextFolder
         : 'All Items'
       setActiveFolder(safeFolder)
       setCollectionBrowserOpen(false)
-      if (workspaceCollections.includes(safeFolder)) {
-        void setActiveWorkspaceCollection(safeFolder)
-      }
+      void setActiveWorkspaceCollection(safeFolder)
     },
-    [folderTree, setActiveWorkspaceCollection, workspaceCollections]
+    [setActiveWorkspaceCollection, workspaceCollections]
   )
 
   const resolveInventoryItemFromTask = useCallback(
@@ -2346,8 +2345,8 @@ export function Collection({
     [activeFolder, folderTree, tableData.length]
   )
   const folderFilterOptions = useMemo(
-    () => flattenFolderOptions(folderTree),
-    [folderTree]
+    () => buildWorkspaceCollectionFilterOptions(workspaceCollections),
+    [workspaceCollections]
   )
   const activeFolderIsAvailable = folderFilterOptions.some(
     (folder) => folder.name === activeFolder
@@ -2361,15 +2360,15 @@ export function Collection({
     [inventoryItems, selectedItemID]
   )
   const visibleTableData = useMemo(() => {
-    if (!isInventoryRoute || activeFolder === 'All Items') {
+    if (!isInventoryRoute || activeFolderFilterValue === 'All Items') {
       return tableData
     }
 
     return tableData.filter((row) => {
       const itemID = row.itemID ?? row.id
-      return itemFolderAssignments[itemID] === activeFolder
+      return itemFolderAssignments[itemID] === activeFolderFilterValue
     })
-  }, [activeFolder, isInventoryRoute, itemFolderAssignments, tableData])
+  }, [activeFolderFilterValue, isInventoryRoute, itemFolderAssignments, tableData])
   const selectedFolderHasNoItems =
     isInventoryRoute &&
     activeFolderFilterValue !== 'All Items' &&
@@ -3348,7 +3347,7 @@ export function Collection({
                     <Button
                       type='button'
                       data-testid='folder-tree-create-submit'
-                      onClick={() => {
+                      onClick={async () => {
                         const name = folderCreateName.trim()
                         if (name === '') {
                           return
@@ -3373,6 +3372,10 @@ export function Collection({
                             next.add(folderCreateParentID)
                             return next
                           })
+                        }
+                        const created = await addCollection(name)
+                        if (!created && workspaceCollections.includes(name)) {
+                          await setActiveWorkspaceCollection(name)
                         }
                         setActiveFolder(name)
                         setFolderCreateOpen(false)

--- a/ui.web/src/features/collections/use-workspace-collections.ts
+++ b/ui.web/src/features/collections/use-workspace-collections.ts
@@ -173,6 +173,14 @@ function defaultWorkspaceCollectionsState(): Required<PersistedWorkspaceCollecti
   }
 }
 
+function loadingWorkspaceCollectionsState(): Required<PersistedWorkspaceCollectionsState> {
+  return {
+    collections: ['All Items'],
+    activeCollection: 'All Items',
+    items: [],
+  }
+}
+
 function parseWorkspaceCollectionsState(
   rawValue: string | undefined
 ): Required<PersistedWorkspaceCollectionsState> {
@@ -229,12 +237,16 @@ function serializeWorkspaceCollectionsState(
 export function useWorkspaceCollections() {
   const {
     activeProfileId,
+    loading,
     settings,
     saveSettings,
   } = useProfileSettings()
   const persistedState = useMemo(
-    () => parseWorkspaceCollectionsState(settings[collectionsSettingsKey]),
-    [settings]
+    () =>
+      loading
+        ? loadingWorkspaceCollectionsState()
+        : parseWorkspaceCollectionsState(settings[collectionsSettingsKey]),
+    [loading, settings]
   )
 
   const workspaceCollections = persistedState.collections
@@ -303,13 +315,15 @@ export function useWorkspaceCollections() {
   ): Promise<string | null> => {
     const normalizedCurrent = normalizeCollectionName(currentName)
     const normalizedNext = normalizeCollectionName(nextName)
+    const currentKey = collectionKey(normalizedCurrent)
+    const nextKey = collectionKey(normalizedNext)
     if (!normalizedCurrent || !normalizedNext || normalizedCurrent === 'All Items') {
       return null
     }
     const exists = workspaceCollections.some(
       (collection) =>
-        collection.toLowerCase() === normalizedNext.toLowerCase() &&
-        collection.toLowerCase() !== normalizedCurrent.toLowerCase()
+        collectionKey(collection) === nextKey &&
+        collectionKey(collection) !== currentKey
     )
     if (exists) {
       return null
@@ -317,16 +331,16 @@ export function useWorkspaceCollections() {
 
     await persistWorkspaceCollectionsState({
       collections: workspaceCollections.map((collection) =>
-        collection.toLowerCase() === normalizedCurrent.toLowerCase()
+        collectionKey(collection) === currentKey
           ? normalizedNext
           : collection
       ),
       activeCollection:
-        activeWorkspaceCollection.toLowerCase() === normalizedCurrent.toLowerCase()
+        collectionKey(activeWorkspaceCollection) === currentKey
           ? normalizedNext
           : activeWorkspaceCollection,
       items: workspaceItems.map((item) =>
-        item.collectionName?.toLowerCase() === normalizedCurrent.toLowerCase()
+        item.collectionName && collectionKey(item.collectionName) === currentKey
           ? { ...item, collectionName: normalizedNext }
           : item
       ),
@@ -337,11 +351,12 @@ export function useWorkspaceCollections() {
 
   const removeCollection = async (name: string): Promise<boolean> => {
     const normalized = normalizeCollectionName(name)
+    const normalizedKey = collectionKey(normalized)
     if (!normalized || normalized === 'All Items') {
       return false
     }
     const exists = workspaceCollections.some(
-      (collection) => collection.toLowerCase() === normalized.toLowerCase()
+      (collection) => collectionKey(collection) === normalizedKey
     )
     if (!exists) {
       return false
@@ -349,14 +364,14 @@ export function useWorkspaceCollections() {
 
     await persistWorkspaceCollectionsState({
       collections: workspaceCollections.filter(
-        (collection) => collection.toLowerCase() !== normalized.toLowerCase()
+        (collection) => collectionKey(collection) !== normalizedKey
       ),
       activeCollection:
-        activeWorkspaceCollection.toLowerCase() === normalized.toLowerCase()
+        collectionKey(activeWorkspaceCollection) === normalizedKey
           ? 'All Items'
           : activeWorkspaceCollection,
       items: workspaceItems.map((item) =>
-        item.collectionName?.toLowerCase() === normalized.toLowerCase()
+        item.collectionName && collectionKey(item.collectionName) === normalizedKey
           ? { ...item, collectionName: null }
           : item
       ),


### PR DESCRIPTION
## Summary
- source Inventory compact collection options from shared workspace collections
- avoid stale default collections while profile settings are still loading
- add Cypress coverage proving deleted collections disappear from Inventory and Wishlist filters
- stabilize Wishlist row action menu dispatch used by adjacent coverage

## Validation
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-compact-collection-filter/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- npx --prefix ui.web eslint src/features/collection/index.tsx src/features/collections/use-workspace-collections.ts cypress/e2e/collections/ui-screen-collections/spec.cy.ts cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts --quiet
- git diff --check
- openspec validate --all --strict --no-interactive

Note: repo-wide npm lint is still blocked by pre-existing baseline issues outside this branch: a merge-conflict marker in ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts and an explicit any in ui.web/src/components/layout/data/sidebar-data.ts.