### PR TITLE
#673 fix(collections): show All Items members overview

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -36,6 +36,16 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-workspace"]').should('be.visible')
     cy.get('[data-testid="collections-shared-table"]').should('be.visible')
     cy.get('[data-testid="collections-members-table"]').should('be.visible')
+    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'All Items')
+    cy.get('[data-testid="collections-member-row-inventory-item-kobe-rookie"]').should(
+      'contain.text',
+      '1996 Topps Kobe Bryant rookie'
+    )
+    cy.get('[data-testid="collections-member-row-inventory-item-charizard-base"]').should(
+      'contain.text',
+      'Base Set Charizard'
+    )
+
     cy.get('[data-testid="collections-row-store-1"]').click()
     cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Store 1')
     cy.get('[data-testid="collections-member-row-inventory-item-pikachu-shadowless"]').should(

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -173,7 +173,9 @@ export function Collections() {
 
   const selectedCollectionItems = useMemo(
     () =>
-      collectionItems.filter((item) => item.collectionName === selectedCollectionName),
+      selectedCollectionName === 'All Items'
+        ? collectionItems
+        : collectionItems.filter((item) => item.collectionName === selectedCollectionName),
     [collectionItems, selectedCollectionName]
   )
 


### PR DESCRIPTION
## Summary
- Make the Collections members table treat `All Items` as the full workspace item overview.
- Keep specific collection selections filtered to their assigned members.
- Add Cypress coverage for the seeded All Items rows before switching to a specific collection.

## Validation
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `npm exec eslint -- src/features/collections/index.tsx cypress/e2e/collections/ui-screen-collections/spec.cy.ts` from `ui.web` (0 errors, 1 existing TanStack/react-compiler warning)
- `git diff --check`
- `openspec validate --all --strict --no-interactive`
- pre-push OpenSpec + fast API docs smoke

Closes #673