### PR TITLE
#674 feat(wishlist): seed representative sample data

### DIFF
--- a/internal/app/e2e_hooks.go
+++ b/internal/app/e2e_hooks.go
@@ -367,6 +367,26 @@ func bootstrapE2EFixtures(ctx context.Context, conn *sql.DB, cfg config.Config, 
 	}
 
 	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO canonical_items(id, profile_id, brand, category, part_number, title, status, priority, make, model, year, scale, series, description, tags_json, created_at, updated_at)
+		VALUES
+		 ('e2e-wishlist-item-grail', ?, 'E2E Wishlist', 'Trading Cards', 'WISH-GRAIL-001', 'Wishlist Sample Grail Chase', 'wishlist', 'high', 'Pokemon', 'Charizard', '1999', 'Card', 'Wishlist Samples', 'Representative high-priority wishlist sample.', '["seed","wishlist","grail"]', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		 ('e2e-wishlist-item-price-drop', ?, 'E2E Wishlist', 'Diecast', 'WISH-DROP-002', 'Wishlist Sample Price Drop Watch', 'wishlist', 'medium', 'Hot Wheels', 'Skyline', '2024', '1:64', 'Wishlist Samples', 'Representative below-target wishlist sample.', '["seed","wishlist","price-drop"]', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		 ('e2e-wishlist-item-steady', ?, 'E2E Wishlist', 'Comics', 'WISH-WATCH-003', 'Wishlist Sample Steady Watch', 'wishlist', 'low', 'Marvel', 'Spider-Man', '1984', 'Issue', 'Wishlist Samples', 'Representative low-priority wishlist sample.', '["seed","wishlist","watch"]', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, profileID, profileID, profileID); err != nil {
+		return e2eBootstrapResponse{}, fmt.Errorf("insert wishlist sample items: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit, below_target_now, created_at, updated_at)
+		VALUES
+		 ('e2e-wishlist-grail', ?, 'e2e-wishlist-item-grail', 150.00, 'high', 'Sample grail chase row for Wishlist review.', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		 ('e2e-wishlist-price-drop', ?, 'e2e-wishlist-item-price-drop', 35.00, 'medium', 'Sample below-target row for Wishlist review.', 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		 ('e2e-wishlist-steady', ?, 'e2e-wishlist-item-steady', 12.00, 'low', 'Sample steady watch row for Wishlist review.', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, profileID, profileID, profileID); err != nil {
+		return e2eBootstrapResponse{}, fmt.Errorf("insert wishlist sample entries: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO instances(id, item_id, condition, status, quantity, storage_location, acquisition_price, acquisition_date, notes, created_at, updated_at)
 		VALUES
 		 ('e2e-instance-001', ?, 'mint', 'sealed', 1, 'Shelf A', 29.99, '2025-01-10', 'seed instance 1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),

--- a/internal/app/onboarding_api_test.go
+++ b/internal/app/onboarding_api_test.go
@@ -33,10 +33,10 @@ func TestOnboardingSampleDataEndpointIsIdempotent(t *testing.T) {
 		t.Fatalf("first sample seed status=%d body=%s", firstSeed.Code, firstSeed.Body.String())
 	}
 	var firstPayload struct {
-		CreatedItems          int  `json:"created_items"`
-		CreatedWishlist       int  `json:"created_wishlist_entries"`
-		TotalItems            int  `json:"total_items"`
-		TotalWishlist         int  `json:"total_wishlist_entries"`
+		CreatedItems            int  `json:"created_items"`
+		CreatedWishlist         int  `json:"created_wishlist_entries"`
+		TotalItems              int  `json:"total_items"`
+		TotalWishlist           int  `json:"total_wishlist_entries"`
 		AlreadySeededForProfile bool `json:"already_seeded_for_profile"`
 	}
 	if err := json.NewDecoder(firstSeed.Body).Decode(&firstPayload); err != nil {
@@ -116,5 +116,48 @@ func TestOnboardingSampleDataEndpointIsIdempotent(t *testing.T) {
 	}
 	if firstPayload.TotalWishlist < 3 {
 		t.Fatalf("expected seeded wishlist coverage, got %+v", firstPayload)
+	}
+
+	wishlistResp := doRequest(t, a, http.MethodGet, "/api/wishlist", nil, nil)
+	if wishlistResp.Code != http.StatusOK {
+		t.Fatalf("wishlist sample status=%d body=%s", wishlistResp.Code, wishlistResp.Body.String())
+	}
+	var wishlistPayload struct {
+		Items []struct {
+			Priority       string `json:"priority"`
+			Notes          string `json:"notes"`
+			BelowTargetNow bool   `json:"below_target_now"`
+			HighlightHit   bool   `json:"highlight_hit"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(wishlistResp.Body).Decode(&wishlistPayload); err != nil {
+		t.Fatalf("decode wishlist payload: %v", err)
+	}
+	if len(wishlistPayload.Items) < 5 {
+		t.Fatalf("expected at least 5 representative wishlist sample rows, got %+v", wishlistPayload.Items)
+	}
+	priorities := make(map[string]struct{})
+	hasBelowTarget := false
+	hasActionableNote := false
+	hasHighlightHit := false
+	for _, entry := range wishlistPayload.Items {
+		priorities[strings.TrimSpace(entry.Priority)] = struct{}{}
+		hasBelowTarget = hasBelowTarget || entry.BelowTargetNow
+		hasActionableNote = hasActionableNote || strings.Contains(strings.ToLower(entry.Notes), "sample")
+		hasHighlightHit = hasHighlightHit || entry.HighlightHit
+	}
+	for _, required := range []string{"high", "medium", "low"} {
+		if _, ok := priorities[required]; !ok {
+			t.Fatalf("expected representative wishlist priority %q, got %+v", required, priorities)
+		}
+	}
+	if !hasBelowTarget {
+		t.Fatalf("expected at least one below-target wishlist sample row, got %+v", wishlistPayload.Items)
+	}
+	if !hasActionableNote {
+		t.Fatalf("expected wishlist sample rows to include review notes, got %+v", wishlistPayload.Items)
+	}
+	if !hasHighlightHit {
+		t.Fatalf("expected wishlist sample rows to include highlighted hit coverage, got %+v", wishlistPayload.Items)
 	}
 }

--- a/internal/app/onboarding_sample.go
+++ b/internal/app/onboarding_sample.go
@@ -20,10 +20,14 @@ type onboardingSampleSeedResult struct {
 }
 
 type onboardingSampleSpec struct {
-	Item        collection.Item
-	Instance    collection.Instance
-	Wishlist    bool
-	TargetPrice float64
+	Item                   collection.Item
+	Instance               collection.Instance
+	Wishlist               bool
+	TargetPrice            float64
+	WishlistPriority       string
+	WishlistNotes          string
+	WishlistHighlightHit   bool
+	WishlistBelowTargetNow bool
 }
 
 func seedOnboardingSampleData(
@@ -68,8 +72,11 @@ func seedOnboardingSampleData(
 				AcquisitionDate:  "2026-01-15",
 				Notes:            "Included as sample onboarding data.",
 			},
-			Wishlist:    true,
-			TargetPrice: 10,
+			Wishlist:             true,
+			TargetPrice:          10,
+			WishlistPriority:     "high",
+			WishlistNotes:        "Sample grail chase: buy when a clean card lands near target.",
+			WishlistHighlightHit: true,
 		},
 		{
 			Item: collection.Item{
@@ -94,8 +101,11 @@ func seedOnboardingSampleData(
 				AcquisitionDate:  "2026-01-20",
 				Notes:            "Included as sample onboarding data.",
 			},
-			Wishlist:    false,
-			TargetPrice: 0,
+			Wishlist:             true,
+			TargetPrice:          9,
+			WishlistPriority:     "low",
+			WishlistNotes:        "Sample steady watch: useful comparison item, not urgent.",
+			WishlistHighlightHit: false,
 		},
 		{
 			Item: collection.Item{
@@ -120,8 +130,12 @@ func seedOnboardingSampleData(
 				AcquisitionDate:  "2026-01-22",
 				Notes:            "Included as sample onboarding data.",
 			},
-			Wishlist:    true,
-			TargetPrice: 18,
+			Wishlist:               true,
+			TargetPrice:            18,
+			WishlistPriority:       "high",
+			WishlistNotes:          "Sample price-drop candidate: below target should bubble up.",
+			WishlistHighlightHit:   true,
+			WishlistBelowTargetNow: true,
 		},
 		{
 			Item: collection.Item{
@@ -146,8 +160,11 @@ func seedOnboardingSampleData(
 				AcquisitionDate:  "2026-01-24",
 				Notes:            "Included as sample onboarding data.",
 			},
-			Wishlist:    false,
-			TargetPrice: 0,
+			Wishlist:             true,
+			TargetPrice:          22,
+			WishlistPriority:     "medium",
+			WishlistNotes:        "Sample display target: watch for boxed examples.",
+			WishlistHighlightHit: true,
 		},
 		{
 			Item: collection.Item{
@@ -172,8 +189,11 @@ func seedOnboardingSampleData(
 				AcquisitionDate:  "2026-01-26",
 				Notes:            "Included as sample onboarding data.",
 			},
-			Wishlist:    true,
-			TargetPrice: 20,
+			Wishlist:             true,
+			TargetPrice:          20,
+			WishlistPriority:     "medium",
+			WishlistNotes:        "Sample silver-age target: review condition before buying.",
+			WishlistHighlightHit: true,
 		},
 		{
 			Item: collection.Item{
@@ -252,12 +272,21 @@ func seedOnboardingSampleData(
 
 		if spec.Wishlist {
 			if _, exists := wishlistByItemID[item.ID]; !exists {
+				priority := spec.WishlistPriority
+				if priority == "" {
+					priority = "medium"
+				}
+				notes := spec.WishlistNotes
+				if notes == "" {
+					notes = "Sample wishlist entry created during onboarding."
+				}
 				createdEntry, createErr := wishlistSvc.CreateForProfile(ctx, active.ID, wishlist.Entry{
-					ItemID:       item.ID,
-					TargetPrice:  spec.TargetPrice,
-					Priority:     "normal",
-					Notes:        "Sample wishlist entry created during onboarding.",
-					HighlightHit: true,
+					ItemID:         item.ID,
+					TargetPrice:    spec.TargetPrice,
+					Priority:       priority,
+					Notes:          notes,
+					HighlightHit:   spec.WishlistHighlightHit,
+					BelowTargetNow: spec.WishlistBelowTargetNow,
 				})
 				if createErr != nil {
 					return onboardingSampleSeedResult{}, fmt.Errorf("create wishlist for %s: %w", item.ID, createErr)

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -47,6 +47,9 @@ describe("ui-screen-wishlist", () => {
   function signInToWishlist(options?: { skipStub?: boolean }) {
     if (!options?.skipStub) {
       stubWishlistData();
+    } else {
+      cy.intercept("GET", "/api/wishlist").as("wishlistItems");
+      cy.intercept("GET", "/api/items?status=wishlist").as("catalogItems");
     }
     cy.intercept("GET", "/api/profiles/*/settings").as("profileSettings");
     cy.e2eReset();
@@ -116,6 +119,18 @@ describe("ui-screen-wishlist", () => {
     cy.contains("button", "Rows").click();
     cy.get('input[placeholder="Filter by title or ID..."]').type("no-match-wishlist");
     cy.contains("No results.").should("be.visible");
+  });
+
+  it("UI-SCREEN-WISHLIST-013 renders representative seeded wishlist rows without stubs", () => {
+    signInToWishlist({ skipStub: true });
+
+    cy.get('button[aria-label="Switch to rows view"]').click();
+    cy.contains("Wishlist Sample Grail Chase").should("be.visible");
+    cy.contains("Wishlist Sample Price Drop Watch").should("be.visible");
+    cy.contains("Wishlist Sample Steady Watch").should("be.visible");
+    cy.contains("Below target").should("be.visible");
+    cy.contains("High").should("be.visible");
+    cy.contains("Low").should("be.visible");
   });
 
   it("UI-SCREEN-WISHLIST-003 supports multi-select with bulk action toolbar", () => {


### PR DESCRIPTION
## Summary
- Expand onboarding sample Wishlist data with varied priorities, review notes, highlighted hits, and below-target coverage.
- Seed representative Wishlist rows in the E2E bootstrap profile so the Wishlist screen can render meaningful rows without network stubs.
- Add API and Cypress coverage for representative Wishlist seed data.

## Validation
- `go test ./internal/app -run TestOnboardingSampleDataEndpointIsIdempotent -count=1`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `npm exec eslint -- cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` from `ui.web`
- `git diff --check`
- `openspec validate --all --strict --no-interactive`
- pre-push OpenSpec + fast API docs smoke

## Known unrelated validation gap
- `go test ./internal/app -count=1` is currently blocked by the existing docs migration guard because `docs/PRODUCT-OVERVIEW.md` and `docs/PRODUCT_OVERVIEW_PLAN.md` still exist.

Closes #674