### PR TITLE
#644 #645 fix(collections): simplify member table screen

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -36,7 +36,9 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-workspace"]').should('be.visible')
     cy.get('[data-testid="collections-shared-table"]').should('be.visible')
     cy.get('[data-testid="collections-members-table"]').should('be.visible')
-    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'All Items')
+    cy.get('[data-testid="collections-active-context"]').should('contain.text', 'All Items')
+    cy.get('[data-testid="collections-selected-name"]').should('not.exist')
+    cy.get('[data-testid="collections-assignment-panel"]').should('not.exist')
     cy.get('[data-testid="collections-member-row-inventory-item-kobe-rookie"]').should(
       'contain.text',
       '1996 Topps Kobe Bryant rookie'
@@ -47,14 +49,19 @@ describe('ui-screen-collections', () => {
     )
 
     cy.get('[data-testid="collections-row-store-1"]').click()
-    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Store 1')
+    cy.get('[data-testid="collections-row-store-1"]').should(
+      'have.attr',
+      'data-state',
+      'selected'
+    )
+    cy.get('[data-testid="collections-active-context"]').should('contain.text', 'Store 1')
     cy.get('[data-testid="collections-member-row-inventory-item-pikachu-shadowless"]').should(
       'contain.text',
       'Shadowless Pikachu'
     )
 
     cy.get('[data-testid="collections-row-overflow"]').click()
-    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Overflow')
+    cy.get('[data-testid="collections-active-context"]').should('contain.text', 'Overflow')
     cy.get('[data-testid="collections-member-row-inventory-item-pikachu-shadowless"]').should(
       'not.exist'
     )
@@ -70,17 +77,20 @@ describe('ui-screen-collections', () => {
 
     cy.get('[data-testid="collections-row-watch-list"]').click()
     cy.wait('@saveCollectionSelection')
-    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Watch List')
-    cy.get('[data-testid="collections-active-context-message"]').should(
-      'contain.text',
-      'Active collection is Watch List'
+    cy.get('[data-testid="collections-row-watch-list"]').should(
+      'have.attr',
+      'data-state',
+      'selected'
     )
+    cy.get('[data-testid="collections-active-context"]').should('contain.text', 'Watch List')
+    cy.get('[data-testid="collections-selected-name"]').should('not.exist')
 
     cy.reload()
-    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Watch List')
-    cy.get('[data-testid="collections-active-context-persistence"]').should(
-      'contain.text',
-      'Persists for this signed-in profile'
+    cy.get('[data-testid="collections-active-context"]').should('contain.text', 'Watch List')
+    cy.get('[data-testid="collections-row-watch-list"]').should(
+      'have.attr',
+      'data-state',
+      'selected'
     )
   })
 
@@ -95,7 +105,7 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-row-collections-alpha"]').should('be.visible')
     cy.reload()
     cy.get('[data-testid="collections-row-collections-alpha"]').should('be.visible')
-    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Collections Alpha')
+    cy.get('[data-testid="collections-active-context"]').should('contain.text', 'Collections Alpha')
   })
 
   it('UI-SCREEN-COLLECTIONS-004 renames a collection from the row workflow and persists after refresh', () => {
@@ -122,10 +132,11 @@ describe('ui-screen-collections', () => {
 
     cy.contains('Store 1 removed from workspace collections.').should('be.visible')
     cy.get('[data-testid="collections-row-store-1"]').should('not.exist')
-
-    cy.get('[data-testid="collections-row-watch-list"]').click()
-    cy.get('[data-testid="collections-assignment-select"]').click()
-    cy.contains('Shadowless Pikachu (Unassigned)').should('be.visible')
+    cy.get('[data-testid="collections-active-context"]').should('contain.text', 'All Items')
+    cy.get('[data-testid="collections-member-row-inventory-item-pikachu-shadowless"]').should(
+      'contain.text',
+      'Currently in Unassigned.'
+    )
   })
 
   it('UI-SCREEN-COLLECTIONS-006 filters collections within the shared table surface', () => {
@@ -138,72 +149,22 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-management-summary"]').should('contain.text', 'Showing 1 of 6 collections.')
   })
 
-  it('UI-SCREEN-COLLECTIONS-007 assigns an item into the selected collection and persists after refresh', () => {
-    signInToCollections()
-    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
-
-    cy.get('[data-testid="collections-row-warehouse-1"]').click()
-    cy.wait('@saveCollectionSettings')
-    cy.get('[data-testid="collections-assignment-select"]').click()
-    cy.contains('Base Set Charizard (Unassigned)').click()
-    cy.get('[data-testid="collections-assignment-submit"]').click()
-    cy.wait('@saveCollectionSettings')
-
-    cy.contains('Base Set Charizard assigned to Warehouse 1.').should('be.visible')
-    cy.get('[data-testid="collections-member-base-set-charizard"]').should('be.visible')
-
-    cy.reload()
-    cy.get('[data-testid="collections-selected-name"]').should('contain.text', 'Warehouse 1')
-    cy.get('[data-testid="collections-member-base-set-charizard"]').should('be.visible')
-  })
-
-  it('UI-SCREEN-COLLECTIONS-008 moves an assigned item between collections and persists after refresh', () => {
+  it('UI-SCREEN-COLLECTIONS-007 keeps item assignment actions out of Collections', () => {
     signInToCollections()
 
     cy.get('[data-testid="collections-row-watch-list"]').click()
     cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('be.visible')
-    cy.get('[data-testid="collections-move-target-1996-topps-kobe-bryant-rookie"]').click()
-    cy.contains('[role="option"]', 'Warehouse 1').click()
-    cy.get('[data-testid="collections-move-submit-1996-topps-kobe-bryant-rookie"]').click({
-      force: true,
-    })
-
-    cy.contains('1996 Topps Kobe Bryant rookie moved to Warehouse 1.').should('be.visible')
-    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('not.exist')
-
-    cy.get('[data-testid="collections-row-warehouse-1"]').click()
-    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('be.visible')
-    cy.reload()
-    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('be.visible')
-  })
-
-  it('UI-SCREEN-COLLECTIONS-008A unassigns an item directly from the selected collection and persists after refresh', () => {
-    signInToCollections()
-    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as('saveCollectionSettings')
-
-    cy.get('[data-testid="collections-row-watch-list"]').click()
-    cy.wait('@saveCollectionSettings')
-    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('be.visible')
-    cy.get('[data-testid="collections-unassign-submit-1996-topps-kobe-bryant-rookie"]').click()
-    cy.wait('@saveCollectionSettings')
-
-    cy.contains('1996 Topps Kobe Bryant rookie removed from Watch List.').should('be.visible')
-    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('not.exist')
-
-    cy.get('[data-testid="collections-assignment-select"]').click()
-    cy.contains('1996 Topps Kobe Bryant rookie (Unassigned)').should('be.visible')
-
-    cy.reload()
-    cy.get('[data-testid="collections-member-1996-topps-kobe-bryant-rookie"]').should('not.exist')
-    cy.get('[data-testid="collections-assignment-select"]').click()
-    cy.contains('1996 Topps Kobe Bryant rookie (Unassigned)').should('be.visible')
+    cy.get('[data-testid="collections-assignment-panel"]').should('not.exist')
+    cy.get('[data-testid^="collections-move-target-"]').should('not.exist')
+    cy.get('[data-testid^="collections-move-submit-"]').should('not.exist')
+    cy.get('[data-testid^="collections-unassign-submit-"]').should('not.exist')
   })
 
   it('UI-SCREEN-COLLECTIONS-009 retains tag iconography for collections route identity', () => {
     signInToCollections()
 
     cy.get('[data-testid="sidebar-nav-link-collections"]').should('be.visible')
-    cy.get('[data-testid="collections-page-icon"]').should('be.visible')
+    cy.get('[data-testid="collections-page-icon"]').should('exist')
     cy.get('[data-testid="sidebar-nav-link-collections"] svg').should('have.class', 'lucide-tag')
     cy.get('[data-testid="collections-page-icon"]').should('have.class', 'lucide-tag')
   })
@@ -218,38 +179,27 @@ describe('ui-screen-collections', () => {
     cy.wait('@saveCollectionSettings')
 
     cy.get('[data-testid="collections-row-profile-persisted-vault"]').click()
-    cy.get('[data-testid="collections-assignment-select"]').click()
-    cy.contains('Base Set Charizard (Unassigned)').click()
-    cy.get('[data-testid="collections-assignment-submit"]').click()
-    cy.wait('@saveCollectionSettings')
 
     cy.request('/api/profiles/e2e-profile-001/settings').then((response) => {
       const settings = (response.body.settings ?? {}) as Record<string, string>
       const persisted = JSON.parse(settings[collectionsSettingsKey] ?? '{}') as {
         collections?: string[]
         activeCollection?: string
-        items?: Array<{ id?: string; collectionName?: string | null }>
       }
 
       expect(persisted.collections).to.include('Profile Persisted Vault')
       expect(persisted.activeCollection).to.equal('Profile Persisted Vault')
-      expect(persisted.items).to.satisfy(
-        (items?: Array<{ id?: string; collectionName?: string | null }>) =>
-          Array.isArray(items) &&
-          items.some(
-            (item) =>
-              item.id === 'inventory-item-charizard-base' &&
-              item.collectionName === 'Profile Persisted Vault'
-          )
-      )
     })
 
     cy.reload()
-    cy.get('[data-testid="collections-selected-name"]').should(
+    cy.get('[data-testid="collections-active-context"]').should(
       'contain.text',
       'Profile Persisted Vault'
     )
-    cy.get('[data-testid="collections-member-base-set-charizard"]').should('be.visible')
+    cy.get('[data-testid="collections-members-empty-row"]').should(
+      'contain.text',
+      'No items are currently assigned to Profile Persisted Vault.'
+    )
   })
 
   it('UI-SCREEN-COLLECTIONS-011 switches collection state with the active profile', () => {
@@ -289,7 +239,7 @@ describe('ui-screen-collections', () => {
           cy.visit('/collections/')
 
           cy.get('[data-testid="collections-row-profile-two-vault"]').should('be.visible')
-          cy.get('[data-testid="collections-selected-name"]').should(
+          cy.get('[data-testid="collections-active-context"]').should(
             'contain.text',
             'Profile Two Vault'
           )
@@ -350,7 +300,7 @@ describe('ui-screen-collections', () => {
     cy.visit('/collections/')
     cy.wait('@loadCollectionSettings')
     cy.get('[data-testid="collections-row-wishlist-sync-shelf"]').should('be.visible')
-    cy.get('[data-testid="collections-selected-name"]').should(
+    cy.get('[data-testid="collections-active-context"]').should(
       'contain.text',
       'Wishlist Sync Shelf'
     )

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -8,7 +8,7 @@ import {
   type SortingState,
   useReactTable,
 } from '@tanstack/react-table'
-import { ArrowRightLeft, Pencil, Plus, Tag, Trash2 } from 'lucide-react'
+import { Pencil, Plus, Tag, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
@@ -34,13 +34,6 @@ import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { Separator } from '@/components/ui/separator'
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import {
   Table,
   TableBody,
   TableCell,
@@ -50,7 +43,6 @@ import {
 } from '@/components/ui/table'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
-  type WorkspaceCollectionItem,
   type WorkspaceCollectionSummary,
   collectionKey,
   useWorkspaceCollections,
@@ -143,8 +135,6 @@ export function Collections() {
     removeCollection,
     collectionItems,
     collectionSummaries,
-    assignItemToCollection,
-    unassignItemFromCollection,
   } = useWorkspaceCollections()
 
   const [sorting, setSorting] = useState<SortingState>([{ id: 'name', desc: false }])
@@ -155,8 +145,6 @@ export function Collections() {
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [createValue, setCreateValue] = useState('')
   const [editValue, setEditValue] = useState('')
-  const [assignmentItemID, setAssignmentItemID] = useState('')
-  const [moveTargets, setMoveTargets] = useState<Record<string, string>>({})
 
   const rows = useMemo(() => collectionSummaries, [collectionSummaries])
 
@@ -170,19 +158,12 @@ export function Collections() {
   )
 
   const selectedCollectionName = selectedRow?.name ?? 'All Items'
-  const isProtectedCollection = selectedCollectionName === 'All Items'
 
   const selectedCollectionItems = useMemo(
     () =>
       selectedCollectionName === 'All Items'
         ? collectionItems
         : collectionItems.filter((item) => item.collectionName === selectedCollectionName),
-    [collectionItems, selectedCollectionName]
-  )
-
-  const assignmentCandidates = useMemo(
-    () =>
-      collectionItems.filter((item) => item.collectionName !== selectedCollectionName),
     [collectionItems, selectedCollectionName]
   )
 
@@ -277,52 +258,6 @@ export function Collections() {
     toast.success(`${removedName} removed from workspace collections.`)
   }
 
-  async function handleAssignToSelectedCollection() {
-    if (!assignmentItemID || !selectedRow || isProtectedCollection) {
-      return
-    }
-    const updated = await assignItemToCollection(assignmentItemID, selectedRow.name)
-    if (!updated) {
-      toast.error('Select an item and a valid collection before saving.')
-      return
-    }
-    setAssignmentItemID('')
-    toast.success(`${updated.name} assigned to ${selectedRow.name}.`)
-  }
-
-  async function handleMoveItem(item: WorkspaceCollectionItem) {
-    const destination = moveTargets[item.id]
-    if (!destination) {
-      toast.error('Choose a destination collection before moving the item.')
-      return
-    }
-    const updated = await assignItemToCollection(item.id, destination)
-    if (!updated) {
-      toast.error('Item move failed.')
-      return
-    }
-    setMoveTargets((current) => {
-      const next = { ...current }
-      delete next[item.id]
-      return next
-    })
-    toast.success(`${item.name} moved to ${destination}.`)
-  }
-
-  async function handleUnassignItem(item: WorkspaceCollectionItem) {
-    const updated = await unassignItemFromCollection(item.id)
-    if (!updated) {
-      toast.error('Item release failed.')
-      return
-    }
-    setMoveTargets((current) => {
-      const next = { ...current }
-      delete next[item.id]
-      return next
-    })
-    toast.success(`${item.name} removed from ${selectedCollectionName}.`)
-  }
-
   return (
     <>
       <Header fixed data-testid='collections-shell-header'>
@@ -339,6 +274,12 @@ export function Collections() {
               />
               <h1 className='text-lg font-bold tracking-tight'>Collections</h1>
               <span className='text-xs font-medium text-muted-foreground'>
+                Active:
+              </span>
+              <span
+                className='text-xs font-medium text-muted-foreground'
+                data-testid='collections-active-context'
+              >
                 {selectedCollectionName}
               </span>
             </div>
@@ -437,67 +378,13 @@ export function Collections() {
 
           <Card data-testid='collections-members-panel'>
             <CardHeader>
-              <div className='flex flex-wrap items-start justify-between gap-3'>
-                <div className='space-y-1'>
-                  <CardTitle>Collection members</CardTitle>
-                  <CardDescription>
-                    Review the inventory items assigned to the selected collection.
-                  </CardDescription>
-                </div>
-                {selectedRow ? (
-                  <div className='min-w-[14rem] rounded-md border bg-muted/30 px-3 py-2 text-sm'>
-                    <div className='font-medium' data-testid='collections-selected-name'>
-                      {selectedRow.name}
-                    </div>
-                    <div className='text-xs text-muted-foreground'>
-                      {selectedRow.description}
-                    </div>
-                    <div className='text-xs text-muted-foreground' data-testid='collections-active-context-message'>
-                      Active collection is {selectedRow.name}.
-                    </div>
-                    <div className='text-xs text-muted-foreground' data-testid='collections-active-context-persistence'>
-                      Persists for this signed-in profile across refresh.
-                    </div>
-                  </div>
-                ) : null}
-              </div>
+              <CardTitle>Collection members</CardTitle>
+              <CardDescription>
+                Review inventory items assigned to the selected collection. Assign or
+                move items from Inventory row actions.
+              </CardDescription>
             </CardHeader>
             <CardContent className='space-y-4'>
-              <div
-                className='rounded-md border bg-muted/20 p-3'
-                data-testid='collections-assignment-panel'
-              >
-                {isProtectedCollection ? (
-                  <div className='text-sm text-muted-foreground' data-testid='collections-assignment-disabled'>
-                    Select a specific collection to assign items. “All Items” stays as the global overview.
-                  </div>
-                ) : (
-                  <>
-                    <Select value={assignmentItemID} onValueChange={setAssignmentItemID}>
-                      <SelectTrigger data-testid='collections-assignment-select'>
-                        <SelectValue placeholder='Choose an item to assign' />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {assignmentCandidates.map((item) => (
-                          <SelectItem key={item.id} value={item.id}>
-                            {item.name} ({item.collectionName ?? 'Unassigned'})
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <Button
-                      type='button'
-                      onClick={() => {
-                        void handleAssignToSelectedCollection()
-                      }}
-                      data-testid='collections-assignment-submit'
-                    >
-                      Assign to {selectedCollectionName}
-                    </Button>
-                  </>
-                )}
-              </div>
-
               <div className='rounded-md border' data-testid='collections-members-table'>
                 <Table>
                   <TableHeader>
@@ -505,7 +392,6 @@ export function Collections() {
                       <TableHead>Item</TableHead>
                       <TableHead>Details</TableHead>
                       <TableHead>Current collection</TableHead>
-                      <TableHead className='min-w-[22rem]'>Actions</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -532,56 +418,11 @@ export function Collections() {
                           >
                             Currently in {item.collectionName ?? 'Unassigned'}.
                           </TableCell>
-                          <TableCell>
-                            <div className='flex flex-wrap items-center gap-2'>
-                              <Select
-                                value={moveTargets[item.id] ?? ''}
-                                onValueChange={(value) =>
-                                  setMoveTargets((current) => ({ ...current, [item.id]: value }))
-                                }
-                              >
-                                <SelectTrigger data-testid={`collections-move-target-${collectionKey(item.name)}`}>
-                                  <SelectValue placeholder='Move to...' />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {rows
-                                    .filter((row) => row.name !== 'All Items' && row.name !== item.collectionName)
-                                    .map((row) => (
-                                      <SelectItem key={row.key} value={row.name}>
-                                        {row.name}
-                                      </SelectItem>
-                                    ))}
-                                </SelectContent>
-                              </Select>
-                              <Button
-                                type='button'
-                                variant='outline'
-                                data-testid={`collections-move-submit-${collectionKey(item.name)}`}
-                                onClick={() => {
-                                  void handleMoveItem(item)
-                                }}
-                              >
-                                <ArrowRightLeft className='mr-2 h-4 w-4' />
-                                Move item
-                              </Button>
-                              <Button
-                                type='button'
-                                variant='outline'
-                                data-testid={`collections-unassign-submit-${collectionKey(item.name)}`}
-                                onClick={() => {
-                                  void handleUnassignItem(item)
-                                }}
-                              >
-                                <Trash2 className='mr-2 h-4 w-4' />
-                                Unassign
-                              </Button>
-                            </div>
-                          </TableCell>
                         </TableRow>
                       ))
                     ) : (
                       <TableRow data-testid='collections-members-empty-row'>
-                        <TableCell colSpan={4} className='h-24 text-center text-muted-foreground'>
+                        <TableCell colSpan={3} className='h-24 text-center text-muted-foreground'>
                           No items are currently assigned to {selectedCollectionName}.
                         </TableCell>
                       </TableRow>


### PR DESCRIPTION
## Summary
- Remove the duplicate selected-collection summary from the Collections page.
- Keep active collection context in the compact global header and selected row state.
- Remove assignment/move/unassign controls from Collections so item assignment remains owned by Inventory row actions.
- Keep Collection members as a real item table with item, details, current collection, and empty state.
- Update Collections Cypress coverage for selection, persistence, member table contents, empty state, and absence of assignment controls.

## Validation
- Initial failing Cypress: cypress/e2e/collections/ui-screen-collections/spec.cy.ts failed on missing compact active context and lingering assignment panel.
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- .\node_modules\.bin\eslint.cmd --no-ignore src/features/collections/index.tsx cypress/e2e/collections/ui-screen-collections/spec.cy.ts (exit 0; existing TanStack React Compiler warning)
- git diff --check
- openspec validate --all --strict --no-interactive

Closes #644
Closes #645