### PR TITLE
#685 fix(inventory): keep row click from opening editor modal

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
@@ -95,10 +95,28 @@ describe("inventory item editor modal", () => {
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATED");
     cy.contains("Created Modal Item").should("be.visible");
 
+    cy.get('[data-testid="inventory-item-row-item-alpha"]').click();
+    cy.wait(250);
+    cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-ALPHA");
+    cy.get('[data-testid="row-details-modal"]').should("not.exist");
+    cy.get('[data-testid="row-edit-modal"]').should("not.exist");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.get('[data-testid="inventory-item-editor-panel"]').should("not.exist");
+
     cy.get('[data-testid="inventory-item-row-item-alpha"]').dblclick();
     cy.get('[data-testid="inventory-item-editor-panel"]')
       .should("be.visible")
       .and("contain", "Edit Item");
+    cy.get('[data-testid="inventory-item-editor-panel"]').then(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.left, "editor panel starts on right half").to.be.greaterThan(
+        Cypress.config("viewportWidth") / 2
+      );
+      expect(rect.right, "editor panel is anchored to right edge").to.be.closeTo(
+        Cypress.config("viewportWidth"),
+        24
+      );
+    });
     cy.get('[data-testid="inventory-item-title"]').should("have.value", "Alpha Item");
     cy.get('[data-testid="inventory-item-editor-cancel"]').click();
     cy.get('[data-testid="inventory-item-editor-panel"]').should("not.exist");

--- a/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
@@ -34,18 +34,25 @@ describe('workspace header action lanes', () => {
   }
 
   function assertHeaderTitleCentered(
-    headerTestID: string,
-    titleTestID: string
+    titleTestID: string,
+    actionsTestID: string
   ) {
-    cy.get(`[data-testid="${headerTestID}"]`).then(($header) => {
-      const headerRect = $header[0].getBoundingClientRect()
-      const headerCenter = headerRect.left + headerRect.width / 2
+    cy.get(`[data-testid="${titleTestID}"]`).then(($title) => {
+      const titleRect = $title[0].getBoundingClientRect()
+      const titleCenter = titleRect.left + titleRect.width / 2
+      const searchElement = $title[0].parentElement?.previousElementSibling
 
-      cy.get(`[data-testid="${titleTestID}"]`).then(($title) => {
-        const titleRect = $title[0].getBoundingClientRect()
-        const titleCenter = titleRect.left + titleRect.width / 2
+      expect(searchElement, 'search element before title lane').to.not.equal(null)
+      const searchRect = searchElement.getBoundingClientRect()
 
-        expect(Math.abs(titleCenter - headerCenter)).to.be.lessThan(8)
+      cy.get(`[data-testid="${actionsTestID}"]`).then(($actions) => {
+        const actionsRect = $actions[0].getBoundingClientRect()
+        const availableCenter = searchRect.right + (actionsRect.left - searchRect.right) / 2
+
+        expect(Math.abs(titleCenter - availableCenter)).to.be.lessThan(8)
+        expect(titleRect.right, 'title does not overlap actions').to.be.lessThan(
+          actionsRect.left
+        )
       })
     })
   }
@@ -73,7 +80,7 @@ describe('workspace header action lanes', () => {
         'aria-label',
         'Inventory - Browse, organize, and update the items you already own.'
       )
-    assertHeaderTitleCentered('inventory-shell-header', 'inventory-header-title')
+    assertHeaderTitleCentered('inventory-header-title', 'inventory-global-header-actions')
     cy.get('[data-testid="inventory-page-header"]').should('not.exist')
     cy.get('[data-testid="inventory-global-header-actions"]')
       .should('be.visible')
@@ -145,7 +152,7 @@ describe('workspace header action lanes', () => {
         'aria-label',
         'Wishlist - Track wanted items, target prices, and planning decisions before they become owned inventory.'
       )
-    assertHeaderTitleCentered('wishlist-shell-header', 'wishlist-header-title')
+    assertHeaderTitleCentered('wishlist-header-title', 'wishlist-global-header-actions')
     cy.get('[data-testid="wishlist-page-header"]').should('not.exist')
     cy.get('[data-testid="wishlist-global-header-actions"]')
       .should('be.visible')
@@ -183,7 +190,7 @@ describe('workspace header action lanes', () => {
         'aria-label',
         'Collections - Manage collection rows and item placement from the shared Cabinet table surface.'
       )
-    assertHeaderTitleCentered('collections-shell-header', 'collections-header-title')
+    assertHeaderTitleCentered('collections-header-title', 'collections-global-header-actions')
     cy.get('[data-testid="collections-page-header"]').should('not.exist')
     cy.get('[data-testid="collections-global-header-actions"]')
       .should('be.visible')

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -3146,20 +3146,22 @@ export function Collection({
         data-testid='inventory-shell-header'
       >
         <Search className='hidden min-w-32 sm:flex' />
-        <h1
-          className='pointer-events-auto absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 whitespace-nowrap text-lg font-bold tracking-tight lg:block'
-          data-testid='inventory-header-title'
-          title={description}
-          aria-label={description ? `${title} - ${description}` : title}
-        >
-          {title}
-        </h1>
-        <div className='ms-auto flex min-w-0 flex-1 items-center justify-end gap-2 sm:flex-none sm:gap-3'>
+        <div className='hidden min-w-[8rem] flex-1 justify-center overflow-hidden lg:flex'>
+          <h1
+            className='max-w-full truncate text-lg font-bold tracking-tight'
+            data-testid='inventory-header-title'
+            title={description}
+            aria-label={description ? `${title} - ${description}` : title}
+          >
+            {title}
+          </h1>
+        </div>
+        <div className='flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3'>
           <div
-            className='flex min-w-0 flex-nowrap items-center justify-end gap-1.5 sm:gap-2'
+            className='flex min-w-0 shrink-0 flex-nowrap items-center justify-end gap-1.5 sm:gap-2'
             data-testid='inventory-global-header-actions'
           >
-            <div className='mr-1 hidden min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1 lg:flex'>
+            <div className='mr-1 hidden min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1 2xl:flex'>
               <span
                 className='text-xs font-medium text-muted-foreground'
                 data-testid='inventory-header-context'
@@ -3949,7 +3951,7 @@ export function Collection({
                     }}
                   >
                     <SheetContent
-                      side='left'
+                      side='right'
                       className='w-[min(28rem,92vw)] overflow-y-auto sm:max-w-md'
                       data-testid='inventory-item-editor-panel'
                     >

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -265,20 +265,22 @@ export function Collections() {
     <>
       <Header fixed data-testid='collections-shell-header'>
         <Search />
-        <h1
-          className='pointer-events-auto absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 items-center gap-2 whitespace-nowrap text-lg font-bold tracking-tight lg:flex'
-          data-testid='collections-header-title'
-          title={collectionsHeaderDescription}
-          aria-label={`Collections - ${collectionsHeaderDescription}`}
-        >
-          <Tag
-            aria-hidden='true'
-            className='h-5 w-5 text-muted-foreground'
-            data-testid='collections-page-icon'
-          />
-          Collections
-        </h1>
-        <div className='ml-auto flex min-w-0 items-center gap-3'>
+        <div className='hidden min-w-0 flex-1 justify-center lg:flex'>
+          <h1
+            className='flex min-w-0 items-center gap-2 text-lg font-bold tracking-tight'
+            data-testid='collections-header-title'
+            title={collectionsHeaderDescription}
+            aria-label={`Collections - ${collectionsHeaderDescription}`}
+          >
+            <Tag
+              aria-hidden='true'
+              className='h-5 w-5 shrink-0 text-muted-foreground'
+              data-testid='collections-page-icon'
+            />
+            <span className='truncate'>Collections</span>
+          </h1>
+        </div>
+        <div className='flex min-w-0 items-center gap-3'>
           <div
             className='flex min-w-0 flex-wrap items-center justify-end gap-2'
             data-testid='collections-global-header-actions'

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -418,6 +418,9 @@ export function TasksTable({
     if (record) {
       onRecordFocus?.(record.itemID ?? record.id, record.id, record.title)
     }
+    if (isInventoryRoute) {
+      return
+    }
     if (clickTimerRef.current !== null) {
       window.clearTimeout(clickTimerRef.current)
     }

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -754,16 +754,18 @@ export function Tasks({
       <Header fixed data-testid={isWishlistRoute ? 'wishlist-shell-header' : undefined}>
         <Search />
         {isWishlistRoute ? (
-          <h1
-            className='pointer-events-auto absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 whitespace-nowrap text-lg font-bold tracking-tight lg:block'
-            data-testid='wishlist-header-title'
-            title={description}
-            aria-label={description ? `${title} - ${description}` : title}
-          >
-            {title}
-          </h1>
+          <div className='hidden min-w-0 flex-1 justify-center lg:flex'>
+            <h1
+              className='truncate text-lg font-bold tracking-tight'
+              data-testid='wishlist-header-title'
+              title={description}
+              aria-label={description ? `${title} - ${description}` : title}
+            >
+              {title}
+            </h1>
+          </div>
         ) : null}
-        <div className='ms-auto flex min-w-0 items-center gap-3'>
+        <div className='flex min-w-0 items-center gap-3'>
           {isWishlistRoute ? (
             <>
               <div


### PR DESCRIPTION
Fixes #685

## Summary
- Prevent Inventory row single-click from opening the old row details/edit modal; single-click now only focuses/selects the row.
- Keep Inventory double-click opening the item editor sheet, now anchored on the right side.
- Replace absolute centered page titles with flex title lanes so header actions remain clickable and non-overlapping.

## Validation
- `eslint --no-ignore src/features/tasks/components/tasks-table.tsx src/features/collection/index.tsx src/features/tasks/index.tsx src/features/collections/index.tsx cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts cypress/e2e/inventory/workspace-header-actions/spec.cy.ts` (passes; existing TanStack React Compiler warning only)
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/inventory/workspace-header-actions/spec.cy.ts" -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts" -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts" -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `openspec validate --all --strict --no-interactive`
