### PR TITLE
#683 ui(shell): center primary screen titles

### DIFF
--- a/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
@@ -33,6 +33,23 @@ describe('workspace header action lanes', () => {
     })
   }
 
+  function assertHeaderTitleCentered(
+    headerTestID: string,
+    titleTestID: string
+  ) {
+    cy.get(`[data-testid="${headerTestID}"]`).then(($header) => {
+      const headerRect = $header[0].getBoundingClientRect()
+      const headerCenter = headerRect.left + headerRect.width / 2
+
+      cy.get(`[data-testid="${titleTestID}"]`).then(($title) => {
+        const titleRect = $title[0].getBoundingClientRect()
+        const titleCenter = titleRect.left + titleRect.width / 2
+
+        expect(Math.abs(titleCenter - headerCenter)).to.be.lessThan(8)
+      })
+    })
+  }
+
   it('keeps Inventory actions in the global shell header without duplicate workspace chrome', () => {
     cy.viewport(1280, 800)
     cy.intercept('GET', '/api/items', {
@@ -44,11 +61,23 @@ describe('workspace header action lanes', () => {
     cy.wait('@items')
 
     cy.get('[data-testid="inventory-shell-header"]').should('be.visible')
+    cy.get('[data-testid="inventory-header-title"]')
+      .should('be.visible')
+      .should(
+        'have.attr',
+        'title',
+        'Browse, organize, and update the items you already own.'
+      )
+      .should(
+        'have.attr',
+        'aria-label',
+        'Inventory - Browse, organize, and update the items you already own.'
+      )
+    assertHeaderTitleCentered('inventory-shell-header', 'inventory-header-title')
     cy.get('[data-testid="inventory-page-header"]').should('not.exist')
     cy.get('[data-testid="inventory-global-header-actions"]')
       .should('be.visible')
       .within(() => {
-        cy.contains('Inventory').should('be.visible')
         cy.get('[data-testid="inventory-header-context"]').should(
           'contain.text',
           'All Items'
@@ -104,11 +133,24 @@ describe('workspace header action lanes', () => {
     cy.wait('@profileSettings')
 
     cy.get('[data-testid="wishlist-shell-header"]').should('be.visible')
+    cy.get('[data-testid="wishlist-header-title"]')
+      .should('be.visible')
+      .should(
+        'have.attr',
+        'title',
+        'Track wanted items, target prices, and planning decisions before they become owned inventory.'
+      )
+      .should(
+        'have.attr',
+        'aria-label',
+        'Wishlist - Track wanted items, target prices, and planning decisions before they become owned inventory.'
+      )
+    assertHeaderTitleCentered('wishlist-shell-header', 'wishlist-header-title')
     cy.get('[data-testid="wishlist-page-header"]').should('not.exist')
     cy.get('[data-testid="wishlist-global-header-actions"]')
       .should('be.visible')
       .within(() => {
-        cy.contains('Wishlist').should('be.visible')
+        cy.contains('Planning list').should('not.exist')
         cy.get('[data-testid="wishlist-new-action"]').should('be.visible')
         cy.get('[data-testid="wishlist-create-menu-trigger"]').should(
           'be.visible'
@@ -129,12 +171,24 @@ describe('workspace header action lanes', () => {
     bootstrap('/collections/')
 
     cy.get('[data-testid="collections-shell-header"]').should('be.visible')
+    cy.get('[data-testid="collections-header-title"]')
+      .should('be.visible')
+      .should(
+        'have.attr',
+        'title',
+        'Manage collection rows and item placement from the shared Cabinet table surface.'
+      )
+      .should(
+        'have.attr',
+        'aria-label',
+        'Collections - Manage collection rows and item placement from the shared Cabinet table surface.'
+      )
+    assertHeaderTitleCentered('collections-shell-header', 'collections-header-title')
     cy.get('[data-testid="collections-page-header"]').should('not.exist')
     cy.get('[data-testid="collections-global-header-actions"]')
       .should('be.visible')
       .within(() => {
-        cy.contains('Collections').should('be.visible')
-        cy.get('[data-testid="collections-page-icon"]').should('be.visible')
+        cy.get('[data-testid="collections-page-icon"]').should('not.exist')
         cy.get('[data-testid="collections-new-action"]').should('be.visible')
       })
     cy.get('[data-testid="collections-header-action-separator"]').should('be.visible')

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -1086,6 +1086,7 @@ function resolveFolderDragPreviewPosition(clientX: number, clientY: number) {
 
 export function Collection({
   title = 'Collection',
+  description = '',
   routePath,
 }: CollectionWorkspaceProps) {
   const [tableData, setTableData] = useState<Task[]>(tasks)
@@ -3145,13 +3146,20 @@ export function Collection({
         data-testid='inventory-shell-header'
       >
         <Search className='hidden min-w-32 sm:flex' />
+        <h1
+          className='pointer-events-auto absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 whitespace-nowrap text-lg font-bold tracking-tight lg:block'
+          data-testid='inventory-header-title'
+          title={description}
+          aria-label={description ? `${title} - ${description}` : title}
+        >
+          {title}
+        </h1>
         <div className='ms-auto flex min-w-0 flex-1 items-center justify-end gap-2 sm:flex-none sm:gap-3'>
           <div
             className='flex min-w-0 flex-nowrap items-center justify-end gap-1.5 sm:gap-2'
             data-testid='inventory-global-header-actions'
           >
             <div className='mr-1 hidden min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1 lg:flex'>
-              <h1 className='text-lg font-bold tracking-tight'>{title}</h1>
               <span
                 className='text-xs font-medium text-muted-foreground'
                 data-testid='inventory-header-context'

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -48,6 +48,9 @@ import {
   useWorkspaceCollections,
 } from './use-workspace-collections'
 
+const collectionsHeaderDescription =
+  'Manage collection rows and item placement from the shared Cabinet table surface.'
+
 type CollectionRow = WorkspaceCollectionSummary
 
 function buildCollectionColumns({
@@ -262,17 +265,25 @@ export function Collections() {
     <>
       <Header fixed data-testid='collections-shell-header'>
         <Search />
+        <h1
+          className='pointer-events-auto absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 items-center gap-2 whitespace-nowrap text-lg font-bold tracking-tight lg:flex'
+          data-testid='collections-header-title'
+          title={collectionsHeaderDescription}
+          aria-label={`Collections - ${collectionsHeaderDescription}`}
+        >
+          <Tag
+            aria-hidden='true'
+            className='h-5 w-5 text-muted-foreground'
+            data-testid='collections-page-icon'
+          />
+          Collections
+        </h1>
         <div className='ml-auto flex min-w-0 items-center gap-3'>
           <div
             className='flex min-w-0 flex-wrap items-center justify-end gap-2'
             data-testid='collections-global-header-actions'
           >
             <div className='mr-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1'>
-              <Tag
-                className='h-5 w-5 text-muted-foreground'
-                data-testid='collections-page-icon'
-              />
-              <h1 className='text-lg font-bold tracking-tight'>Collections</h1>
               <span className='text-xs font-medium text-muted-foreground'>
                 Active:
               </span>

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -218,6 +218,7 @@ function TasksHeaderActions({
 
 export function Tasks({
   title = 'Tasks',
+  description = '',
   routePath = '/_authenticated/inventory/',
 }: TasksProps) {
   const {
@@ -752,6 +753,16 @@ export function Tasks({
     <>
       <Header fixed data-testid={isWishlistRoute ? 'wishlist-shell-header' : undefined}>
         <Search />
+        {isWishlistRoute ? (
+          <h1
+            className='pointer-events-auto absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 whitespace-nowrap text-lg font-bold tracking-tight lg:block'
+            data-testid='wishlist-header-title'
+            title={description}
+            aria-label={description ? `${title} - ${description}` : title}
+          >
+            {title}
+          </h1>
+        ) : null}
         <div className='ms-auto flex min-w-0 items-center gap-3'>
           {isWishlistRoute ? (
             <>
@@ -759,12 +770,6 @@ export function Tasks({
                 className='flex min-w-0 flex-wrap items-center justify-end gap-2'
                 data-testid='wishlist-global-header-actions'
               >
-                <div className='mr-1 flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1'>
-                  <h2 className='text-lg font-bold tracking-tight'>{title}</h2>
-                  <span className='text-xs font-medium text-muted-foreground'>
-                    Planning list
-                  </span>
-                </div>
                 <TasksHeaderActions
                   isWishlistRoute={isWishlistRoute}
                   onOpenCollectionCreate={() => {


### PR DESCRIPTION
## Summary
- centers primary screen titles in the global shell header
- exposes page descriptions as title/ARIA hints instead of inline header copy
- keeps page actions in the header action lane for Inventory, Wishlist, and Collections

## Verification
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/inventory/workspace-header-actions/spec.cy.ts" -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/collections/ui-screen-collections/spec.cy.ts" -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `.\node_modules\.bin\eslint.cmd --no-ignore src/features/collection/index.tsx src/features/tasks/index.tsx src/features/collections/index.tsx cypress/e2e/inventory/workspace-header-actions/spec.cy.ts` (warning only: existing TanStack Table React Compiler warning)
- `git diff --check`
- `openspec validate --all --strict --no-interactive`

Closes #683
