### PR TITLE
#526 test(shell): cover primary document titles

### DIFF
--- a/ui.web/cypress/e2e/general/document-title/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/document-title/spec.cy.ts
@@ -1,0 +1,35 @@
+describe('document title', () => {
+  function signInTo(path: string) {
+    cy.visit(`/sign-in?redirect=${encodeURIComponent(path)}`)
+    cy.get('input[name="email"]').clear().type('e2e-document-title@example.com')
+    cy.get('input[name="password"]').clear().type('password123')
+    cy.contains('button', 'Sign in').click()
+  }
+
+  it('uses Cabinet - <Page Title> across primary authenticated routes', () => {
+    const primaryRoutes = [
+      { path: '/dashboard/', title: 'Cabinet - Home' },
+      { path: '/inventory/', title: 'Cabinet - Inventory' },
+      { path: '/collections/', title: 'Cabinet - Collections' },
+      { path: '/wishlist/', title: 'Cabinet - Wishlist' },
+      { path: '/integrations/', title: 'Cabinet - Integrations' },
+      { path: '/chats/', title: 'Cabinet - Chats' },
+      { path: '/inbox/', title: 'Cabinet - Inbox' },
+      { path: '/discoveries/', title: 'Cabinet - Discoveries' },
+      { path: '/reports/', title: 'Cabinet - Reports' },
+      { path: '/settings/profile', title: 'Cabinet - Settings' },
+    ]
+
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    signInTo(primaryRoutes[0].path)
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/dashboard\/?$/)
+
+    primaryRoutes.forEach(({ path, title }) => {
+      cy.visit(path)
+      cy.location('pathname', { timeout: 15000 }).should('eq', path)
+      cy.title().should('eq', title)
+      cy.title().should('not.match', /^[a-z]+\./)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add focused Cypress coverage for primary authenticated route document titles.
- Verify `Cabinet - <Page Title>` format for Home, Inventory, Collections, Wishlist, Integrations, Chats, Inbox, Discoveries, Reports, and Settings.
- Verify titles do not leak raw translation-style keys.

## Validation
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/document-title/spec.cy.ts -Browser electron -RequireE2EHooks -StartupTimeoutSec 90
- .\node_modules\.bin\eslint.cmd --no-ignore cypress/e2e/general/document-title/spec.cy.ts cypress/e2e/general/ui-foundation-shell-navigation/spec.cy.ts
- git diff --check
- openspec validate --all --strict --no-interactive

Closes #526