### PR TITLE
#687 fix(collections): remove redundant table heading copy

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -26,6 +26,10 @@ describe('ui-screen-collections', () => {
 
     cy.get('[data-testid="collections-section"]').should('be.visible')
     cy.get('[data-testid="collections-shared-table"]').should('be.visible')
+    cy.contains('Collections table').should('not.exist')
+    cy.contains(
+      'Browse, create, rename, and remove collection rows from the same management surface.'
+    ).should('not.exist')
     cy.get('[data-testid="collections-new-action"]').should('be.visible')
     cy.get('[data-testid="collections-row-all-items"]').should('be.visible')
   })

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -320,12 +320,6 @@ export function Collections() {
           data-testid='collections-workspace'
         >
           <Card data-testid='collections-section'>
-            <CardHeader>
-              <CardTitle>Collections table</CardTitle>
-              <CardDescription>
-                Browse, create, rename, and remove collection rows from the same management surface.
-              </CardDescription>
-            </CardHeader>
             <CardContent className='space-y-4'>
               <div className='flex items-center gap-3' data-testid='collections-management-tools'>
                 <Input


### PR DESCRIPTION
Fixes #687

## Summary
- Removed the redundant `Collections table` title and descriptive sentence from the Collections management card.
- Kept the collections controls and shared table directly visible.
- Added Cypress coverage to prevent the copy from coming back.

## Validation
- `eslint --no-ignore src/features/collections/index.tsx cypress/e2e/collections/ui-screen-collections/spec.cy.ts` (passes; existing TanStack React Compiler warning only)
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/collections/ui-screen-collections/spec.cy.ts" -Browser electron -RequireE2EHooks -StartupTimeoutSec 90`
- `openspec validate --all --strict --no-interactive`
