### PR TITLE
#670 fix(inventory): standardize media modal close controls

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts
@@ -55,6 +55,15 @@ describe('inventory barcode modal', () => {
     cy.get('[data-testid="inventory-barcodes-dialog"]')
       .should('be.visible')
       .and('contain', 'Barcode Alpha')
+    cy.get('[data-testid="inventory-barcodes-dialog"] [data-slot="dialog-close"]').should(
+      'have.length',
+      1
+    )
+    cy.get('[data-testid="inventory-barcodes-dialog-close"]').should(
+      'have.attr',
+      'data-slot',
+      'dialog-close'
+    )
     cy.get('[data-testid="inventory-barcodes-lookup-input"]').type('1234567890123')
     cy.get('[data-testid="inventory-barcodes-lookup-button"]').click()
     cy.wait('@lookupAlpha')

--- a/ui.web/cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts
@@ -56,6 +56,15 @@ describe('inventory photo modal', () => {
     cy.get('[data-testid="inventory-photos-dialog"]')
       .should('be.visible')
       .and('contain', 'Photo Alpha')
+    cy.get('[data-testid="inventory-photos-dialog"] [data-slot="dialog-close"]').should(
+      'have.length',
+      1
+    )
+    cy.get('[data-testid="inventory-photos-dialog-close"]').should(
+      'have.attr',
+      'data-slot',
+      'dialog-close'
+    )
     cy.contains('[data-testid="inventory-photo-row"]', 'alpha-one.jpg').should('be.visible')
     cy.get('[data-testid="inventory-photos-dialog-close"]').click()
     cy.get('[data-testid="inventory-photos-dialog"]').should('not.exist')

--- a/ui.web/src/components/ui/dialog.tsx
+++ b/ui.web/src/components/ui/dialog.tsx
@@ -48,9 +48,11 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  closeButtonTestId,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  closeButtonTestId?: string
   showCloseButton?: boolean
 }) {
   return (
@@ -67,6 +69,7 @@ function DialogContent({
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close
+            data-testid={closeButtonTestId}
             data-slot='dialog-close'
             className="absolute end-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -4118,13 +4118,14 @@ export function Collection({
                   >
                     <DialogContent
                       className='max-h-[86vh] overflow-y-auto sm:max-w-4xl'
+                      closeButtonTestId='inventory-photos-dialog-close'
                       data-testid='inventory-photos-dialog'
                     >
                       <section
                         className='space-y-3'
                         data-testid='inventory-photos-panel'
                       >
-                        <div className='flex flex-wrap items-start justify-between gap-3'>
+                        <div className='flex flex-wrap items-start justify-between gap-3 pr-8'>
                           <div>
                             <DialogHeader>
                               <DialogTitle>Photos</DialogTitle>
@@ -4138,14 +4139,6 @@ export function Collection({
                                 : 'Select an inventory item before managing photos.'}
                             </p>
                           </div>
-                          <Button
-                            type='button'
-                            variant='outline'
-                            data-testid='inventory-photos-dialog-close'
-                            onClick={() => setPhotosDialogOpen(false)}
-                          >
-                            Close
-                          </Button>
                         </div>
                         <div className='sr-only'>
                           Review item media and inspect photos in fullscreen
@@ -4381,13 +4374,14 @@ export function Collection({
                   >
                     <DialogContent
                       className='max-h-[86vh] overflow-y-auto sm:max-w-4xl'
+                      closeButtonTestId='inventory-barcodes-dialog-close'
                       data-testid='inventory-barcodes-dialog'
                     >
                       <section
                         className='space-y-3'
                         data-testid='inventory-barcodes-panel'
                       >
-                        <div className='flex flex-wrap items-start justify-between gap-3'>
+                        <div className='flex flex-wrap items-start justify-between gap-3 pr-8'>
                           <div>
                             <DialogHeader>
                               <DialogTitle>Barcodes</DialogTitle>
@@ -4401,14 +4395,6 @@ export function Collection({
                                 : 'Select an inventory item before managing barcodes.'}
                             </p>
                           </div>
-                          <Button
-                            type='button'
-                            variant='outline'
-                            data-testid='inventory-barcodes-dialog-close'
-                            onClick={() => setBarcodesDialogOpen(false)}
-                          >
-                            Close
-                          </Button>
                         </div>
                         <div className='sr-only'>
                           Add barcodes to the selected item, run local lookup,


### PR DESCRIPTION
## Summary
- Remove the duplicate large Close buttons from Inventory Photos and Barcodes modals.
- Reuse the shared Dialog close affordance and preserve modal-specific test IDs on the standard control.
- Add spacing beside modal headings so the shared close control does not overlap header text.
- Add Cypress assertions that each modal exposes exactly one standardized dialog close control.

## Validation
- Initial failing test: cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts failed because inventory-photos-dialog-close was not the shared dialog close control.
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- .\node_modules\.bin\eslint.cmd --no-ignore src/components/ui/dialog.tsx src/features/collection/index.tsx cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts
- git diff --check
- openspec validate --all --strict --no-interactive

Note: barcode modal Cypress passed after retries.

Closes #670