### PR TITLE
#672 feat(shell): move page actions into global header

### DIFF
--- a/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
@@ -33,7 +33,7 @@ describe('workspace header action lanes', () => {
     })
   }
 
-  it('keeps Inventory actions in a compact page header without duplicate workspace chrome', () => {
+  it('keeps Inventory actions in the global shell header without duplicate workspace chrome', () => {
     cy.viewport(1280, 800)
     cy.intercept('GET', '/api/items', {
       statusCode: 200,
@@ -43,7 +43,9 @@ describe('workspace header action lanes', () => {
     bootstrap('/inventory/')
     cy.wait('@items')
 
-    cy.get('[data-testid="inventory-page-header"]')
+    cy.get('[data-testid="inventory-shell-header"]').should('be.visible')
+    cy.get('[data-testid="inventory-page-header"]').should('not.exist')
+    cy.get('[data-testid="inventory-global-header-actions"]')
       .should('be.visible')
       .within(() => {
         cy.contains('Inventory').should('be.visible')
@@ -56,14 +58,15 @@ describe('workspace header action lanes', () => {
           'be.visible'
         )
       })
+    cy.get('[data-testid="inventory-header-action-separator"]').should('be.visible')
     cy.contains('Browse, organize, and update the items you already own.').should(
       'not.exist'
     )
     cy.get('[data-testid="collection-context-label"]').should('not.exist')
-    assertWorkspaceStartsBelowHeader('inventory-page-header', 'inventory-workspace')
+    assertWorkspaceStartsBelowHeader('inventory-shell-header', 'inventory-workspace')
   })
 
-  it('keeps Wishlist actions in the same compact header pattern', () => {
+  it('keeps Wishlist actions in the same global shell header pattern', () => {
     cy.viewport(1280, 800)
     cy.intercept('GET', '/api/wishlist', {
       statusCode: 200,
@@ -100,7 +103,9 @@ describe('workspace header action lanes', () => {
     cy.wait('@wishlistCatalog')
     cy.wait('@profileSettings')
 
-    cy.get('[data-testid="wishlist-page-header"]')
+    cy.get('[data-testid="wishlist-shell-header"]').should('be.visible')
+    cy.get('[data-testid="wishlist-page-header"]').should('not.exist')
+    cy.get('[data-testid="wishlist-global-header-actions"]')
       .should('be.visible')
       .within(() => {
         cy.contains('Wishlist').should('be.visible')
@@ -109,31 +114,35 @@ describe('workspace header action lanes', () => {
           'be.visible'
         )
       })
+    cy.get('[data-testid="wishlist-header-action-separator"]').should('be.visible')
     cy.contains(
       'Track wanted items, target prices, and planning decisions before they become owned inventory.'
     ).should('not.exist')
     assertWorkspaceStartsBelowHeader(
-      'wishlist-page-header',
+      'wishlist-shell-header',
       'wishlist-workspace'
     )
   })
 
-  it('keeps Collections actions in the same compact header pattern', () => {
+  it('keeps Collections actions in the same global shell header pattern', () => {
     cy.viewport(1280, 800)
     bootstrap('/collections/')
 
-    cy.get('[data-testid="collections-page-header"]')
+    cy.get('[data-testid="collections-shell-header"]').should('be.visible')
+    cy.get('[data-testid="collections-page-header"]').should('not.exist')
+    cy.get('[data-testid="collections-global-header-actions"]')
       .should('be.visible')
       .within(() => {
         cy.contains('Collections').should('be.visible')
         cy.get('[data-testid="collections-page-icon"]').should('be.visible')
         cy.get('[data-testid="collections-new-action"]').should('be.visible')
       })
+    cy.get('[data-testid="collections-header-action-separator"]').should('be.visible')
     cy.contains(
       'Manage collection rows and item placement from the shared Cabinet table surface.'
     ).should('not.exist')
     assertWorkspaceStartsBelowHeader(
-      'collections-page-header',
+      'collections-shell-header',
       'collections-workspace'
     )
   })

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -34,6 +34,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
+import { Separator } from '@/components/ui/separator'
 import {
   Sheet,
   SheetContent,
@@ -3132,34 +3133,22 @@ export function Collection({
 
   return (
     <TasksProvider>
-      <Header fixed>
+      <Header fixed data-testid='inventory-shell-header'>
         <Search />
-        <div className='ms-auto flex items-center space-x-4'>
-          <LanguageSwitch />
-          <ThemeSwitch />
-          <ConfigDrawer />
-          <ProfileDropdown />
-        </div>
-      </Header>
-
-      <Main className='space-y-3'>
-        <div
-          className='flex flex-wrap items-center justify-between gap-2'
-          data-testid='inventory-page-header'
-        >
-          <div className='flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
-            <h1 className='text-xl font-bold tracking-tight'>{title}</h1>
-            <span
-              className='text-xs font-medium text-muted-foreground'
-              data-testid='inventory-header-context'
-            >
-              Collection: {activeFolder}
-            </span>
-          </div>
+        <div className='ms-auto flex min-w-0 items-center gap-3'>
           <div
-            className='flex flex-wrap items-center justify-end gap-2'
-            data-testid='inventory-header-actions'
+            className='flex min-w-0 flex-wrap items-center justify-end gap-2'
+            data-testid='inventory-global-header-actions'
           >
+            <div className='mr-1 flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
+              <h1 className='text-lg font-bold tracking-tight'>{title}</h1>
+              <span
+                className='text-xs font-medium text-muted-foreground'
+                data-testid='inventory-header-context'
+              >
+                Collection: {activeFolder}
+              </span>
+            </div>
             {isInventoryRoute ? (
               <>
                 <Button
@@ -3225,8 +3214,21 @@ export function Collection({
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
+          <Separator
+            orientation='vertical'
+            className='h-6'
+            data-testid='inventory-header-action-separator'
+          />
+          <div className='flex items-center space-x-4'>
+            <LanguageSwitch />
+            <ThemeSwitch />
+            <ConfigDrawer />
+            <ProfileDropdown />
+          </div>
         </div>
+      </Header>
 
+      <Main className='space-y-3'>
         <div className='grid grid-cols-1 gap-4' data-testid='inventory-workspace'>
           <Card className='hidden'>
             <CardHeader>

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -32,6 +32,7 @@ import { LanguageSwitch } from '@/components/language-switch'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
+import { Separator } from '@/components/ui/separator'
 import {
   Select,
   SelectContent,
@@ -324,36 +325,42 @@ export function Collections() {
 
   return (
     <>
-      <Header>
+      <Header fixed data-testid='collections-shell-header'>
         <Search />
-        <div className='ml-auto flex items-center gap-4'>
-          <ThemeSwitch />
-          <LanguageSwitch />
-          <ProfileDropdown />
+        <div className='ml-auto flex min-w-0 items-center gap-3'>
+          <div
+            className='flex min-w-0 flex-wrap items-center justify-end gap-2'
+            data-testid='collections-global-header-actions'
+          >
+            <div className='mr-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1'>
+              <Tag
+                className='h-5 w-5 text-muted-foreground'
+                data-testid='collections-page-icon'
+              />
+              <h1 className='text-lg font-bold tracking-tight'>Collections</h1>
+              <span className='text-xs font-medium text-muted-foreground'>
+                {selectedCollectionName}
+              </span>
+            </div>
+            <Button data-testid='collections-new-action' onClick={() => setCreateOpen(true)}>
+              <Plus className='mr-2 h-4 w-4' />
+              New collection
+            </Button>
+          </div>
+          <Separator
+            orientation='vertical'
+            className='h-6'
+            data-testid='collections-header-action-separator'
+          />
+          <div className='flex items-center gap-4'>
+            <ThemeSwitch />
+            <LanguageSwitch />
+            <ProfileDropdown />
+          </div>
         </div>
       </Header>
 
       <Main className='flex flex-1 flex-col gap-3 sm:gap-4'>
-        <div
-          className='flex flex-wrap items-center justify-between gap-2'
-          data-testid='collections-page-header'
-        >
-          <div className='flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1'>
-            <Tag
-              className='h-5 w-5 text-muted-foreground'
-              data-testid='collections-page-icon'
-            />
-            <h1 className='text-xl font-bold tracking-tight'>Collections</h1>
-            <span className='text-xs font-medium text-muted-foreground'>
-              {selectedCollectionName}
-            </span>
-          </div>
-          <Button data-testid='collections-new-action' onClick={() => setCreateOpen(true)}>
-            <Plus className='mr-2 h-4 w-4' />
-            New collection
-          </Button>
-        </div>
-
         <div
           className='grid gap-4'
           data-testid='collections-workspace'

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
+import { Separator } from '@/components/ui/separator'
 import {
   collectionKey,
   useWorkspaceCollections,
@@ -749,45 +750,54 @@ export function Tasks({
 
   return (
     <>
-      <Header fixed>
+      <Header fixed data-testid={isWishlistRoute ? 'wishlist-shell-header' : undefined}>
         <Search />
-        <div className='ms-auto flex items-center space-x-4'>
-          <LanguageSwitch />
-          <ThemeSwitch />
-          <ConfigDrawer />
-          <ProfileDropdown />
+        <div className='ms-auto flex min-w-0 items-center gap-3'>
+          {isWishlistRoute ? (
+            <>
+              <div
+                className='flex min-w-0 flex-wrap items-center justify-end gap-2'
+                data-testid='wishlist-global-header-actions'
+              >
+                <div className='mr-1 flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
+                  <h2 className='text-lg font-bold tracking-tight'>{title}</h2>
+                  <span className='text-xs font-medium text-muted-foreground'>
+                    Planning list
+                  </span>
+                </div>
+                <TasksHeaderActions
+                  isWishlistRoute={isWishlistRoute}
+                  onOpenCollectionCreate={() => {
+                    setInlineCollectionValidationMessage('')
+                    setInlineCollectionInputOpen(true)
+                  }}
+                  onCreate={() => {
+                    setCurrentDialogRow(null)
+                    setDialogOpen('create')
+                  }}
+                  onImport={() => {
+                    setCurrentDialogRow(null)
+                    setDialogOpen('import')
+                  }}
+                />
+              </div>
+              <Separator
+                orientation='vertical'
+                className='h-6'
+                data-testid='wishlist-header-action-separator'
+              />
+            </>
+          ) : null}
+          <div className='flex items-center space-x-4'>
+            <LanguageSwitch />
+            <ThemeSwitch />
+            <ConfigDrawer />
+            <ProfileDropdown />
+          </div>
         </div>
       </Header>
 
       <Main className='flex flex-1 flex-col gap-3 sm:gap-4'>
-        <div
-          className='flex flex-wrap items-center justify-between gap-2'
-          data-testid={isWishlistRoute ? 'wishlist-page-header' : undefined}
-        >
-          <div className='flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
-            <h2 className='text-xl font-bold tracking-tight'>{title}</h2>
-            {isWishlistRoute ? (
-              <span className='text-xs font-medium text-muted-foreground'>
-                Planning list
-              </span>
-            ) : null}
-          </div>
-          <TasksHeaderActions
-            isWishlistRoute={isWishlistRoute}
-            onOpenCollectionCreate={() => {
-              setInlineCollectionValidationMessage('')
-              setInlineCollectionInputOpen(true)
-            }}
-            onCreate={() => {
-              setCurrentDialogRow(null)
-              setDialogOpen('create')
-            }}
-            onImport={() => {
-              setCurrentDialogRow(null)
-              setDialogOpen('import')
-            }}
-          />
-        </div>
         <div
           className='flex flex-1 flex-col gap-4 sm:gap-6'
           data-testid={isWishlistRoute ? 'wishlist-workspace' : undefined}


### PR DESCRIPTION
## Summary
- Move Inventory, Wishlist, and Collections page actions into the global shell header.
- Place page actions to the left of global controls with a separator.
- Remove page-local title/action header blocks so workspaces start higher.
- Update Cypress coverage to assert shell-header action lanes and absence of content-area page headers.

## Validation
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/workspace-header-actions/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `npm exec eslint -- src/features/collection/index.tsx src/features/tasks/index.tsx src/features/collections/index.tsx cypress/e2e/inventory/workspace-header-actions/spec.cy.ts` from `ui.web` (0 errors, 1 existing TanStack/react-compiler warning)
- `git diff --check`
- `openspec validate --all --strict --no-interactive`
- pre-push OpenSpec + fast API docs smoke

Closes #672