### PR TITLE
#693 Center page header titles with icons

### DIFF
--- a/ui.web/cypress/e2e/general/ui-foundation-shell-navigation/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-foundation-shell-navigation/spec.cy.ts
@@ -52,6 +52,31 @@ describe('ui-foundation-shell-navigation', () => {
     cy.title().should('eq', 'Cabinet - Home')
   })
 
+  it('UI-FOUNDATION-SHELL-NAVIGATION-011 centers primary page titles with route icons and no inline context', () => {
+    function assertCenteredHeader(testId: string, title: string) {
+      cy.get(`[data-testid="${testId}-header-title"]`)
+        .should('be.visible')
+        .and('have.attr', 'data-centered', 'true')
+        .and('contain', title)
+      cy.get(`[data-testid="${testId}-page-icon"]`).should('be.visible')
+      cy.get('header').should('not.contain', 'Active:')
+      cy.get('header').should('not.contain', 'Collection:')
+      cy.get('header').should('not.contain', 'Planning list')
+    }
+
+    signInTo('/inventory/')
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
+    assertCenteredHeader('inventory', 'Inventory')
+
+    visibleByTestId('sidebar-nav-link-collections').click()
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/collections\/?$/)
+    assertCenteredHeader('collections', 'Collections')
+
+    visibleByTestId('sidebar-nav-link-wishlist').click()
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/wishlist\/?$/)
+    assertCenteredHeader('wishlist', 'Wishlist')
+  })
+
   it('UI-FOUNDATION-SHELL-NAVIGATION-004 renders app version and build date metadata in sidebar footer', () => {
     cy.intercept('GET', '/api/runtime', {
       statusCode: 200,
@@ -303,24 +328,16 @@ describe('ui-foundation-shell-navigation', () => {
       ])
   })
 
-  it('UI-FOUNDATION-SHELL-NAVIGATION-003 updates collection context label when folder selection changes', () => {
+  it('UI-FOUNDATION-SHELL-NAVIGATION-003 updates collection browser context when folder selection changes', () => {
     signInTo('/inventory/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
 
-    cy.get('[data-testid="collection-context-label"]').should(
-      'contain',
-      'All Items'
-    )
     cy.get('[data-testid="collection-active-context"]').should(
       'have.text',
       'All Items'
     )
 
     cy.get('[data-testid="collection-folder-store-1"]').click()
-    cy.get('[data-testid="collection-context-label"]').should(
-      'contain',
-      'Store 1'
-    )
     cy.get('[data-testid="collection-active-context"]').should(
       'have.text',
       'Store 1'
@@ -347,8 +364,8 @@ describe('ui-foundation-shell-navigation', () => {
 
     visibleByTestId('collections-section').should('be.visible')
     visibleByTestId('collections-new-action').click()
-    visibleByTestId('collections-new-input').clear().type('Quick Create Shelf')
-    visibleByTestId('collections-new-save').click()
+    visibleByTestId('collections-create-input').clear().type('Quick Create Shelf')
+    visibleByTestId('collections-create-submit').click()
     visibleByTestId('collections-item-quick-create-shelf').should('be.visible')
 
     signInTo('/inventory/')
@@ -468,7 +485,7 @@ describe('ui-foundation-shell-navigation', () => {
       })
     })
 
-    cy.get('[data-testid="collection-context-label"]').should('be.visible')
+    cy.get('[data-testid="inventory-header-title"]').should('be.visible')
     cy.contains('Folders').should('be.visible')
     cy.contains('Items').should('be.visible')
   })

--- a/ui.web/cypress/e2e/general/ui-page-header-title/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-page-header-title/spec.cy.ts
@@ -1,0 +1,39 @@
+describe('ui-page-header-title', () => {
+  function signInTo(path: string) {
+    cy.visit(`/sign-in?redirect=${encodeURIComponent(path)}`)
+    cy.get('input[name="email"]').clear().type('e2e-header-title@example.com')
+    cy.get('input[name="password"]').clear().type('password123')
+    cy.contains('button', /^Sign in$/).click()
+  }
+
+  function assertCenteredHeader(testId: string, title: string) {
+    cy.get(`[data-testid="${testId}-header-title"]`)
+      .should('be.visible')
+      .and('have.attr', 'data-centered', 'true')
+      .and('contain', title)
+    cy.get(`[data-testid="${testId}-page-icon"]`).should('be.visible')
+    cy.get('header').should('not.contain', 'Active:')
+    cy.get('header').should('not.contain', 'Collection:')
+    cy.get('header').should('not.contain', 'Planning list')
+  }
+
+  beforeEach(() => {
+    cy.clearCookies()
+    cy.clearLocalStorage()
+    cy.viewport(1440, 900)
+  })
+
+  it('UI-PAGE-HEADER-TITLE-001 centers primary page titles with icons and no inline context text', () => {
+    signInTo('/inventory/')
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
+    assertCenteredHeader('inventory', 'Inventory')
+
+    cy.visit('/collections/')
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/collections\/?$/)
+    assertCenteredHeader('collections', 'Collections')
+
+    cy.visit('/wishlist/')
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/wishlist\/?$/)
+    assertCenteredHeader('wishlist', 'Wishlist')
+  })
+})

--- a/ui.web/src/components/layout/header.tsx
+++ b/ui.web/src/components/layout/header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { type ComponentType, useEffect, useState } from 'react'
 import { MessageSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useShellWorkspace } from '@/context/shell-workspace-provider'
@@ -9,6 +9,51 @@ import { SidebarTrigger } from '@/components/ui/sidebar'
 type HeaderProps = React.HTMLAttributes<HTMLElement> & {
   fixed?: boolean
   ref?: React.Ref<HTMLElement>
+}
+
+type HeaderTitleProps = {
+  title: string
+  description?: string
+  icon: ComponentType<{ className?: string; 'aria-hidden'?: true }>
+  testId: string
+  iconTestId?: string
+  className?: string
+}
+
+export function HeaderTitle({
+  title,
+  description,
+  icon: Icon,
+  testId,
+  iconTestId,
+  className,
+}: HeaderTitleProps) {
+  const titleText = title.trim()
+  const hint = description?.trim()
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-none absolute top-1/2 left-1/2 z-10 hidden max-w-[min(34rem,42vw)] -translate-x-1/2 -translate-y-1/2 justify-center md:flex',
+        className
+      )}
+    >
+      <h1
+        className='flex min-w-0 items-center justify-center gap-2 truncate text-center text-lg font-bold tracking-tight'
+        data-testid={testId}
+        data-centered='true'
+        title={hint || titleText}
+        aria-label={hint ? `${titleText} - ${hint}` : titleText}
+      >
+        <Icon
+          aria-hidden
+          className='h-5 w-5 shrink-0 text-muted-foreground'
+          data-testid={iconTestId}
+        />
+        <span className='truncate'>{titleText}</span>
+      </h1>
+    </div>
+  )
 }
 
 export function Header({ className, fixed, children, ...props }: HeaderProps) {

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -8,7 +8,13 @@ import {
   useState,
 } from 'react'
 import { getRouteApi } from '@tanstack/react-router'
-import { ArrowDownAZ, ArrowUpAZ, SlidersHorizontal, Store } from 'lucide-react'
+import {
+  ArrowDownAZ,
+  ArrowUpAZ,
+  PlugZap,
+  SlidersHorizontal,
+  Store,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -36,7 +42,7 @@ import {
 } from '@/components/ui/table'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { LanguageSwitch } from '@/components/language-switch'
-import { Header } from '@/components/layout/header'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
@@ -634,6 +640,13 @@ export function Apps({
     <>
       <Header>
         <Search />
+        <HeaderTitle
+          title={title}
+          description={description}
+          icon={PlugZap}
+          testId='integrations-header-title'
+          iconTestId='integrations-page-icon'
+        />
         <div className='ms-auto flex items-center gap-4'>
           <LanguageSwitch />
           <ThemeSwitch />

--- a/ui.web/src/features/chats/index.tsx
+++ b/ui.web/src/features/chats/index.tsx
@@ -1,16 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { MessagesSquare, Send } from 'lucide-react'
-import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
-import { LanguageSwitch } from '@/components/language-switch'
-import { Main } from '@/components/layout/main'
-import { ProfileDropdown } from '@/components/profile-dropdown'
-import { Search } from '@/components/search'
-import { ThemeSwitch } from '@/components/theme-switch'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { ScrollArea } from '@/components/ui/scroll-area'
-import { Separator } from '@/components/ui/separator'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,6 +10,17 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
 
 type ChatThread = {
   id: string
@@ -98,7 +98,9 @@ export function Chats() {
     'create_inventory_item' | 'create_wishlist_entry' | 'update_inventory_item'
   >('create_inventory_item')
   const [actionTargetItemID, setActionTargetItemID] = useState('')
-  const [actionPreview, setActionPreview] = useState<ChatActionPreview | null>(null)
+  const [actionPreview, setActionPreview] = useState<ChatActionPreview | null>(
+    null
+  )
   const [applyResult, setApplyResult] = useState<ChatApplyResult | null>(null)
   const [confirmApplyOpen, setConfirmApplyOpen] = useState(false)
 
@@ -109,31 +111,34 @@ export function Chats() {
 
   const threadCreationDisabled = loading || Boolean(error) || !activeProfileId
 
-  const loadMessages = useCallback(async (profileID: string, threadID: string) => {
-    if (!profileID || !threadID) {
-      setMessages([])
-      return
-    }
-    setMessagesLoading(true)
-    setSendError(null)
-    try {
-      const response = await fetch(
-        `/api/chat/messages?profile_id=${encodeURIComponent(profileID)}&thread_id=${encodeURIComponent(threadID)}`
-      )
-      if (!response.ok) {
-        throw new Error(`chat_messages_${response.status}`)
+  const loadMessages = useCallback(
+    async (profileID: string, threadID: string) => {
+      if (!profileID || !threadID) {
+        setMessages([])
+        return
       }
-      const payload = (await response.json()) as { messages?: ChatMessage[] }
-      setMessages(payload.messages ?? [])
-    } catch (err) {
-      setSendError(
-        err instanceof Error ? err.message : 'failed_to_load_chat_messages'
-      )
-      setMessages([])
-    } finally {
-      setMessagesLoading(false)
-    }
-  }, [])
+      setMessagesLoading(true)
+      setSendError(null)
+      try {
+        const response = await fetch(
+          `/api/chat/messages?profile_id=${encodeURIComponent(profileID)}&thread_id=${encodeURIComponent(threadID)}`
+        )
+        if (!response.ok) {
+          throw new Error(`chat_messages_${response.status}`)
+        }
+        const payload = (await response.json()) as { messages?: ChatMessage[] }
+        setMessages(payload.messages ?? [])
+      } catch (err) {
+        setSendError(
+          err instanceof Error ? err.message : 'failed_to_load_chat_messages'
+        )
+        setMessages([])
+      } finally {
+        setMessagesLoading(false)
+      }
+    },
+    []
+  )
 
   const loadThreads = useCallback(
     async (profileID: string, preserveSelected = true) => {
@@ -273,7 +278,10 @@ export function Chats() {
           title: actionTitle.trim(),
           brand: 'AFX',
           category: 'General',
-          item_id: actionMode === 'update_inventory_item' ? actionTargetItemID.trim() : '',
+          item_id:
+            actionMode === 'update_inventory_item'
+              ? actionTargetItemID.trim()
+              : '',
           priority: actionMode === 'create_wishlist_entry' ? 'medium' : '',
         },
       }),
@@ -333,6 +341,13 @@ export function Chats() {
     <>
       <Header>
         <Search />
+        <HeaderTitle
+          title='Chats'
+          description='Persistent profile-scoped conversation threads backed by Cabinet runtime.'
+          icon={MessagesSquare}
+          testId='chats-header-title'
+          iconTestId='chats-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />
@@ -346,11 +361,19 @@ export function Chats() {
           <h1 className='text-2xl font-bold tracking-tight'>Chats</h1>
           <MessagesSquare className='h-5 w-5 text-muted-foreground' />
         </div>
-        <p className='text-muted-foreground' data-testid='chat-workspace-description'>
-          Persistent profile-scoped conversation threads backed by Cabinet runtime.
+        <p
+          className='text-muted-foreground'
+          data-testid='chat-workspace-description'
+        >
+          Persistent profile-scoped conversation threads backed by Cabinet
+          runtime.
         </p>
-        <p className='text-sm text-muted-foreground' data-testid='chat-workspace-boundary-note'>
-          Use Assistant for AI-guided help and actions; use Chats for durable conversation threads.
+        <p
+          className='text-sm text-muted-foreground'
+          data-testid='chat-workspace-boundary-note'
+        >
+          Use Assistant for AI-guided help and actions; use Chats for durable
+          conversation threads.
         </p>
         <Separator className='my-4' />
 
@@ -428,7 +451,9 @@ export function Chats() {
             <ScrollArea className='h-[380px] rounded-md border p-3'>
               <div data-testid='chat-message-list' className='space-y-3'>
                 {messagesLoading ? (
-                  <p className='text-sm text-muted-foreground'>Loading messages...</p>
+                  <p className='text-sm text-muted-foreground'>
+                    Loading messages...
+                  </p>
                 ) : null}
                 {!messagesLoading && selectedThread && messages.length === 0 ? (
                   <p className='text-sm text-muted-foreground'>
@@ -436,7 +461,10 @@ export function Chats() {
                   </p>
                 ) : null}
                 {messages.map((message) => (
-                  <div key={message.id} className='rounded-md border p-2 text-sm'>
+                  <div
+                    key={message.id}
+                    className='rounded-md border p-2 text-sm'
+                  >
                     <p className='font-medium'>{prettyRole(message.role)}</p>
                     <p>{message.content}</p>
                   </div>
@@ -444,7 +472,10 @@ export function Chats() {
               </div>
             </ScrollArea>
             {sendError ? (
-              <p className='mt-2 text-sm text-destructive' data-testid='chat-send-error'>
+              <p
+                className='mt-2 text-sm text-destructive'
+                data-testid='chat-send-error'
+              >
                 {sendError}
               </p>
             ) : null}
@@ -486,9 +517,14 @@ export function Chats() {
                   Upload
                 </Button>
               </div>
-              <div data-testid='chat-attachment-list' className='space-y-1 text-sm'>
+              <div
+                data-testid='chat-attachment-list'
+                className='space-y-1 text-sm'
+              >
                 {attachments.length === 0 ? (
-                  <p className='text-muted-foreground'>No attachments uploaded.</p>
+                  <p className='text-muted-foreground'>
+                    No attachments uploaded.
+                  </p>
                 ) : (
                   attachments.map((attachment) => (
                     <p key={attachment.id}>{attachment.filename}</p>
@@ -515,16 +551,24 @@ export function Chats() {
                   }
                   disabled={!selectedThreadId}
                 >
-                  <option value='create_inventory_item'>create_inventory_item</option>
-                  <option value='create_wishlist_entry'>create_wishlist_entry</option>
-                  <option value='update_inventory_item'>update_inventory_item</option>
+                  <option value='create_inventory_item'>
+                    create_inventory_item
+                  </option>
+                  <option value='create_wishlist_entry'>
+                    create_wishlist_entry
+                  </option>
+                  <option value='update_inventory_item'>
+                    update_inventory_item
+                  </option>
                 </select>
               </label>
               {actionMode === 'update_inventory_item' ? (
                 <Input
                   data-testid='chat-preview-target-item-id'
                   value={actionTargetItemID}
-                  onChange={(event) => setActionTargetItemID(event.target.value)}
+                  onChange={(event) =>
+                    setActionTargetItemID(event.target.value)
+                  }
                   placeholder='Existing item ID'
                   disabled={!selectedThreadId}
                 />
@@ -570,8 +614,12 @@ export function Chats() {
                 </Button>
               </div>
               {actionPreview ? (
-                <p data-testid='chat-action-preview' className='text-sm text-muted-foreground'>
-                  Preview {actionPreview.id}: {actionPreview.action} ({actionPreview.status})
+                <p
+                  data-testid='chat-action-preview'
+                  className='text-sm text-muted-foreground'
+                >
+                  Preview {actionPreview.id}: {actionPreview.action} (
+                  {actionPreview.status})
                 </p>
               ) : null}
               {applyResult ? (

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -9,7 +9,15 @@ import {
   useRef,
   useState,
 } from 'react'
-import { ChevronRight, Ellipsis, GripVertical, Plus } from 'lucide-react'
+import {
+  Barcode,
+  ChevronRight,
+  Ellipsis,
+  GripVertical,
+  Images,
+  ListChecks,
+  Plus,
+} from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -47,7 +55,7 @@ import {
 } from '@/components/ui/sheet'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { LanguageSwitch } from '@/components/language-switch'
-import { Header } from '@/components/layout/header'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
@@ -1105,7 +1113,8 @@ export function Collection({
     assignWorkspaceItemToCollection,
   } = useWorkspaceCollections()
   const assignableWorkspaceCollections = useMemo(
-    () => workspaceCollections.filter((collection) => collection !== 'All Items'),
+    () =>
+      workspaceCollections.filter((collection) => collection !== 'All Items'),
     [workspaceCollections]
   )
   const activeWorkspaceCollectionRef = useRef(activeWorkspaceCollection)
@@ -1201,17 +1210,13 @@ export function Collection({
       const defaultCollection =
         currentAssignment && currentAssignment !== 'All Items'
           ? currentAssignment
-          : assignableWorkspaceCollections[0] ?? ''
+          : (assignableWorkspaceCollections[0] ?? '')
       selectInventoryItem(item)
       setAssignCollectionItem(item)
       setAssignCollectionName(defaultCollection)
       setAssignCollectionOpen(true)
     },
-    [
-      assignableWorkspaceCollections,
-      itemFolderAssignments,
-      selectInventoryItem,
-    ]
+    [assignableWorkspaceCollections, itemFolderAssignments, selectInventoryItem]
   )
 
   const handleAssignInventoryItemToCollection = useCallback(async () => {
@@ -2268,7 +2273,12 @@ export function Collection({
       const itemID = row.itemID ?? row.id
       return itemFolderAssignments[itemID] === activeFolderFilterValue
     })
-  }, [activeFolderFilterValue, isInventoryRoute, itemFolderAssignments, tableData])
+  }, [
+    activeFolderFilterValue,
+    isInventoryRoute,
+    itemFolderAssignments,
+    tableData,
+  ])
   const selectedFolderHasNoItems =
     isInventoryRoute &&
     activeFolderFilterValue !== 'All Items' &&
@@ -3038,79 +3048,77 @@ export function Collection({
         data-testid='inventory-shell-header'
       >
         <Search className='hidden min-w-32 sm:flex' />
-        <div className='hidden min-w-[8rem] flex-1 justify-center overflow-hidden lg:flex'>
-          <h1
-            className='max-w-full truncate text-lg font-bold tracking-tight'
-            data-testid='inventory-header-title'
-            title={description}
-            aria-label={description ? `${title} - ${description}` : title}
-          >
-            {title}
-          </h1>
-        </div>
-        <div className='flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3'>
+        <HeaderTitle
+          title={title}
+          description={description}
+          icon={ListChecks}
+          testId='inventory-header-title'
+          iconTestId='inventory-page-icon'
+        />
+        <div className='ms-auto flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3'>
           <div
             className='flex min-w-0 shrink-0 flex-nowrap items-center justify-end gap-1.5 sm:gap-2'
             data-testid='inventory-global-header-actions'
           >
-            <div className='mr-1 hidden min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1 2xl:flex'>
-              <span
-                className='text-xs font-medium text-muted-foreground'
-                data-testid='inventory-header-context'
-              >
-                Collection: {activeFolder}
-              </span>
-            </div>
             {isInventoryRoute ? (
               <>
                 <Button
                   type='button'
                   variant='outline'
-                  className='h-8 px-2 text-xs sm:h-9 sm:px-4 sm:text-sm'
+                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
                   data-testid='inventory-barcodes-action'
+                  aria-label='Manage barcodes'
+                  title='Barcodes'
                   onClick={() =>
                     openInventoryBarcodesForItem(
                       selectedInventoryItem ?? inventoryItems[0] ?? null
                     )
                   }
                 >
-                  <span className='hidden sm:inline'>Barcodes</span>
-                  <span className='sm:hidden'>Codes</span>
+                  <Barcode className='size-4 2xl:mr-2' aria-hidden />
+                  <span className='hidden 2xl:inline'>Barcodes</span>
                 </Button>
                 <Button
                   type='button'
                   variant='outline'
-                  className='h-8 px-2 text-xs sm:h-9 sm:px-4 sm:text-sm'
+                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
                   data-testid='inventory-photos-action'
+                  aria-label='Manage photos'
+                  title='Photos'
                   onClick={() =>
                     openInventoryPhotosForItem(
                       selectedInventoryItem ?? inventoryItems[0] ?? null
                     )
                   }
                 >
-                  <span className='hidden sm:inline'>Photos</span>
-                  <span className='sm:hidden'>Pics</span>
+                  <Images className='size-4 2xl:mr-2' aria-hidden />
+                  <span className='hidden 2xl:inline'>Photos</span>
                 </Button>
               </>
             ) : null}
             <Button
               type='button'
-              className='h-8 px-2 text-xs sm:h-9 sm:px-4 sm:text-sm'
+              className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
               data-testid='inventory-new-action'
+              aria-label='New item'
+              title='New'
               onClick={startCreateItem}
             >
-              <span>New</span>
+              <Plus className='size-4 2xl:mr-2' aria-hidden />
+              <span className='hidden 2xl:inline'>New</span>
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   type='button'
                   variant='outline'
-                  className='h-8 px-2 text-xs sm:h-9 sm:px-4 sm:text-sm'
+                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
                   data-testid='inventory-create-menu-trigger'
+                  aria-label='Create menu'
+                  title='Create'
                 >
-                  <span className='hidden sm:inline'>Create</span>
-                  <span className='sm:hidden'>More</span>
+                  <Ellipsis className='size-4 2xl:mr-2' aria-hidden />
+                  <span className='hidden 2xl:inline'>Create</span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align='end'>
@@ -3148,7 +3156,10 @@ export function Collection({
       </Header>
 
       <Main className='space-y-3'>
-        <div className='grid grid-cols-1 gap-4' data-testid='inventory-workspace'>
+        <div
+          className='grid grid-cols-1 gap-4'
+          data-testid='inventory-workspace'
+        >
           <Card className='hidden'>
             <CardHeader>
               <CardTitle>Folders</CardTitle>

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -26,12 +26,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Header } from '@/components/layout/header'
 import { Input } from '@/components/ui/input'
-import { LanguageSwitch } from '@/components/language-switch'
-import { Main } from '@/components/layout/main'
-import { ProfileDropdown } from '@/components/profile-dropdown'
-import { Search } from '@/components/search'
 import { Separator } from '@/components/ui/separator'
 import {
   Table,
@@ -41,6 +36,11 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
   type WorkspaceCollectionSummary,
@@ -66,10 +66,15 @@ function buildCollectionColumns({
       header: 'Collection',
       cell: ({ row }) => (
         <div className='space-y-1'>
-          <div className='font-medium' data-testid={`collections-row-name-${row.original.key}`}>
+          <div
+            className='font-medium'
+            data-testid={`collections-row-name-${row.original.key}`}
+          >
             {row.original.name}
           </div>
-          <div className='text-xs text-muted-foreground'>{row.original.description}</div>
+          <div className='text-xs text-muted-foreground'>
+            {row.original.description}
+          </div>
         </div>
       ),
     },
@@ -77,7 +82,9 @@ function buildCollectionColumns({
       accessorKey: 'itemCount',
       header: 'Items',
       cell: ({ row }) => (
-        <span data-testid={`collections-row-count-${row.original.key}`}>{row.original.itemCount}</span>
+        <span data-testid={`collections-row-count-${row.original.key}`}>
+          {row.original.itemCount}
+        </span>
       ),
     },
     {
@@ -140,9 +147,13 @@ export function Collections() {
     collectionSummaries,
   } = useWorkspaceCollections()
 
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'name', desc: false }])
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'name', desc: false },
+  ])
   const [globalFilter, setGlobalFilter] = useState('')
-  const [selectedCollectionID, setSelectedCollectionID] = useState<string | null>(null)
+  const [selectedCollectionID, setSelectedCollectionID] = useState<
+    string | null
+  >(null)
   const [createOpen, setCreateOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -166,7 +177,9 @@ export function Collections() {
     () =>
       selectedCollectionName === 'All Items'
         ? collectionItems
-        : collectionItems.filter((item) => item.collectionName === selectedCollectionName),
+        : collectionItems.filter(
+            (item) => item.collectionName === selectedCollectionName
+          ),
     [collectionItems, selectedCollectionName]
   )
 
@@ -265,38 +278,22 @@ export function Collections() {
     <>
       <Header fixed data-testid='collections-shell-header'>
         <Search />
-        <div className='hidden min-w-0 flex-1 justify-center lg:flex'>
-          <h1
-            className='flex min-w-0 items-center gap-2 text-lg font-bold tracking-tight'
-            data-testid='collections-header-title'
-            title={collectionsHeaderDescription}
-            aria-label={`Collections - ${collectionsHeaderDescription}`}
-          >
-            <Tag
-              aria-hidden='true'
-              className='h-5 w-5 shrink-0 text-muted-foreground'
-              data-testid='collections-page-icon'
-            />
-            <span className='truncate'>Collections</span>
-          </h1>
-        </div>
-        <div className='flex min-w-0 items-center gap-3'>
+        <HeaderTitle
+          title='Collections'
+          description={collectionsHeaderDescription}
+          icon={Tag}
+          testId='collections-header-title'
+          iconTestId='collections-page-icon'
+        />
+        <div className='ms-auto flex min-w-0 items-center gap-3'>
           <div
             className='flex min-w-0 flex-wrap items-center justify-end gap-2'
             data-testid='collections-global-header-actions'
           >
-            <div className='mr-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1'>
-              <span className='text-xs font-medium text-muted-foreground'>
-                Active:
-              </span>
-              <span
-                className='text-xs font-medium text-muted-foreground'
-                data-testid='collections-active-context'
-              >
-                {selectedCollectionName}
-              </span>
-            </div>
-            <Button data-testid='collections-new-action' onClick={() => setCreateOpen(true)}>
+            <Button
+              data-testid='collections-new-action'
+              onClick={() => setCreateOpen(true)}
+            >
               <Plus className='mr-2 h-4 w-4' />
               New collection
             </Button>
@@ -315,25 +312,31 @@ export function Collections() {
       </Header>
 
       <Main className='flex flex-1 flex-col gap-3 sm:gap-4'>
-        <div
-          className='grid gap-4'
-          data-testid='collections-workspace'
-        >
+        <div className='grid gap-4' data-testid='collections-workspace'>
           <Card data-testid='collections-section'>
             <CardContent className='space-y-4'>
-              <div className='flex items-center gap-3' data-testid='collections-management-tools'>
+              <div
+                className='flex items-center gap-3'
+                data-testid='collections-management-tools'
+              >
                 <Input
                   value={globalFilter}
                   onChange={(event) => setGlobalFilter(event.target.value)}
                   placeholder='Filter collections...'
                   data-testid='collections-search-input'
                 />
-                <div className='text-sm text-muted-foreground' data-testid='collections-management-summary'>
+                <div
+                  className='text-sm text-muted-foreground'
+                  data-testid='collections-management-summary'
+                >
                   Showing {filteredCount} of {rows.length} collections.
                 </div>
               </div>
 
-              <div className='rounded-md border' data-testid='collections-shared-table'>
+              <div
+                className='rounded-md border'
+                data-testid='collections-shared-table'
+              >
                 <Table>
                   <TableHeader>
                     {table.getHeaderGroups().map((headerGroup) => (
@@ -342,7 +345,10 @@ export function Collections() {
                           <TableHead key={header.id}>
                             {header.isPlaceholder
                               ? null
-                              : flexRender(header.column.columnDef.header, header.getContext())}
+                              : flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext()
+                                )}
                           </TableHead>
                         ))}
                       </TableRow>
@@ -364,7 +370,10 @@ export function Collections() {
                           >
                             {row.getVisibleCells().map((cell) => (
                               <TableCell key={cell.id}>
-                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                {flexRender(
+                                  cell.column.columnDef.cell,
+                                  cell.getContext()
+                                )}
                               </TableCell>
                             ))}
                           </TableRow>
@@ -372,7 +381,10 @@ export function Collections() {
                       })
                     ) : (
                       <TableRow>
-                        <TableCell colSpan={columns.length} className='h-24 text-center'>
+                        <TableCell
+                          colSpan={columns.length}
+                          className='h-24 text-center'
+                        >
                           No collections match the current filter.
                         </TableCell>
                       </TableRow>
@@ -387,12 +399,15 @@ export function Collections() {
             <CardHeader>
               <CardTitle>Collection members</CardTitle>
               <CardDescription>
-                Review inventory items assigned to the selected collection. Assign or
-                move items from Inventory row actions.
+                Review inventory items assigned to the selected collection.
+                Assign or move items from Inventory row actions.
               </CardDescription>
             </CardHeader>
             <CardContent className='space-y-4'>
-              <div className='rounded-md border' data-testid='collections-members-table'>
+              <div
+                className='rounded-md border'
+                data-testid='collections-members-table'
+              >
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -412,7 +427,9 @@ export function Collections() {
                             className='font-medium'
                             data-testid={`collections-member-${collectionKey(item.name)}`}
                           >
-                            <span data-testid={`collections-member-name-${collectionKey(item.name)}`}>
+                            <span
+                              data-testid={`collections-member-name-${collectionKey(item.name)}`}
+                            >
                               {item.name}
                             </span>
                           </TableCell>
@@ -429,8 +446,12 @@ export function Collections() {
                       ))
                     ) : (
                       <TableRow data-testid='collections-members-empty-row'>
-                        <TableCell colSpan={3} className='h-24 text-center text-muted-foreground'>
-                          No items are currently assigned to {selectedCollectionName}.
+                        <TableCell
+                          colSpan={3}
+                          className='h-24 text-center text-muted-foreground'
+                        >
+                          No items are currently assigned to{' '}
+                          {selectedCollectionName}.
                         </TableCell>
                       </TableRow>
                     )}
@@ -446,7 +467,9 @@ export function Collections() {
         <DialogContent data-testid='collections-create-dialog'>
           <DialogHeader>
             <DialogTitle>Create collection</DialogTitle>
-            <DialogDescription>Add a new collection row to the management table.</DialogDescription>
+            <DialogDescription>
+              Add a new collection row to the management table.
+            </DialogDescription>
           </DialogHeader>
           <Input
             value={createValue}
@@ -455,7 +478,11 @@ export function Collections() {
             data-testid='collections-create-input'
           />
           <DialogFooter>
-            <Button type='button' variant='outline' onClick={() => setCreateOpen(false)}>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setCreateOpen(false)}
+            >
               Cancel
             </Button>
             <Button
@@ -475,7 +502,9 @@ export function Collections() {
         <DialogContent data-testid='collections-edit-dialog'>
           <DialogHeader>
             <DialogTitle>Edit collection</DialogTitle>
-            <DialogDescription>Rename the selected collection through the row workflow.</DialogDescription>
+            <DialogDescription>
+              Rename the selected collection through the row workflow.
+            </DialogDescription>
           </DialogHeader>
           <Input
             value={editValue}
@@ -484,7 +513,11 @@ export function Collections() {
             data-testid='collections-edit-input'
           />
           <DialogFooter>
-            <Button type='button' variant='outline' onClick={() => setEditOpen(false)}>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setEditOpen(false)}
+            >
               Cancel
             </Button>
             <Button
@@ -514,7 +547,11 @@ export function Collections() {
               : 'No collection is selected.'}
           </p>
           <DialogFooter>
-            <Button type='button' variant='outline' onClick={() => setDeleteOpen(false)}>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setDeleteOpen(false)}
+            >
               Cancel
             </Button>
             <Button

--- a/ui.web/src/features/dashboard/index.tsx
+++ b/ui.web/src/features/dashboard/index.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { LayoutDashboard } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -8,13 +10,12 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
 import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
-import { useTranslation } from 'react-i18next'
 
 type DashboardCard = {
   title: string
@@ -84,10 +85,22 @@ export function Dashboard() {
       return []
     }
     return [
-      { title: t('dashboard.metrics.inventoryItems'), value: `${summary.total_items}` },
-      { title: t('dashboard.metrics.inventoryUnits'), value: `${summary.total_instances}` },
-      { title: t('dashboard.metrics.wishlistHits'), value: `${summary.wishlist_hits}` },
-      { title: t('dashboard.metrics.estimatedValue'), value: formatCurrency(summary.estimated_value) },
+      {
+        title: t('dashboard.metrics.inventoryItems'),
+        value: `${summary.total_items}`,
+      },
+      {
+        title: t('dashboard.metrics.inventoryUnits'),
+        value: `${summary.total_instances}`,
+      },
+      {
+        title: t('dashboard.metrics.wishlistHits'),
+        value: `${summary.wishlist_hits}`,
+      },
+      {
+        title: t('dashboard.metrics.estimatedValue'),
+        value: formatCurrency(summary.estimated_value),
+      },
     ]
   }, [summary, t])
 
@@ -95,6 +108,13 @@ export function Dashboard() {
     <>
       <Header fixed>
         <Search />
+        <HeaderTitle
+          title={t('dashboard.title')}
+          description={t('dashboard.subtitle')}
+          icon={LayoutDashboard}
+          testId='dashboard-header-title'
+          iconTestId='dashboard-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />
@@ -106,10 +126,10 @@ export function Dashboard() {
       <Main className='space-y-6'>
         <div className='flex flex-wrap items-center justify-between gap-3'>
           <div>
-            <h1 className='text-2xl font-bold tracking-tight'>{t('dashboard.title')}</h1>
-            <p className='text-muted-foreground'>
-              {t('dashboard.subtitle')}
-            </p>
+            <h1 className='text-2xl font-bold tracking-tight'>
+              {t('dashboard.title')}
+            </h1>
+            <p className='text-muted-foreground'>{t('dashboard.subtitle')}</p>
           </div>
           <Button onClick={() => void loadDashboard()} disabled={loading}>
             {loading ? t('dashboard.refreshing') : t('dashboard.refresh')}
@@ -204,11 +224,15 @@ export function Dashboard() {
           <Card className='col-span-1 lg:col-span-3'>
             <CardHeader>
               <CardTitle>{t('dashboard.recentlyAdded')}</CardTitle>
-              <CardDescription>{t('dashboard.recentlyAddedDescription')}</CardDescription>
+              <CardDescription>
+                {t('dashboard.recentlyAddedDescription')}
+              </CardDescription>
             </CardHeader>
             <CardContent>
               {loading ? (
-                <p className='text-sm text-muted-foreground'>{t('dashboard.loadingItems')}</p>
+                <p className='text-sm text-muted-foreground'>
+                  {t('dashboard.loadingItems')}
+                </p>
               ) : summary?.recently_added?.length ? (
                 <ul className='space-y-2'>
                   {summary.recently_added.map((item) => (
@@ -219,7 +243,9 @@ export function Dashboard() {
                         className='flex items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors hover:bg-muted'
                       >
                         <span className='truncate'>{item}</span>
-                        <span className='text-xs text-muted-foreground'>{t('dashboard.openInventory')}</span>
+                        <span className='text-xs text-muted-foreground'>
+                          {t('dashboard.openInventory')}
+                        </span>
                       </a>
                     </li>
                   ))}

--- a/ui.web/src/features/discover/index.tsx
+++ b/ui.web/src/features/discover/index.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Header } from '@/components/layout/header'
-import { Main } from '@/components/layout/main'
-import { Search } from '@/components/search'
+import { Telescope } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { LanguageSwitch } from '@/components/language-switch'
-import { ThemeSwitch } from '@/components/theme-switch'
 import { ConfigDrawer } from '@/components/config-drawer'
+import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
 
 type DiscoveryItem = {
   candidate_id: string
@@ -19,7 +20,11 @@ type DiscoveryItem = {
   stock_count: number
 }
 
-type DiscoveryActionType = 'ignore' | 'add_to_wishlist' | 'track_price' | 'create_item'
+type DiscoveryActionType =
+  | 'ignore'
+  | 'add_to_wishlist'
+  | 'track_price'
+  | 'create_item'
 
 export function Discover() {
   const [query, setQuery] = useState('')
@@ -52,7 +57,8 @@ export function Discover() {
       const payload = (await response.json()) as { items?: DiscoveryItem[] }
       setItems(payload.items ?? [])
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'discover_list_failed'
+      const message =
+        err instanceof Error ? err.message : 'discover_list_failed'
       setError(message)
       setItems([])
     } finally {
@@ -64,7 +70,10 @@ export function Discover() {
     void loadItems()
   }, [loadItems])
 
-  const applyAction = async (candidateID: string, type: DiscoveryActionType) => {
+  const applyAction = async (
+    candidateID: string,
+    type: DiscoveryActionType
+  ) => {
     setActionStatus(null)
     const response = await fetch('/api/discovery/action', {
       method: 'POST',
@@ -87,6 +96,13 @@ export function Discover() {
     <>
       <Header fixed>
         <Search />
+        <HeaderTitle
+          title='Discoveries'
+          description='Not-in-collection candidates with triage actions.'
+          icon={Telescope}
+          testId='discoveries-header-title'
+          iconTestId='discoveries-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />
@@ -145,7 +161,10 @@ export function Discover() {
             onChange={(event) => setDateFrom(event.target.value)}
             placeholder='Date from (YYYY-MM-DD)'
           />
-          <Button data-testid='discover-apply-filters' onClick={() => void loadItems()}>
+          <Button
+            data-testid='discover-apply-filters'
+            onClick={() => void loadItems()}
+          >
             Apply Filters
           </Button>
         </section>
@@ -176,7 +195,9 @@ export function Discover() {
 
         <div data-testid='discover-list' className='rounded-md border'>
           {loading ? (
-            <p className='p-4 text-sm text-muted-foreground'>Loading discoveries...</p>
+            <p className='p-4 text-sm text-muted-foreground'>
+              Loading discoveries...
+            </p>
           ) : items.length === 0 ? (
             <p className='p-4 text-sm text-muted-foreground'>
               No discovery candidates match current filters.
@@ -189,10 +210,16 @@ export function Discover() {
                     <div>
                       <p className='font-medium'>{item.title}</p>
                       <p className='text-xs text-muted-foreground'>
-                        {item.candidate_id} | ${item.price.toFixed(2)} | Stock {item.stock_count}
+                        {item.candidate_id} | ${item.price.toFixed(2)} | Stock{' '}
+                        {item.stock_count}
                       </p>
                     </div>
-                    <a href={item.url} className='text-sm underline' target='_blank' rel='noreferrer'>
+                    <a
+                      href={item.url}
+                      className='text-sm underline'
+                      target='_blank'
+                      rel='noreferrer'
+                    >
                       Open Listing
                     </a>
                   </div>
@@ -201,7 +228,9 @@ export function Discover() {
                       size='sm'
                       variant='outline'
                       data-testid={`discover-action-ignore-${item.candidate_id}`}
-                      onClick={() => void applyAction(item.candidate_id, 'ignore')}
+                      onClick={() =>
+                        void applyAction(item.candidate_id, 'ignore')
+                      }
                     >
                       Ignore
                     </Button>
@@ -209,7 +238,9 @@ export function Discover() {
                       size='sm'
                       variant='outline'
                       data-testid={`discover-action-wishlist-${item.candidate_id}`}
-                      onClick={() => void applyAction(item.candidate_id, 'add_to_wishlist')}
+                      onClick={() =>
+                        void applyAction(item.candidate_id, 'add_to_wishlist')
+                      }
                     >
                       Add to Wishlist
                     </Button>
@@ -217,14 +248,18 @@ export function Discover() {
                       size='sm'
                       variant='outline'
                       data-testid={`discover-action-track-${item.candidate_id}`}
-                      onClick={() => void applyAction(item.candidate_id, 'track_price')}
+                      onClick={() =>
+                        void applyAction(item.candidate_id, 'track_price')
+                      }
                     >
                       Track Price
                     </Button>
                     <Button
                       size='sm'
                       data-testid={`discover-action-create-${item.candidate_id}`}
-                      onClick={() => void applyAction(item.candidate_id, 'create_item')}
+                      onClick={() =>
+                        void applyAction(item.candidate_id, 'create_item')
+                      }
                     >
                       Create Item
                     </Button>

--- a/ui.web/src/features/help-center/index.tsx
+++ b/ui.web/src/features/help-center/index.tsx
@@ -1,16 +1,22 @@
 import { useMemo, useState } from 'react'
 import { BookOpenText, FileText, LibraryBig } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
 import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { type HelpCenterArticle, helpCenterArticles } from './articles'
 
 type MarkdownBlock =
@@ -110,10 +116,16 @@ function parseMarkdown(content: string): MarkdownBlock[] {
 }
 
 function MarkdownArticle({ article }: { article: HelpCenterArticle }) {
-  const blocks = useMemo(() => parseMarkdown(article.content), [article.content])
+  const blocks = useMemo(
+    () => parseMarkdown(article.content),
+    [article.content]
+  )
 
   return (
-    <div className='space-y-4' data-testid={`help-center-article-content-${article.id}`}>
+    <div
+      className='space-y-4'
+      data-testid={`help-center-article-content-${article.id}`}
+    >
       {blocks.map((block, index) => {
         const key = `${article.id}-${block.type}-${index}`
 
@@ -143,7 +155,10 @@ function MarkdownArticle({ article }: { article: HelpCenterArticle }) {
 
         if (block.type === 'unordered-list') {
           return (
-            <ul key={key} className='list-disc space-y-1 ps-5 text-sm text-muted-foreground'>
+            <ul
+              key={key}
+              className='list-disc space-y-1 ps-5 text-sm text-muted-foreground'
+            >
               {block.items.map((item) => (
                 <li key={`${key}-${item}`}>{item}</li>
               ))}
@@ -153,7 +168,10 @@ function MarkdownArticle({ article }: { article: HelpCenterArticle }) {
 
         if (block.type === 'ordered-list') {
           return (
-            <ol key={key} className='list-decimal space-y-1 ps-5 text-sm text-muted-foreground'>
+            <ol
+              key={key}
+              className='list-decimal space-y-1 ps-5 text-sm text-muted-foreground'
+            >
               {block.items.map((item) => (
                 <li key={`${key}-${item}`}>{item}</li>
               ))}
@@ -172,7 +190,9 @@ function MarkdownArticle({ article }: { article: HelpCenterArticle }) {
 }
 
 export function HelpCenter() {
-  const [selectedArticleId, setSelectedArticleId] = useState(helpCenterArticles[0]?.id ?? '')
+  const [selectedArticleId, setSelectedArticleId] = useState(
+    helpCenterArticles[0]?.id ?? ''
+  )
 
   const groupedArticles = useMemo(() => {
     const grouped = new Map<string, HelpCenterArticle[]>()
@@ -186,12 +206,20 @@ export function HelpCenter() {
   }, [])
 
   const selectedArticle =
-    helpCenterArticles.find((article) => article.id === selectedArticleId) ?? helpCenterArticles[0]
+    helpCenterArticles.find((article) => article.id === selectedArticleId) ??
+    helpCenterArticles[0]
 
   return (
     <>
       <Header fixed>
         <Search />
+        <HeaderTitle
+          title='Help Center'
+          description='Browse in-app guides, section walkthroughs, and Cabinet workflow references.'
+          icon={BookOpenText}
+          testId='help-center-header-title'
+          iconTestId='help-center-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />
@@ -203,7 +231,10 @@ export function HelpCenter() {
       <Main className='space-y-6'>
         <div className='space-y-2'>
           <h1 className='text-2xl font-bold tracking-tight'>Help Center</h1>
-          <p className='text-muted-foreground'>Browse in-app guides, section walkthroughs, and shared Cabinet workflow references.</p>
+          <p className='text-muted-foreground'>
+            Browse in-app guides, section walkthroughs, and shared Cabinet
+            workflow references.
+          </p>
         </div>
 
         <div className='grid gap-4 md:grid-cols-3'>
@@ -215,8 +246,13 @@ export function HelpCenter() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className='text-3xl font-semibold'>{helpCenterArticles.length}</div>
-              <p className='mt-2 text-sm text-muted-foreground'>Help articles are grouped into Getting Started, Sections, and Reference guides.</p>
+              <div className='text-3xl font-semibold'>
+                {helpCenterArticles.length}
+              </div>
+              <p className='mt-2 text-sm text-muted-foreground'>
+                Help articles are grouped into Getting Started, Sections, and
+                Reference guides.
+              </p>
             </CardContent>
           </Card>
 
@@ -228,7 +264,12 @@ export function HelpCenter() {
               </CardTitle>
             </CardHeader>
             <CardContent className='text-sm text-muted-foreground'>
-              Begin with <span className='font-medium text-foreground'>Login and Database Setup</span> to make sure you are in the right Cabinet profile before using Inventory, Wishlist, or Integrations.
+              Begin with{' '}
+              <span className='font-medium text-foreground'>
+                Login and Database Setup
+              </span>{' '}
+              to make sure you are in the right Cabinet profile before using
+              Inventory, Wishlist, or Integrations.
             </CardContent>
           </Card>
 
@@ -240,7 +281,8 @@ export function HelpCenter() {
               </CardTitle>
             </CardHeader>
             <CardContent className='text-sm text-muted-foreground'>
-              Select any article from the library to open its in-app reading panel without leaving the Help Center route.
+              Select any article from the library to open its in-app reading
+              panel without leaving the Help Center route.
             </CardContent>
           </Card>
         </div>
@@ -249,14 +291,17 @@ export function HelpCenter() {
           <Card data-testid='help-center-article-library'>
             <CardHeader>
               <CardTitle>Browse articles</CardTitle>
-              <CardDescription>The Help Center now surfaces the available article set instead of a placeholder-only card.</CardDescription>
+              <CardDescription>
+                The Help Center now surfaces the available article set instead
+                of a placeholder-only card.
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <div className='space-y-6'>
                 {groupedArticles.map(([category, articles]) => (
                   <div key={category} className='space-y-3'>
                     <div className='flex items-center justify-between'>
-                      <h2 className='text-sm font-semibold uppercase tracking-wide text-muted-foreground'>
+                      <h2 className='text-sm font-semibold tracking-wide text-muted-foreground uppercase'>
                         {category}
                       </h2>
                       <Badge variant='outline'>{articles.length}</Badge>
@@ -274,8 +319,12 @@ export function HelpCenter() {
                             onClick={() => setSelectedArticleId(article.id)}
                           >
                             <div className='space-y-1'>
-                              <div className='font-medium text-foreground'>{article.title}</div>
-                              <div className='whitespace-normal text-xs text-muted-foreground'>{article.summary}</div>
+                              <div className='font-medium text-foreground'>
+                                {article.title}
+                              </div>
+                              <div className='text-xs whitespace-normal text-muted-foreground'>
+                                {article.summary}
+                              </div>
                             </div>
                           </Button>
                         )
@@ -293,7 +342,9 @@ export function HelpCenter() {
                 <Badge variant='outline'>{selectedArticle.category}</Badge>
                 <Badge variant='secondary'>In-app article</Badge>
               </div>
-              <CardTitle data-testid='help-center-selected-article-title'>{selectedArticle.title}</CardTitle>
+              <CardTitle data-testid='help-center-selected-article-title'>
+                {selectedArticle.title}
+              </CardTitle>
               <CardDescription>{selectedArticle.summary}</CardDescription>
             </CardHeader>
             <CardContent>

--- a/ui.web/src/features/reports/index.tsx
+++ b/ui.web/src/features/reports/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ChartColumn } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -8,8 +9,8 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
 import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
@@ -71,12 +72,21 @@ export function Reports() {
         throw new Error('active_profile_missing')
       }
 
-      const [wishlistResp, statsResp, trendResp, sourceResp] = await Promise.all([
-        fetch(`/api/wishlist/hits?profile_id=${encodeURIComponent(profileID)}`),
-        fetch(`/api/pricing/stats?profile_id=${encodeURIComponent(profileID)}`),
-        fetch(`/api/pricing/trend?profile_id=${encodeURIComponent(profileID)}`),
-        fetch(`/api/pricing/by-source?profile_id=${encodeURIComponent(profileID)}`),
-      ])
+      const [wishlistResp, statsResp, trendResp, sourceResp] =
+        await Promise.all([
+          fetch(
+            `/api/wishlist/hits?profile_id=${encodeURIComponent(profileID)}`
+          ),
+          fetch(
+            `/api/pricing/stats?profile_id=${encodeURIComponent(profileID)}`
+          ),
+          fetch(
+            `/api/pricing/trend?profile_id=${encodeURIComponent(profileID)}`
+          ),
+          fetch(
+            `/api/pricing/by-source?profile_id=${encodeURIComponent(profileID)}`
+          ),
+        ])
 
       if (!wishlistResp.ok) {
         throw new Error(`reports_wishlist_hits_${wishlistResp.status}`)
@@ -167,6 +177,13 @@ export function Reports() {
     <>
       <Header fixed>
         <Search />
+        <HeaderTitle
+          title='Reports'
+          description='Wishlist and pricing analytics with export-ready snapshots.'
+          icon={ChartColumn}
+          testId='reports-header-title'
+          iconTestId='reports-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />
@@ -184,7 +201,11 @@ export function Reports() {
             </p>
           </div>
           <div className='flex gap-2'>
-            <Button variant='outline' onClick={() => void loadReports()} disabled={loading}>
+            <Button
+              variant='outline'
+              onClick={() => void loadReports()}
+              disabled={loading}
+            >
               {loading ? 'Refreshing...' : 'Refresh Reports'}
             </Button>
             <Button
@@ -212,7 +233,10 @@ export function Reports() {
         ) : null}
 
         {exportMessage ? (
-          <div className='rounded-md border bg-muted/30 px-3 py-2 text-sm' data-testid='reports-export-message'>
+          <div
+            className='rounded-md border bg-muted/30 px-3 py-2 text-sm'
+            data-testid='reports-export-message'
+          >
             {exportMessage}
           </div>
         ) : null}
@@ -222,7 +246,9 @@ export function Reports() {
             [1, 2, 3, 4].map((slot) => (
               <Card key={slot}>
                 <CardHeader className='pb-2'>
-                  <CardTitle className='text-sm font-medium'>Loading...</CardTitle>
+                  <CardTitle className='text-sm font-medium'>
+                    Loading...
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className='text-2xl font-bold'>--</div>
@@ -233,15 +259,21 @@ export function Reports() {
             <>
               <Card>
                 <CardHeader className='pb-2'>
-                  <CardTitle className='text-sm font-medium'>Wishlist Hits</CardTitle>
+                  <CardTitle className='text-sm font-medium'>
+                    Wishlist Hits
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className='text-2xl font-bold'>{data?.wishlistHits ?? 0}</div>
+                  <div className='text-2xl font-bold'>
+                    {data?.wishlistHits ?? 0}
+                  </div>
                 </CardContent>
               </Card>
               <Card>
                 <CardHeader className='pb-2'>
-                  <CardTitle className='text-sm font-medium'>Price Min</CardTitle>
+                  <CardTitle className='text-sm font-medium'>
+                    Price Min
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className='text-2xl font-bold'>
@@ -251,7 +283,9 @@ export function Reports() {
               </Card>
               <Card>
                 <CardHeader className='pb-2'>
-                  <CardTitle className='text-sm font-medium'>Price Median</CardTitle>
+                  <CardTitle className='text-sm font-medium'>
+                    Price Median
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className='text-2xl font-bold'>
@@ -261,7 +295,9 @@ export function Reports() {
               </Card>
               <Card>
                 <CardHeader className='pb-2'>
-                  <CardTitle className='text-sm font-medium'>Price Latest</CardTitle>
+                  <CardTitle className='text-sm font-medium'>
+                    Price Latest
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className='text-2xl font-bold'>

--- a/ui.web/src/features/scanner/index.tsx
+++ b/ui.web/src/features/scanner/index.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ScanSearch } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
-import { Main } from '@/components/layout/main'
 import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 
 type QuerySet = {
   id: string
@@ -95,7 +96,11 @@ function parseErrorCode(payload: unknown, fallback: string): string {
   return fallback
 }
 
-function mapScannerActionError(operation: 'run' | 'retry', status: number, errorCode: string): ActionFeedback {
+function mapScannerActionError(
+  operation: 'run' | 'retry',
+  status: number,
+  errorCode: string
+): ActionFeedback {
   if (operation === 'run' && status === 400) {
     return {
       summary: 'Run failed due to query validation.',
@@ -126,7 +131,10 @@ function mapScannerActionError(operation: 'run' | 'retry', status: number, error
   if (status >= 500) {
     return {
       summary: 'Market Watch service is temporarily unavailable.',
-      actions: ['Retry shortly.', 'Check diagnostics for provider/runtime health.'],
+      actions: [
+        'Retry shortly.',
+        'Check diagnostics for provider/runtime health.',
+      ],
       diagnosticCode: errorCode,
     }
   }
@@ -143,33 +151,55 @@ function mapScannerActionError(operation: 'run' | 'retry', status: number, error
 export function Scanner() {
   const [querySets, setQuerySets] = useState<QuerySet[]>([])
   const [failures, setFailures] = useState<Failure[]>([])
-  const [candidatesByQuerySet, setCandidatesByQuerySet] = useState<Record<string, Candidate[]>>({})
-  const [runSummaryByQuerySet, setRunSummaryByQuerySet] = useState<Record<string, RunSummary>>({})
-  const [runMetaByQuerySet, setRunMetaByQuerySet] = useState<Record<string, RunMeta>>({})
+  const [candidatesByQuerySet, setCandidatesByQuerySet] = useState<
+    Record<string, Candidate[]>
+  >({})
+  const [runSummaryByQuerySet, setRunSummaryByQuerySet] = useState<
+    Record<string, RunSummary>
+  >({})
+  const [runMetaByQuerySet, setRunMetaByQuerySet] = useState<
+    Record<string, RunMeta>
+  >({})
   const [providerHealth, setProviderHealth] = useState('unknown')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [actionStatus, setActionStatus] = useState<string | null>(null)
-  const [actionFeedback, setActionFeedback] = useState<ActionFeedback | null>(null)
+  const [actionFeedback, setActionFeedback] = useState<ActionFeedback | null>(
+    null
+  )
   const [newName, setNewName] = useState('')
   const [newKeywords, setNewKeywords] = useState('')
   const [newScheduleCron, setNewScheduleCron] = useState('0 */6 * * *')
-  const [createValidation, setCreateValidation] = useState<CreateQueryValidation>({})
+  const [createValidation, setCreateValidation] =
+    useState<CreateQueryValidation>({})
   const [providerMode, setProviderMode] = useState<ProviderMode>('single')
   const [singleProvider, setSingleProvider] = useState('ebay')
-  const [multiProviders, setMultiProviders] = useState<string[]>(['ebay', 'amazon'])
-  const [providerValidation, setProviderValidation] = useState<string | null>(null)
+  const [multiProviders, setMultiProviders] = useState<string[]>([
+    'ebay',
+    'amazon',
+  ])
+  const [providerValidation, setProviderValidation] = useState<string | null>(
+    null
+  )
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards')
-  const [selectedOutputQuerySetID, setSelectedOutputQuerySetID] = useState<string | null>(null)
-  const [editingQuerySetID, setEditingQuerySetID] = useState<string | null>(null)
+  const [selectedOutputQuerySetID, setSelectedOutputQuerySetID] = useState<
+    string | null
+  >(null)
+  const [editingQuerySetID, setEditingQuerySetID] = useState<string | null>(
+    null
+  )
   const [editingName, setEditingName] = useState('')
   const [editingKeywords, setEditingKeywords] = useState('')
   const [editingScheduleCron, setEditingScheduleCron] = useState('')
   const [handoffStatus, setHandoffStatus] = useState<string | null>(null)
   const [quickScanStatus, setQuickScanStatus] = useState<string | null>(null)
   const [quickScanQueue, setQuickScanQueue] = useState<QuickScanQueueItem[]>([])
-  const [pendingApplyScanID, setPendingApplyScanID] = useState<string | null>(null)
-  const [quickCategoryView, setQuickCategoryView] = useState<'cards' | 'table'>('cards')
+  const [pendingApplyScanID, setPendingApplyScanID] = useState<string | null>(
+    null
+  )
+  const [quickCategoryView, setQuickCategoryView] = useState<'cards' | 'table'>(
+    'cards'
+  )
   const quickScanFileInputRef = useRef<HTMLInputElement | null>(null)
 
   const loadScanner = useCallback(async () => {
@@ -191,8 +221,12 @@ export function Scanner() {
         throw new Error(`provider_health_${healthRes.status}`)
       }
 
-      const querySetPayload = (await querySetsRes.json()) as { query_sets?: QuerySet[] }
-      const failuresPayload = (await failuresRes.json()) as { failures?: Failure[] }
+      const querySetPayload = (await querySetsRes.json()) as {
+        query_sets?: QuerySet[]
+      }
+      const failuresPayload = (await failuresRes.json()) as {
+        failures?: Failure[]
+      }
       const healthPayload = (await healthRes.json()) as { status?: string }
 
       setQuerySets(querySetPayload.query_sets ?? [])
@@ -264,7 +298,8 @@ export function Scanner() {
       nextValidation.name = 'Query set name is required.'
     }
     if (keywords.length === 0) {
-      nextValidation.keywords = 'Enter at least one keyword before creating a query set.'
+      nextValidation.keywords =
+        'Enter at least one keyword before creating a query set.'
     }
     if (nextValidation.name || nextValidation.keywords) {
       setCreateValidation(nextValidation)
@@ -300,7 +335,11 @@ export function Scanner() {
     if (!response.ok) {
       setActionStatus('create_query_set_failed')
       setActionFeedback(
-        mapScannerActionError('run', response.status, `create_query_set_${response.status}`)
+        mapScannerActionError(
+          'run',
+          response.status,
+          `create_query_set_${response.status}`
+        )
       )
       return
     }
@@ -345,30 +384,50 @@ export function Scanner() {
         .filter(Boolean),
       schedule_cron: editingScheduleCron.trim(),
     }
-    const response = await fetch(`/api/scanner/query-sets/${encodeURIComponent(querySet.id)}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    })
+    const response = await fetch(
+      `/api/scanner/query-sets/${encodeURIComponent(querySet.id)}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }
+    )
     if (!response.ok) {
       setActionStatus('update_query_set_failed')
-      setActionFeedback(mapScannerActionError('run', response.status, `update_query_set_${response.status}`))
+      setActionFeedback(
+        mapScannerActionError(
+          'run',
+          response.status,
+          `update_query_set_${response.status}`
+        )
+      )
       return
     }
     const updated = (await response.json()) as QuerySet
-    setQuerySets((current) => current.map((item) => (item.id === updated.id ? updated : item)))
+    setQuerySets((current) =>
+      current.map((item) => (item.id === updated.id ? updated : item))
+    )
     setActionStatus(`query_set_updated_${updated.id}`)
     setActionFeedback(null)
     cancelEditQuerySet()
   }
 
   const deleteQuerySet = async (querySetID: string) => {
-    const response = await fetch(`/api/scanner/query-sets/${encodeURIComponent(querySetID)}`, {
-      method: 'DELETE',
-    })
+    const response = await fetch(
+      `/api/scanner/query-sets/${encodeURIComponent(querySetID)}`,
+      {
+        method: 'DELETE',
+      }
+    )
     if (!response.ok) {
       setActionStatus('delete_query_set_failed')
-      setActionFeedback(mapScannerActionError('run', response.status, `delete_query_set_${response.status}`))
+      setActionFeedback(
+        mapScannerActionError(
+          'run',
+          response.status,
+          `delete_query_set_${response.status}`
+        )
+      )
       return
     }
     setQuerySets((current) => current.filter((item) => item.id !== querySetID))
@@ -430,13 +489,17 @@ export function Scanner() {
       setHandoffStatus(`discoveries_handoff_failed_${response.status}`)
       return
     }
-    const payload = (await response.json()) as { items?: Array<{ candidate_id: string }> }
+    const payload = (await response.json()) as {
+      items?: Array<{ candidate_id: string }>
+    }
     setHandoffStatus(`discoveries_handoff_ok_${payload.items?.length ?? 0}`)
   }
 
   const handoffFirstCandidateToWishlist = async (querySetID: string) => {
     const candidates = candidatesByQuerySet[querySetID] ?? []
-    const firstCandidate = candidates.find((candidate) => (candidate.id ?? '').trim() !== '')
+    const firstCandidate = candidates.find(
+      (candidate) => (candidate.id ?? '').trim() !== ''
+    )
     if (!firstCandidate || !firstCandidate.id) {
       setHandoffStatus('wishlist_handoff_no_candidate')
       return
@@ -466,7 +529,9 @@ export function Scanner() {
       [querySet.id]: { status: 'running' },
     }))
     const providerScope = Array.isArray(querySet.provider_scope)
-      ? querySet.provider_scope.map((value) => value.trim().toLowerCase()).filter(Boolean)
+      ? querySet.provider_scope
+          .map((value) => value.trim().toLowerCase())
+          .filter(Boolean)
       : []
     const isBonzaOnly =
       providerScope.length === 1 &&
@@ -488,7 +553,9 @@ export function Scanner() {
           code = fallbackCode
         }
         setActionStatus('run_failed')
-        setActionFeedback(mapScannerActionError('run', bonzaResponse.status, code))
+        setActionFeedback(
+          mapScannerActionError('run', bonzaResponse.status, code)
+        )
         setRunMetaByQuerySet((current) => ({
           ...current,
           [querySet.id]: { status: 'failed' },
@@ -513,7 +580,10 @@ export function Scanner() {
       setActionFeedback(null)
       setRunMetaByQuerySet((current) => ({
         ...current,
-        [querySet.id]: { status: 'succeeded', ranAtISO: new Date().toISOString() },
+        [querySet.id]: {
+          status: 'succeeded',
+          ranAtISO: new Date().toISOString(),
+        },
       }))
       return
     }
@@ -545,7 +615,9 @@ export function Scanner() {
       `/api/scanner/candidates?query_set_id=${encodeURIComponent(querySet.id)}`
     )
     if (candidatesResponse.ok) {
-      const payload = (await candidatesResponse.json()) as { candidates?: Candidate[] }
+      const payload = (await candidatesResponse.json()) as {
+        candidates?: Candidate[]
+      }
       setCandidatesByQuerySet((current) => ({
         ...current,
         [querySet.id]: payload.candidates ?? [],
@@ -563,7 +635,10 @@ export function Scanner() {
     setActionFeedback(null)
     setRunMetaByQuerySet((current) => ({
       ...current,
-      [querySet.id]: { status: 'succeeded', ranAtISO: new Date().toISOString() },
+      [querySet.id]: {
+        status: 'succeeded',
+        ranAtISO: new Date().toISOString(),
+      },
     }))
   }
 
@@ -598,13 +673,13 @@ export function Scanner() {
     await loadScanner()
   }
 
-  const hasNoQuerySets = useMemo(() => !loading && !error && querySets.length === 0, [
-    error,
-    loading,
-    querySets.length,
-  ])
+  const hasNoQuerySets = useMemo(
+    () => !loading && !error && querySets.length === 0,
+    [error, loading, querySets.length]
+  )
 
-  const formatRunStatus = (querySetID: string) => runMetaByQuerySet[querySetID]?.status ?? 'never'
+  const formatRunStatus = (querySetID: string) =>
+    runMetaByQuerySet[querySetID]?.status ?? 'never'
 
   const formatRunTime = (querySetID: string) => {
     const ranAtISO = runMetaByQuerySet[querySetID]?.ranAtISO
@@ -631,7 +706,8 @@ export function Scanner() {
   }
 
   const launchQuickScan = () => {
-    const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= 768
+    const isMobileViewport =
+      typeof window !== 'undefined' && window.innerWidth <= 768
     const hasCameraAPI =
       typeof navigator !== 'undefined' &&
       typeof navigator.mediaDevices !== 'undefined' &&
@@ -640,7 +716,9 @@ export function Scanner() {
     if (isMobileViewport) {
       setQuickScanStatus('Mobile quick capture ready')
     } else if (hasCameraAPI) {
-      setQuickScanStatus('Desktop quick capture ready (camera available + upload fallback)')
+      setQuickScanStatus(
+        'Desktop quick capture ready (camera available + upload fallback)'
+      )
     } else {
       setQuickScanStatus('Desktop quick capture ready (upload fallback active)')
     }
@@ -652,13 +730,20 @@ export function Scanner() {
     if (!file) {
       return
     }
-    const normalized = file.name.replace(/\.[^.]+$/, '').trim().toLowerCase() || 'scan'
+    const normalized =
+      file.name
+        .replace(/\.[^.]+$/, '')
+        .trim()
+        .toLowerCase() || 'scan'
     const suggestions = [
       `${normalized} (primary match)`,
       `${normalized} (alt: foil variant)`,
       `${normalized} (alt: promo variant)`,
     ]
-    const confidencePct = Math.max(52, Math.min(96, 96 - (file.name.length % 32)))
+    const confidencePct = Math.max(
+      52,
+      Math.min(96, 96 - (file.name.length % 32))
+    )
     const entry: QuickScanQueueItem = {
       id: `${Date.now()}-${file.name}`,
       fileName: file.name,
@@ -682,18 +767,25 @@ export function Scanner() {
           ? {
               ...item,
               selectedSuggestion:
-                item.suggestions[(item.suggestions.indexOf(item.selectedSuggestion) + 1) % item.suggestions.length],
+                item.suggestions[
+                  (item.suggestions.indexOf(item.selectedSuggestion) + 1) %
+                    item.suggestions.length
+                ],
               overrideUsed: true,
             }
           : item
       )
     )
-    setQuickScanStatus('Manual override selected. Confirm apply to mutate inventory link state.')
+    setQuickScanStatus(
+      'Manual override selected. Confirm apply to mutate inventory link state.'
+    )
   }
 
   const reviewQuickScanApply = (itemID: string) => {
     setPendingApplyScanID(itemID)
-    setQuickScanStatus('Reviewing apply mutation. Confirm to link scan to inventory.')
+    setQuickScanStatus(
+      'Reviewing apply mutation. Confirm to link scan to inventory.'
+    )
   }
 
   const confirmQuickScanApply = () => {
@@ -707,7 +799,9 @@ export function Scanner() {
           : item
       )
     )
-    setQuickScanStatus('Inventory mutation applied after explicit confirmation.')
+    setQuickScanStatus(
+      'Inventory mutation applied after explicit confirmation.'
+    )
     setPendingApplyScanID(null)
   }
 
@@ -728,6 +822,13 @@ export function Scanner() {
     <>
       <Header fixed>
         <Search />
+        <HeaderTitle
+          title='Market Watch'
+          description='Provider scans, listing candidates, and discovery queues.'
+          icon={ScanSearch}
+          testId='market-watch-header-title'
+          iconTestId='market-watch-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />
@@ -740,11 +841,15 @@ export function Scanner() {
         <div>
           <h1 className='text-2xl font-bold tracking-tight'>Market Watch</h1>
           <p className='text-muted-foreground'>
-            Manage provider query sets, run market watch searches, and recover from provider failures.
+            Manage provider query sets, run market watch searches, and recover
+            from provider failures.
           </p>
         </div>
 
-        <div className='rounded-md border p-3 text-sm' data-testid='scanner-provider-health'>
+        <div
+          className='rounded-md border p-3 text-sm'
+          data-testid='scanner-provider-health'
+        >
           Provider health (eBay): <strong>{providerHealth}</strong>
         </div>
 
@@ -754,14 +859,20 @@ export function Scanner() {
               value={newName}
               onChange={(event) => {
                 setNewName(event.target.value)
-                setCreateValidation((current) => ({ ...current, name: undefined }))
+                setCreateValidation((current) => ({
+                  ...current,
+                  name: undefined,
+                }))
               }}
               placeholder='Query set name'
               aria-invalid={createValidation.name ? 'true' : 'false'}
               data-testid='scanner-new-query-name'
             />
             {createValidation.name ? (
-              <p className='text-xs text-destructive' data-testid='scanner-new-query-name-validation'>
+              <p
+                className='text-xs text-destructive'
+                data-testid='scanner-new-query-name-validation'
+              >
                 {createValidation.name}
               </p>
             ) : null}
@@ -771,14 +882,20 @@ export function Scanner() {
               value={newKeywords}
               onChange={(event) => {
                 setNewKeywords(event.target.value)
-                setCreateValidation((current) => ({ ...current, keywords: undefined }))
+                setCreateValidation((current) => ({
+                  ...current,
+                  keywords: undefined,
+                }))
               }}
               placeholder='Keywords (comma-separated)'
               aria-invalid={createValidation.keywords ? 'true' : 'false'}
               data-testid='scanner-new-query-keywords'
             />
             {createValidation.keywords ? (
-              <p className='text-xs text-destructive' data-testid='scanner-new-query-keywords-validation'>
+              <p
+                className='text-xs text-destructive'
+                data-testid='scanner-new-query-keywords-validation'
+              >
                 {createValidation.keywords}
               </p>
             ) : null}
@@ -820,7 +937,10 @@ export function Scanner() {
           ) : (
             <div className='flex flex-wrap gap-2 md:col-span-2'>
               {MARKET_WATCH_PROVIDER_OPTIONS.map((provider) => (
-                <label key={provider} className='inline-flex items-center gap-2 text-sm'>
+                <label
+                  key={provider}
+                  className='inline-flex items-center gap-2 text-sm'
+                >
                   <input
                     type='checkbox'
                     checked={multiProviders.includes(provider)}
@@ -828,7 +948,9 @@ export function Scanner() {
                       setProviderValidation(null)
                       setMultiProviders((current) => {
                         if (event.target.checked) {
-                          return current.includes(provider) ? current : [...current, provider]
+                          return current.includes(provider)
+                            ? current
+                            : [...current, provider]
                         }
                         return current.filter((value) => value !== provider)
                       })
@@ -840,7 +962,10 @@ export function Scanner() {
               ))}
             </div>
           )}
-          <Button onClick={() => void createQuerySet()} data-testid='scanner-create-query'>
+          <Button
+            onClick={() => void createQuerySet()}
+            data-testid='scanner-create-query'
+          >
             Create Query Set
           </Button>
           <Button
@@ -888,22 +1013,32 @@ export function Scanner() {
             Table
           </Button>
           {quickScanStatus ? (
-            <span className='text-xs text-muted-foreground' data-testid='card-scanner-quick-scan-status'>
+            <span
+              className='text-xs text-muted-foreground'
+              data-testid='card-scanner-quick-scan-status'
+            >
               {quickScanStatus}
             </span>
           ) : (
             <span className='text-xs text-muted-foreground'>
-              Quick Scan supports one-tap mobile capture and desktop upload fallback.
+              Quick Scan supports one-tap mobile capture and desktop upload
+              fallback.
             </span>
           )}
         </section>
-        <section className='rounded-md border p-2 text-xs' data-testid='card-scanner-queue'>
+        <section
+          className='rounded-md border p-2 text-xs'
+          data-testid='card-scanner-queue'
+        >
           {quickScanQueue.length === 0 ? (
             <p className='text-muted-foreground'>No quick-scan items queued.</p>
           ) : (
             <ul className='space-y-1'>
               {quickScanQueue.map((item) => (
-                <li key={item.id} className='flex flex-wrap items-center justify-between gap-2'>
+                <li
+                  key={item.id}
+                  className='flex flex-wrap items-center justify-between gap-2'
+                >
                   <span>{item.fileName}</span>
                   <span className='text-muted-foreground'>{item.status}</span>
                 </li>
@@ -911,7 +1046,10 @@ export function Scanner() {
             </ul>
           )}
         </section>
-        <section className='rounded-md border p-3' data-testid='card-scanner-quick-category'>
+        <section
+          className='rounded-md border p-3'
+          data-testid='card-scanner-quick-category'
+        >
           <div className='flex flex-wrap items-center justify-between gap-2'>
             <p className='text-sm font-medium'>Recent Unlinked Scans</p>
             <div className='flex items-center gap-2'>
@@ -940,8 +1078,12 @@ export function Scanner() {
               No recent unlinked scans. Add quick-scan items to review here.
             </p>
           ) : null}
-          {recentUnlinkedQuickScans.length > 0 && quickCategoryView === 'cards' ? (
-            <ul className='mt-3 space-y-2' data-testid='card-scanner-unlinked-cards-list'>
+          {recentUnlinkedQuickScans.length > 0 &&
+          quickCategoryView === 'cards' ? (
+            <ul
+              className='mt-3 space-y-2'
+              data-testid='card-scanner-unlinked-cards-list'
+            >
               {recentUnlinkedQuickScans.map((item) => (
                 <li
                   key={item.id}
@@ -1002,7 +1144,8 @@ export function Scanner() {
                       data-testid={`card-scanner-apply-confirmation-${item.id}`}
                     >
                       <p className='mb-2'>
-                        Confirm apply to link this scan to inventory using selected suggestion.
+                        Confirm apply to link this scan to inventory using
+                        selected suggestion.
                       </p>
                       <div className='flex flex-wrap gap-2'>
                         <Button
@@ -1029,9 +1172,13 @@ export function Scanner() {
               ))}
             </ul>
           ) : null}
-          {recentUnlinkedQuickScans.length > 0 && quickCategoryView === 'table' ? (
+          {recentUnlinkedQuickScans.length > 0 &&
+          quickCategoryView === 'table' ? (
             <div className='mt-3 overflow-x-auto'>
-              <table className='w-full text-xs' data-testid='card-scanner-unlinked-table'>
+              <table
+                className='w-full text-xs'
+                data-testid='card-scanner-unlinked-table'
+              >
                 <thead className='text-left'>
                   <tr>
                     <th className='px-2 py-1'>File</th>
@@ -1047,7 +1194,9 @@ export function Scanner() {
                       <td className='px-2 py-1'>{item.fileName}</td>
                       <td className='px-2 py-1'>{item.confidencePct}%</td>
                       <td className='px-2 py-1'>{item.selectedSuggestion}</td>
-                      <td className='px-2 py-1'>{new Date(item.queuedAtISO).toLocaleString()}</td>
+                      <td className='px-2 py-1'>
+                        {new Date(item.queuedAtISO).toLocaleString()}
+                      </td>
                       <td className='px-2 py-1'>{item.status}</td>
                     </tr>
                   ))}
@@ -1057,7 +1206,10 @@ export function Scanner() {
           ) : null}
         </section>
         {providerValidation ? (
-          <p className='text-sm text-destructive' data-testid='market-watch-provider-validation'>
+          <p
+            className='text-sm text-destructive'
+            data-testid='market-watch-provider-validation'
+          >
             {providerValidation}
           </p>
         ) : null}
@@ -1075,7 +1227,12 @@ export function Scanner() {
           >
             <p className='font-medium'>Market Watch data is unavailable.</p>
             <p className='mt-1 text-muted-foreground'>{error}</p>
-            <Button className='mt-3' variant='outline' size='sm' onClick={() => void loadScanner()}>
+            <Button
+              className='mt-3'
+              variant='outline'
+              size='sm'
+              onClick={() => void loadScanner()}
+            >
               Retry
             </Button>
           </div>
@@ -1086,7 +1243,8 @@ export function Scanner() {
             className='rounded-md border border-dashed p-4 text-sm text-muted-foreground'
             data-testid='scanner-empty-state'
           >
-            No query sets found. Create your first query set to start Market Watch runs.
+            No query sets found. Create your first query set to start Market
+            Watch runs.
           </div>
         ) : null}
 
@@ -1101,7 +1259,10 @@ export function Scanner() {
           </p>
         ) : null}
         {actionFeedback ? (
-          <div className='rounded-md border p-3 text-sm' data-testid='scanner-action-feedback'>
+          <div
+            className='rounded-md border p-3 text-sm'
+            data-testid='scanner-action-feedback'
+          >
             <p className='font-medium'>{actionFeedback.summary}</p>
             <ul className='mt-2 list-disc ps-4 text-muted-foreground'>
               {actionFeedback.actions.map((action) => (
@@ -1109,7 +1270,10 @@ export function Scanner() {
               ))}
             </ul>
             {actionFeedback.diagnosticCode ? (
-              <details className='mt-2 text-xs text-muted-foreground' data-testid='scanner-action-diagnostics'>
+              <details
+                className='mt-2 text-xs text-muted-foreground'
+                data-testid='scanner-action-diagnostics'
+              >
                 <summary>Diagnostics</summary>
                 <p className='mt-1'>{actionFeedback.diagnosticCode}</p>
               </details>
@@ -1118,26 +1282,38 @@ export function Scanner() {
         ) : null}
 
         {querySets.length > 0 && viewMode === 'cards' ? (
-          <section className='rounded-md border' data-testid='scanner-query-list'>
+          <section
+            className='rounded-md border'
+            data-testid='scanner-query-list'
+          >
             <div className='divide-y'>
               {querySets.map((querySet) => (
-                <div key={querySet.id} className='flex flex-wrap items-center justify-between gap-2 p-3'>
+                <div
+                  key={querySet.id}
+                  className='flex flex-wrap items-center justify-between gap-2 p-3'
+                >
                   <div>
                     {editingQuerySetID === querySet.id ? (
                       <div className='grid gap-2'>
                         <Input
                           value={editingName}
-                          onChange={(event) => setEditingName(event.target.value)}
+                          onChange={(event) =>
+                            setEditingName(event.target.value)
+                          }
                           data-testid={`scanner-edit-name-${querySet.id}`}
                         />
                         <Input
                           value={editingKeywords}
-                          onChange={(event) => setEditingKeywords(event.target.value)}
+                          onChange={(event) =>
+                            setEditingKeywords(event.target.value)
+                          }
                           data-testid={`scanner-edit-keywords-${querySet.id}`}
                         />
                         <Input
                           value={editingScheduleCron}
-                          onChange={(event) => setEditingScheduleCron(event.target.value)}
+                          onChange={(event) =>
+                            setEditingScheduleCron(event.target.value)
+                          }
                           data-testid={`scanner-edit-schedule-${querySet.id}`}
                         />
                       </div>
@@ -1155,7 +1331,10 @@ export function Scanner() {
                     >
                       {(querySet.provider_scope ?? []).join(', ') || 'ebay'}
                     </p>
-                    <p className='text-xs text-muted-foreground' data-testid={`scanner-query-schedule-${querySet.id}`}>
+                    <p
+                      className='text-xs text-muted-foreground'
+                      data-testid={`scanner-query-schedule-${querySet.id}`}
+                    >
                       Schedule: {querySet.schedule_cron || 'none'}
                     </p>
                   </div>
@@ -1220,7 +1399,10 @@ export function Scanner() {
         ) : null}
 
         {querySets.length > 0 && viewMode === 'table' ? (
-          <section className='rounded-md border' data-testid='market-watch-query-table'>
+          <section
+            className='rounded-md border'
+            data-testid='market-watch-query-table'
+          >
             <div className='overflow-x-auto'>
               <table className='w-full text-sm'>
                 <thead className='bg-muted/30 text-left'>
@@ -1229,7 +1411,9 @@ export function Scanner() {
                     <th className='px-3 py-2 font-medium'>Provider Scope</th>
                     <th className='px-3 py-2 font-medium'>Last Run Status</th>
                     <th className='px-3 py-2 font-medium'>Last Run Time</th>
-                    <th className='px-3 py-2 font-medium'>Latest Output Summary</th>
+                    <th className='px-3 py-2 font-medium'>
+                      Latest Output Summary
+                    </th>
                     <th className='px-3 py-2 font-medium'>Actions</th>
                   </tr>
                 </thead>
@@ -1240,16 +1424,24 @@ export function Scanner() {
                       <td className='px-3 py-2'>
                         {(querySet.provider_scope ?? []).join(', ') || 'ebay'}
                       </td>
-                      <td className='px-3 py-2 capitalize'>{formatRunStatus(querySet.id)}</td>
-                      <td className='px-3 py-2'>{formatRunTime(querySet.id)}</td>
-                      <td className='px-3 py-2'>{formatOutputSummary(querySet.id)}</td>
+                      <td className='px-3 py-2 capitalize'>
+                        {formatRunStatus(querySet.id)}
+                      </td>
+                      <td className='px-3 py-2'>
+                        {formatRunTime(querySet.id)}
+                      </td>
+                      <td className='px-3 py-2'>
+                        {formatOutputSummary(querySet.id)}
+                      </td>
                       <td className='px-3 py-2'>
                         <Button
                           type='button'
                           size='sm'
                           variant='outline'
                           data-testid={`market-watch-open-output-${querySet.id}`}
-                          onClick={() => setSelectedOutputQuerySetID(querySet.id)}
+                          onClick={() =>
+                            setSelectedOutputQuerySetID(querySet.id)
+                          }
                         >
                           Inspect Output
                         </Button>
@@ -1263,17 +1455,23 @@ export function Scanner() {
         ) : null}
 
         {selectedOutputQuerySetID ? (
-          <section className='rounded-md border p-3' data-testid='market-watch-output-detail'>
+          <section
+            className='rounded-md border p-3'
+            data-testid='market-watch-output-detail'
+          >
             <div className='flex items-start justify-between gap-3'>
               <div>
                 <p className='text-sm font-medium'>
-                  {querySets.find((querySet) => querySet.id === selectedOutputQuerySetID)?.name ??
-                    selectedOutputQuerySetID}
+                  {querySets.find(
+                    (querySet) => querySet.id === selectedOutputQuerySetID
+                  )?.name ?? selectedOutputQuerySetID}
                 </p>
                 <p className='mt-1 text-xs text-muted-foreground'>
                   Provider Scope:{' '}
-                  {(querySets.find((querySet) => querySet.id === selectedOutputQuerySetID)
-                    ?.provider_scope ?? ['ebay']
+                  {(
+                    querySets.find(
+                      (querySet) => querySet.id === selectedOutputQuerySetID
+                    )?.provider_scope ?? ['ebay']
                   ).join(', ')}
                 </p>
                 <p className='text-xs text-muted-foreground'>
@@ -1295,28 +1493,41 @@ export function Scanner() {
             {runSummaryByQuerySet[selectedOutputQuerySetID] ? (
               <div className='mt-3 rounded-md border p-2 text-xs'>
                 <p>
-                  Pages scanned: {runSummaryByQuerySet[selectedOutputQuerySetID].page_count}
+                  Pages scanned:{' '}
+                  {runSummaryByQuerySet[selectedOutputQuerySetID].page_count}
                 </p>
                 <p>
-                  Candidates: {runSummaryByQuerySet[selectedOutputQuerySetID].candidates_total}
+                  Candidates:{' '}
+                  {
+                    runSummaryByQuerySet[selectedOutputQuerySetID]
+                      .candidates_total
+                  }
                 </p>
                 <p>
                   Observed page size:{' '}
-                  {runSummaryByQuerySet[selectedOutputQuerySetID].observed_page_size}
+                  {
+                    runSummaryByQuerySet[selectedOutputQuerySetID]
+                      .observed_page_size
+                  }
                 </p>
               </div>
             ) : null}
             <div className='mt-3'>
               <p className='text-xs font-medium'>Latest output items</p>
-              {(candidatesByQuerySet[selectedOutputQuerySetID] ?? []).length === 0 ? (
-                <p className='text-xs text-muted-foreground'>No output available yet.</p>
+              {(candidatesByQuerySet[selectedOutputQuerySetID] ?? []).length ===
+              0 ? (
+                <p className='text-xs text-muted-foreground'>
+                  No output available yet.
+                </p>
               ) : (
                 <ul className='mt-1 space-y-1 text-xs text-muted-foreground'>
-                  {(candidatesByQuerySet[selectedOutputQuerySetID] ?? []).map((candidate) => (
-                    <li key={candidate.id || candidate.listing_id}>
-                      {candidate.title} ({candidate.source ?? 'unknown'})
-                    </li>
-                  ))}
+                  {(candidatesByQuerySet[selectedOutputQuerySetID] ?? []).map(
+                    (candidate) => (
+                      <li key={candidate.id || candidate.listing_id}>
+                        {candidate.title} ({candidate.source ?? 'unknown'})
+                      </li>
+                    )
+                  )}
                 </ul>
               )}
             </div>
@@ -1326,7 +1537,9 @@ export function Scanner() {
                 size='sm'
                 variant='outline'
                 data-testid={`scanner-handoff-wishlist-${selectedOutputQuerySetID}`}
-                onClick={() => void handoffFirstCandidateToWishlist(selectedOutputQuerySetID)}
+                onClick={() =>
+                  void handoffFirstCandidateToWishlist(selectedOutputQuerySetID)
+                }
               >
                 Add First Result to Wishlist
               </Button>
@@ -1336,7 +1549,9 @@ export function Scanner() {
                 variant='outline'
                 data-testid={`scanner-handoff-discoveries-detail-${selectedOutputQuerySetID}`}
                 onClick={() => {
-                  const current = querySets.find((querySet) => querySet.id === selectedOutputQuerySetID)
+                  const current = querySets.find(
+                    (querySet) => querySet.id === selectedOutputQuerySetID
+                  )
                   if (current) {
                     void handoffToDiscoveries(current)
                   }
@@ -1348,45 +1563,56 @@ export function Scanner() {
           </section>
         ) : null}
 
-        {Object.entries(candidatesByQuerySet).map(([querySetID, candidates]) => (
-          <section
-            key={querySetID}
-            className='rounded-md border p-3'
-            data-testid={`scanner-candidates-${querySetID}`}
-          >
-            {runSummaryByQuerySet[querySetID] ? (
-              <p
-                className='mb-2 text-xs text-muted-foreground'
-                data-testid={`scanner-run-summary-${querySetID}`}
-              >
-                Pages: {runSummaryByQuerySet[querySetID].page_count} • Candidates:{' '}
-                {runSummaryByQuerySet[querySetID].candidates_total} • Observed page size:{' '}
-                {runSummaryByQuerySet[querySetID].observed_page_size}
-              </p>
-            ) : null}
-            <p className='mb-2 text-sm font-medium'>Candidates</p>
-            {candidates.length === 0 ? (
-              <p className='text-xs text-muted-foreground'>No candidates returned.</p>
-            ) : (
-              <ul className='space-y-1 text-xs text-muted-foreground'>
-                {candidates.map((candidate) => (
-                  <li key={candidate.id || candidate.listing_id}>
-                    {candidate.title} ({candidate.source ?? 'unknown'})
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-        ))}
+        {Object.entries(candidatesByQuerySet).map(
+          ([querySetID, candidates]) => (
+            <section
+              key={querySetID}
+              className='rounded-md border p-3'
+              data-testid={`scanner-candidates-${querySetID}`}
+            >
+              {runSummaryByQuerySet[querySetID] ? (
+                <p
+                  className='mb-2 text-xs text-muted-foreground'
+                  data-testid={`scanner-run-summary-${querySetID}`}
+                >
+                  Pages: {runSummaryByQuerySet[querySetID].page_count} •
+                  Candidates:{' '}
+                  {runSummaryByQuerySet[querySetID].candidates_total} • Observed
+                  page size:{' '}
+                  {runSummaryByQuerySet[querySetID].observed_page_size}
+                </p>
+              ) : null}
+              <p className='mb-2 text-sm font-medium'>Candidates</p>
+              {candidates.length === 0 ? (
+                <p className='text-xs text-muted-foreground'>
+                  No candidates returned.
+                </p>
+              ) : (
+                <ul className='space-y-1 text-xs text-muted-foreground'>
+                  {candidates.map((candidate) => (
+                    <li key={candidate.id || candidate.listing_id}>
+                      {candidate.title} ({candidate.source ?? 'unknown'})
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )
+        )}
 
         {failures.length > 0 ? (
           <section className='rounded-md border' data-testid='scanner-failures'>
             <div className='divide-y'>
               {failures.map((failure) => (
-                <div key={failure.id} className='flex flex-wrap items-center justify-between gap-2 p-3'>
+                <div
+                  key={failure.id}
+                  className='flex flex-wrap items-center justify-between gap-2 p-3'
+                >
                   <div>
                     <p className='font-medium'>{failure.provider}</p>
-                    <p className='text-xs text-muted-foreground'>{failure.message}</p>
+                    <p className='text-xs text-muted-foreground'>
+                      {failure.message}
+                    </p>
                   </div>
                   <Button
                     size='sm'

--- a/ui.web/src/features/settings/index.tsx
+++ b/ui.web/src/features/settings/index.tsx
@@ -8,11 +8,12 @@ import {
   Cog,
   CreditCard,
   HardDrive,
+  Settings as SettingsIcon,
 } from 'lucide-react'
 import { Separator } from '@/components/ui/separator'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { LanguageSwitch } from '@/components/language-switch'
-import { Header } from '@/components/layout/header'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
@@ -68,6 +69,13 @@ export function Settings() {
       {/* ===== Top Heading ===== */}
       <Header>
         <Search />
+        <HeaderTitle
+          title='Settings'
+          description='Manage account, appearance, storage, and operations preferences.'
+          icon={SettingsIcon}
+          testId='settings-header-title'
+          iconTestId='settings-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -1,10 +1,6 @@
-import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
-import { LanguageSwitch } from '@/components/language-switch'
-import { Main } from '@/components/layout/main'
-import { ProfileDropdown } from '@/components/profile-dropdown'
-import { Search } from '@/components/search'
-import { ThemeSwitch } from '@/components/theme-switch'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Heart } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -14,17 +10,22 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
 import {
   collectionKey,
   useWorkspaceCollections,
 } from '@/features/collections/use-workspace-collections'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import { TasksDialogs, type TasksDialogType } from './components/tasks-dialogs'
-import { TasksTable } from './components/tasks-table'
 import { type WishlistEntryDraft } from './components/tasks-mutate-drawer'
-import { tasks } from './data/tasks'
+import { TasksTable } from './components/tasks-table'
 import { type Task } from './data/schema'
+import { tasks } from './data/tasks'
 
 type TasksProps = {
   title?: string
@@ -142,7 +143,14 @@ function buildWishlistCsv(tasksToExport: Task[]) {
   }
 
   return [
-    ['title', 'part_number', 'category', 'priority', 'notes', 'target_price'].join(','),
+    [
+      'title',
+      'part_number',
+      'category',
+      'priority',
+      'notes',
+      'target_price',
+    ].join(','),
     ...tasksToExport.map((task) =>
       [
         escapeCell(task.title),
@@ -228,16 +236,19 @@ export function Tasks({
     setActiveWorkspaceCollection,
     addCollection,
   } = useWorkspaceCollections()
-  const [inlineCollectionInputOpen, setInlineCollectionInputOpen] = useState(false)
+  const [inlineCollectionInputOpen, setInlineCollectionInputOpen] =
+    useState(false)
   const [inlineCollectionName, setInlineCollectionName] = useState('')
-  const [inlineCollectionValidationMessage, setInlineCollectionValidationMessage] =
-    useState('')
+  const [
+    inlineCollectionValidationMessage,
+    setInlineCollectionValidationMessage,
+  ] = useState('')
   const [tableData, setTableData] = useState<Task[]>(tasks)
   const [dialogOpen, setDialogOpen] = useState<TasksDialogType | null>(null)
   const [currentDialogRow, setCurrentDialogRow] = useState<Task | null>(null)
-  const [wishlistActionItemID, setWishlistActionItemID] = useState<string | null>(
-    null
-  )
+  const [wishlistActionItemID, setWishlistActionItemID] = useState<
+    string | null
+  >(null)
   const [isWishlistMutating, setIsWishlistMutating] = useState(false)
   const [wishlistPlanningFocus, setWishlistPlanningFocus] =
     useState<WishlistPlanningFocus>(() => {
@@ -417,10 +428,15 @@ export function Tasks({
         await saveWishlistDraft(draft, currentRow)
         await refreshWishlistTable()
         toast.success(
-          currentRow ? `${draft.title} updated.` : `${draft.title} added to wishlist.`
+          currentRow
+            ? `${draft.title} updated.`
+            : `${draft.title} added to wishlist.`
         )
       } catch (error) {
-        if (error instanceof Error && error.message === 'invalid_target_price') {
+        if (
+          error instanceof Error &&
+          error.message === 'invalid_target_price'
+        ) {
           toast.error('Target price must be a positive number.')
         } else {
           toast.error('Wishlist save failed. Try again.')
@@ -470,9 +486,14 @@ export function Tasks({
           await saveWishlistDraft(entry)
         }
         await refreshWishlistTable()
-        toast.success(`Imported ${entries.length} wishlist entr${entries.length === 1 ? 'y' : 'ies'}.`)
+        toast.success(
+          `Imported ${entries.length} wishlist entr${entries.length === 1 ? 'y' : 'ies'}.`
+        )
       } catch (error) {
-        if (error instanceof Error && error.message === 'invalid_target_price') {
+        if (
+          error instanceof Error &&
+          error.message === 'invalid_target_price'
+        ) {
           toast.error('Target price must be a positive number.')
         } else {
           toast.error('Wishlist import failed. Try again.')
@@ -511,7 +532,9 @@ export function Tasks({
           }
         }
         await refreshWishlistTable()
-        toast.success(`Updated priority for ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`)
+        toast.success(
+          `Updated priority for ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`
+        )
       } catch {
         toast.error('Bulk priority update failed. Try again.')
         throw new Error('wishlist_bulk_priority_failed')
@@ -581,7 +604,9 @@ export function Tasks({
           }
         }
         await refreshWishlistTable()
-        toast.success(`Deleted ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`)
+        toast.success(
+          `Deleted ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`
+        )
       } catch {
         toast.error('Bulk delete failed. Try again.')
         throw new Error('wishlist_bulk_delete_failed')
@@ -603,7 +628,9 @@ export function Tasks({
     anchor.click()
     anchor.remove()
     window.URL.revokeObjectURL(url)
-    toast.success(`Exported ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`)
+    toast.success(
+      `Exported ${selectedTasks.length} wishlist entr${selectedTasks.length === 1 ? 'y' : 'ies'}.`
+    )
   }, [])
 
   useEffect(() => {
@@ -751,21 +778,21 @@ export function Tasks({
 
   return (
     <>
-      <Header fixed data-testid={isWishlistRoute ? 'wishlist-shell-header' : undefined}>
+      <Header
+        fixed
+        data-testid={isWishlistRoute ? 'wishlist-shell-header' : undefined}
+      >
         <Search />
         {isWishlistRoute ? (
-          <div className='hidden min-w-0 flex-1 justify-center lg:flex'>
-            <h1
-              className='truncate text-lg font-bold tracking-tight'
-              data-testid='wishlist-header-title'
-              title={description}
-              aria-label={description ? `${title} - ${description}` : title}
-            >
-              {title}
-            </h1>
-          </div>
+          <HeaderTitle
+            title={title}
+            description={description}
+            icon={Heart}
+            testId='wishlist-header-title'
+            iconTestId='wishlist-page-icon'
+          />
         ) : null}
-        <div className='flex min-w-0 items-center gap-3'>
+        <div className='ms-auto flex min-w-0 items-center gap-3'>
           {isWishlistRoute ? (
             <>
               <div
@@ -866,7 +893,9 @@ export function Tasks({
             onWishlistBulkDelete={
               isWishlistRoute ? handleWishlistBulkDelete : undefined
             }
-            onWishlistExport={isWishlistRoute ? handleWishlistExport : undefined}
+            onWishlistExport={
+              isWishlistRoute ? handleWishlistExport : undefined
+            }
             wishlistActionItemID={wishlistActionItemID}
             isWishlistMutating={isWishlistMutating}
           />

--- a/ui.web/src/features/users/index.tsx
+++ b/ui.web/src/features/users/index.tsx
@@ -1,12 +1,13 @@
-import { getRouteApi } from '@tanstack/react-router'
 import { useCallback, useEffect, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import { Users as UsersIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
 import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
-import { Button } from '@/components/ui/button'
 import { ThemeSwitch } from '@/components/theme-switch'
 import { UsersDialogs } from './components/users-dialogs'
 import { UsersPrimaryButtons } from './components/users-primary-buttons'
@@ -51,6 +52,13 @@ export function Users() {
     <UsersProvider>
       <Header fixed>
         <Search />
+        <HeaderTitle
+          title='Users'
+          description='Manage users and roles.'
+          icon={UsersIcon}
+          testId='users-header-title'
+          iconTestId='users-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />

--- a/ui.web/src/routes/_authenticated/errors/$error.tsx
+++ b/ui.web/src/routes/_authenticated/errors/$error.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { TriangleAlert } from 'lucide-react'
 import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
 import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
@@ -32,6 +33,13 @@ function RouteComponent() {
     <>
       <Header fixed className='border-b'>
         <Search />
+        <HeaderTitle
+          title='Error'
+          description='Review the current route error state.'
+          icon={TriangleAlert}
+          testId='error-header-title'
+          iconTestId='error-page-icon'
+        />
         <div className='ms-auto flex items-center space-x-4'>
           <LanguageSwitch />
           <ThemeSwitch />

--- a/ui.web/src/routes/clerk/_authenticated/user-management.tsx
+++ b/ui.web/src/routes/clerk/_authenticated/user-management.tsx
@@ -7,11 +7,11 @@ import {
   useRouter,
 } from '@tanstack/react-router'
 import { SignedIn, useAuth, UserButton } from '@clerk/clerk-react'
-import { ExternalLink, Loader2 } from 'lucide-react'
+import { ExternalLink, Loader2, Users } from 'lucide-react'
 import { ClerkLogo } from '@/assets/clerk-logo'
 import { Button } from '@/components/ui/button'
-import { Header } from '@/components/layout/header'
 import { LanguageSwitch } from '@/components/language-switch'
+import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { LearnMore } from '@/components/learn-more'
 import { Search } from '@/components/search'
@@ -51,6 +51,13 @@ function UserManagement() {
         <UsersProvider>
           <Header fixed>
             <Search />
+            <HeaderTitle
+              title='Users'
+              description='Manage users and roles.'
+              icon={Users}
+              testId='clerk-users-header-title'
+              iconTestId='clerk-users-page-icon'
+            />
             <div className='ms-auto flex items-center space-x-4'>
               <LanguageSwitch />
               <ThemeSwitch />


### PR DESCRIPTION
## Summary

- Adds a shared centered `HeaderTitle` with route icon and description tooltip.
- Applies the centered title/icon header pattern across routed pages and removes inline context text beside primary page titles.
- Keeps Inventory header actions usable at crowded desktop widths by switching to compact icon buttons below wide layouts.

## Validation

- `npm run build` from `ui.web`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-page-header-title/spec.cy.ts -Browser electron`
- Push hook: OpenSpec validation and fast API docs smoke test

Closes #693.