### PR TITLE
#691 fix(wishlist): seed demo wishlist sample data

### DIFF
--- a/cmd/cabinet/startup_flags.go
+++ b/cmd/cabinet/startup_flags.go
@@ -30,6 +30,7 @@ func parseStartupArgs(args []string) (startupOverrides, error) {
 	var baseURL string
 	var restart bool
 	var allowParallel bool
+	var seedSampleData bool
 	var logLevel string
 	var noOpenBrowser bool
 
@@ -42,6 +43,7 @@ func parseStartupArgs(args []string) (startupOverrides, error) {
 	fs.StringVar(&baseURL, "base-url", "", "Base URL override for runtime callbacks/origin.")
 	fs.BoolVar(&restart, "restart", false, "Restart an already-running Cabinet instance on the requested endpoint.")
 	fs.BoolVar(&allowParallel, "allow-parallel", false, "Allow parallel runtime instances.")
+	fs.BoolVar(&seedSampleData, "seed-sample-data", false, "Seed idempotent sample data for the active profile on startup.")
 	fs.StringVar(&logLevel, "log-level", "", "Log level override (debug|info|warn|error).")
 	fs.BoolVar(&noOpenBrowser, "no-open-browser", false, "Disable browser auto-open on startup.")
 
@@ -115,6 +117,10 @@ func parseStartupArgs(args []string) (startupOverrides, error) {
 		env["CABINET_ALLOW_PARALLEL"] = "true"
 	}
 
+	if seedSampleData {
+		env["CABINET_SEED_SAMPLE_DATA"] = "true"
+	}
+
 	logLevel = strings.ToLower(strings.TrimSpace(logLevel))
 	if logLevel != "" {
 		switch logLevel {
@@ -141,7 +147,7 @@ func applyStartupOverrides(overrides startupOverrides) {
 
 func buildEffectiveStartupConfigLine(cfg config.Config) string {
 	return fmt.Sprintf(
-		"CABINET_EFFECTIVE_CONFIG addr=%s host=%s port=%d data_dir=%s profile=%s auth_mode=%s base_url=%s allow_parallel=%s log_level=%s",
+		"CABINET_EFFECTIVE_CONFIG addr=%s host=%s port=%d data_dir=%s profile=%s auth_mode=%s base_url=%s allow_parallel=%s seed_sample_data=%s log_level=%s",
 		cfg.Addr,
 		cfg.Host,
 		cfg.Port,
@@ -150,6 +156,7 @@ func buildEffectiveStartupConfigLine(cfg config.Config) string {
 		envOrDefault("CABINET_AUTH_MODE", "local"),
 		envOrDefault("CABINET_BASE_URL", fmt.Sprintf("http://%s", cfg.Addr)),
 		envOrDefault("CABINET_ALLOW_PARALLEL", "false"),
+		envOrDefault("CABINET_SEED_SAMPLE_DATA", "false"),
 		envOrDefault("CABINET_LOG_LEVEL", "info"),
 	)
 }

--- a/cmd/cabinet/startup_flags_test.go
+++ b/cmd/cabinet/startup_flags_test.go
@@ -19,6 +19,7 @@ func TestParseStartupArgsBuildsEnvOverrides(t *testing.T) {
 		"--base-url", "http://127.0.0.1:19090",
 		"--restart",
 		"--allow-parallel",
+		"--seed-sample-data",
 		"--log-level", "debug",
 	})
 	if err != nil {
@@ -45,6 +46,9 @@ func TestParseStartupArgsBuildsEnvOverrides(t *testing.T) {
 	}
 	if overrides.Env["CABINET_ALLOW_PARALLEL"] != "true" {
 		t.Fatalf("expected CABINET_ALLOW_PARALLEL=true")
+	}
+	if overrides.Env["CABINET_SEED_SAMPLE_DATA"] != "true" {
+		t.Fatalf("expected CABINET_SEED_SAMPLE_DATA=true")
 	}
 	if overrides.Env["CABINET_LOG_LEVEL"] != "debug" {
 		t.Fatalf("expected CABINET_LOG_LEVEL=debug")
@@ -138,9 +142,9 @@ func TestValidateStartupOverridesRejectsRestartWithAllowParallel(t *testing.T) {
 
 	err := validateStartupOverrides(startupOverrides{
 		Env: map[string]string{
-			"CABINET_RESTART":       "true",
+			"CABINET_RESTART":        "true",
 			"CABINET_ALLOW_PARALLEL": "true",
-			"CABINET_PROFILE":       "demo",
+			"CABINET_PROFILE":        "demo",
 		},
 	})
 	if err == nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -67,6 +67,15 @@ func startupMigrationTimeout() time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
+func startupSampleDataSeedEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CABINET_SEED_SAMPLE_DATA"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 type App struct {
 	cfg           config.Config
 	db            *sql.DB
@@ -128,6 +137,19 @@ func New(cfg config.Config) (*App, error) {
 	if err != nil {
 		conn.Close()
 		return nil, err
+	}
+	if startupSampleDataSeedEnabled() {
+		result, seedErr := seedOnboardingSampleData(ctx, profiles, collectionRepo, wishlistSvc, conn)
+		if seedErr != nil {
+			log.Printf("sample data startup seed skipped: %v", seedErr)
+		} else {
+			log.Printf(
+				"sample data startup seed complete: created_items=%d created_wishlist_entries=%d total_wishlist_entries=%d",
+				result.CreatedItems,
+				result.CreatedWishlistEntries,
+				result.TotalWishlistEntries,
+			)
+		}
 	}
 	cloudLeases := newCloudLeaseStore()
 	cloudEntitlements := newCloudEntitlementStore()

--- a/internal/app/onboarding_startup_seed_test.go
+++ b/internal/app/onboarding_startup_seed_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/collectors-tech/cabinet/internal/config"
+	"github.com/collectors-tech/cabinet/internal/db"
+	"github.com/collectors-tech/cabinet/internal/profile"
+	"github.com/collectors-tech/cabinet/internal/update"
+)
+
+func TestStartupSampleDataBootstrapSeedsWishlistForActiveProfile(t *testing.T) {
+	t.Setenv("CABINET_SEED_SAMPLE_DATA", "1")
+
+	base := t.TempDir()
+	cfg := config.Config{
+		Addr:           "127.0.0.1:0",
+		DataDir:        base,
+		DBPath:         filepath.Join(base, "cabinet.db"),
+		UpdateChannel:  update.ChannelStable,
+		WebAuthnRPID:   "127.0.0.1",
+		WebAuthnOrigin: "http://127.0.0.1:8080",
+		WebAuthnName:   "Cabinet Test",
+		BackupInterval: 60,
+	}
+
+	ctx := context.Background()
+	conn, err := db.OpenAndMigrate(ctx, cfg.DBPath)
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	profiles := profile.NewRepository(conn)
+	created, err := profiles.Create(ctx, "Showcase DB")
+	if err != nil {
+		t.Fatalf("Create() profile error = %v", err)
+	}
+	if err := profiles.SetActiveProfile(ctx, created.ID); err != nil {
+		t.Fatalf("SetActiveProfile() error = %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close seed connection: %v", err)
+	}
+
+	a := newTestAppWithConfig(t, cfg)
+	resp := doRequest(t, a, http.MethodGet, "/api/wishlist", nil, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("wishlist status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var payload struct {
+		Items []struct {
+			Priority       string `json:"priority"`
+			BelowTargetNow bool   `json:"below_target_now"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode wishlist payload: %v", err)
+	}
+	if len(payload.Items) < 3 {
+		t.Fatalf("expected startup sample seed to create wishlist rows, got %+v", payload.Items)
+	}
+}

--- a/scripts/runtime/start-demo2.ps1
+++ b/scripts/runtime/start-demo2.ps1
@@ -52,6 +52,7 @@ $args = @(
   '--data-dir', $dataDir,
   '--profile', $profile,
   '--instance-name', $instanceName,
+  '--seed-sample-data',
   '--port', $port
 )
 


### PR DESCRIPTION
## Summary
- Add a startup sample-data seed flag for Cabinet runtimes.
- Seed onboarding sample data during startup when enabled, including Wishlist entries for the active profile.
- Enable the flag from start-demo2 so Showcase DB regains sample Wishlist rows on demo restart.

## Validation
- go test ./cmd/cabinet -count=1
- go test ./internal/app -run "Test(OnboardingSampleDataEndpointIsIdempotent|StartupSampleDataBootstrapSeedsWishlistForActiveProfile)$" -count=1
- pwsh -NoLogo -NoProfile -File .\scripts\runtime\start-demo2.ps1 -Rebuild -Restart -Background
- GET http://127.0.0.1:17882/api/wishlist returns 5 seeded rows for active Showcase DB

Note: go test ./cmd/cabinet ./internal/app -count=1 still hits the existing docs migration guard: docs/PRODUCT-OVERVIEW.md and docs/PRODUCT_OVERVIEW_PLAN.md remain under docs/.