### PR TITLE
#695 Prevent header title action overlap

### DIFF
--- a/ui.web/cypress/e2e/general/ui-page-header-title/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-page-header-title/spec.cy.ts
@@ -17,23 +17,58 @@ describe('ui-page-header-title', () => {
     cy.get('header').should('not.contain', 'Planning list')
   }
 
+  function assertHeaderTitleDoesNotOverlapActions(testId: string) {
+    cy.get(`[data-testid="${testId}-header-title"]`).then(($title) => {
+      const titleRect = $title[0].getBoundingClientRect()
+
+      cy.get(`[data-testid="${testId}-global-header-actions"]`).then(
+        ($actions) => {
+          const actionsRect = $actions[0].getBoundingClientRect()
+
+          expect(
+            titleRect.right,
+            `${testId} title stays clear of header actions`
+          ).to.be.lessThan(actionsRect.left - 8)
+        }
+      )
+    })
+  }
+
   beforeEach(() => {
     cy.clearCookies()
     cy.clearLocalStorage()
-    cy.viewport(1440, 900)
   })
 
-  it('UI-PAGE-HEADER-TITLE-001 centers primary page titles with icons and no inline context text', () => {
+  it('UI-PAGE-HEADER-TITLE-001 hides crowded titles instead of overlapping header actions', () => {
+    cy.viewport(1240, 720)
+
+    signInTo('/inventory/')
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
+    cy.get('[data-testid="inventory-header-title"]')
+      .should('have.attr', 'data-crowded', 'true')
+      .and('not.be.visible')
+    cy.get('[data-testid="inventory-global-header-actions"]').should('be.visible')
+    cy.get('header').should('not.contain', 'Active:')
+    cy.get('header').should('not.contain', 'Collection:')
+    cy.get('header').should('not.contain', 'Planning list')
+  })
+
+  it('UI-PAGE-HEADER-TITLE-002 centers primary page titles with icons and no inline context text', () => {
+    cy.viewport(2048, 900)
+
     signInTo('/inventory/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
     assertCenteredHeader('inventory', 'Inventory')
+    assertHeaderTitleDoesNotOverlapActions('inventory')
 
     cy.visit('/collections/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/collections\/?$/)
     assertCenteredHeader('collections', 'Collections')
+    assertHeaderTitleDoesNotOverlapActions('collections')
 
     cy.visit('/wishlist/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/wishlist\/?$/)
     assertCenteredHeader('wishlist', 'Wishlist')
+    assertHeaderTitleDoesNotOverlapActions('wishlist')
   })
 })

--- a/ui.web/src/components/layout/header.tsx
+++ b/ui.web/src/components/layout/header.tsx
@@ -1,4 +1,10 @@
-import { type ComponentType, useEffect, useState } from 'react'
+import {
+  type ComponentType,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import { MessageSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useShellWorkspace } from '@/context/shell-workspace-provider'
@@ -30,20 +36,77 @@ export function HeaderTitle({
 }: HeaderTitleProps) {
   const titleText = title.trim()
   const hint = description?.trim()
+  const titleRef = useRef<HTMLHeadingElement | null>(null)
+  const [isCrowded, setIsCrowded] = useState(false)
+
+  useLayoutEffect(() => {
+    const titleElement = titleRef.current
+    const headerElement = titleElement?.closest('header')
+    if (!titleElement || !headerElement) {
+      return
+    }
+
+    let frame = 0
+    const measure = () => {
+      cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(() => {
+        const titleRect = titleElement.getBoundingClientRect()
+        const avoidElements = Array.from(
+          headerElement.querySelectorAll('[data-header-title-avoid="true"]')
+        )
+        const overlapsHeaderControls = avoidElements.some((element) => {
+          const controlRect = element.getBoundingClientRect()
+          const hasHorizontalOverlap =
+            titleRect.right > controlRect.left - 8 &&
+            titleRect.left < controlRect.right + 8
+          const hasVerticalOverlap =
+            titleRect.bottom > controlRect.top &&
+            titleRect.top < controlRect.bottom
+
+          return hasHorizontalOverlap && hasVerticalOverlap
+        })
+
+        setIsCrowded(overlapsHeaderControls)
+      })
+    }
+
+    const resizeObserver = new ResizeObserver(measure)
+    resizeObserver.observe(headerElement)
+    resizeObserver.observe(titleElement)
+    Array.from(
+      headerElement.querySelectorAll('[data-header-title-avoid="true"]')
+    ).forEach((element) => resizeObserver.observe(element))
+
+    window.addEventListener('resize', measure)
+    measure()
+
+    return () => {
+      cancelAnimationFrame(frame)
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [titleText])
 
   return (
     <div
       className={cn(
         'pointer-events-none absolute top-1/2 left-1/2 z-10 hidden max-w-[min(34rem,42vw)] -translate-x-1/2 -translate-y-1/2 justify-center md:flex',
+        isCrowded && 'opacity-0',
         className
       )}
+      data-crowded={isCrowded ? 'true' : 'false'}
     >
       <h1
+        ref={titleRef}
         className='flex min-w-0 items-center justify-center gap-2 truncate text-center text-lg font-bold tracking-tight'
         data-testid={testId}
         data-centered='true'
+        data-crowded={isCrowded ? 'true' : 'false'}
         title={hint || titleText}
-        aria-label={hint ? `${titleText} - ${hint}` : titleText}
+        aria-hidden={isCrowded ? true : undefined}
+        aria-label={
+          isCrowded ? undefined : hint ? `${titleText} - ${hint}` : titleText
+        }
       >
         <Icon
           aria-hidden

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -647,7 +647,10 @@ export function Apps({
           testId='integrations-header-title'
           iconTestId='integrations-page-icon'
         />
-        <div className='ms-auto flex items-center gap-4'>
+        <div
+          className='ms-auto flex items-center gap-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/chats/index.tsx
+++ b/ui.web/src/features/chats/index.tsx
@@ -348,7 +348,10 @@ export function Chats() {
           testId='chats-header-title'
           iconTestId='chats-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -3055,7 +3055,10 @@ export function Collection({
           testId='inventory-header-title'
           iconTestId='inventory-page-icon'
         />
-        <div className='ms-auto flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3'>
+        <div
+          className='ms-auto flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3'
+          data-header-title-avoid='true'
+        >
           <div
             className='flex min-w-0 shrink-0 flex-nowrap items-center justify-end gap-1.5 sm:gap-2'
             data-testid='inventory-global-header-actions'

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -285,7 +285,10 @@ export function Collections() {
           testId='collections-header-title'
           iconTestId='collections-page-icon'
         />
-        <div className='ms-auto flex min-w-0 items-center gap-3'>
+        <div
+          className='ms-auto flex min-w-0 items-center gap-3'
+          data-header-title-avoid='true'
+        >
           <div
             className='flex min-w-0 flex-wrap items-center justify-end gap-2'
             data-testid='collections-global-header-actions'

--- a/ui.web/src/features/dashboard/index.tsx
+++ b/ui.web/src/features/dashboard/index.tsx
@@ -115,7 +115,10 @@ export function Dashboard() {
           testId='dashboard-header-title'
           iconTestId='dashboard-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/discover/index.tsx
+++ b/ui.web/src/features/discover/index.tsx
@@ -103,7 +103,10 @@ export function Discover() {
           testId='discoveries-header-title'
           iconTestId='discoveries-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/help-center/index.tsx
+++ b/ui.web/src/features/help-center/index.tsx
@@ -220,7 +220,10 @@ export function HelpCenter() {
           testId='help-center-header-title'
           iconTestId='help-center-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/reports/index.tsx
+++ b/ui.web/src/features/reports/index.tsx
@@ -184,7 +184,10 @@ export function Reports() {
           testId='reports-header-title'
           iconTestId='reports-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/scanner/index.tsx
+++ b/ui.web/src/features/scanner/index.tsx
@@ -829,7 +829,10 @@ export function Scanner() {
           testId='market-watch-header-title'
           iconTestId='market-watch-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/settings/index.tsx
+++ b/ui.web/src/features/settings/index.tsx
@@ -76,7 +76,10 @@ export function Settings() {
           testId='settings-header-title'
           iconTestId='settings-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -792,7 +792,10 @@ export function Tasks({
             iconTestId='wishlist-page-icon'
           />
         ) : null}
-        <div className='ms-auto flex min-w-0 items-center gap-3'>
+        <div
+          className='ms-auto flex min-w-0 items-center gap-3'
+          data-header-title-avoid='true'
+        >
           {isWishlistRoute ? (
             <>
               <div

--- a/ui.web/src/features/users/index.tsx
+++ b/ui.web/src/features/users/index.tsx
@@ -59,7 +59,10 @@ export function Users() {
           testId='users-header-title'
           iconTestId='users-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/routes/_authenticated/errors/$error.tsx
+++ b/ui.web/src/routes/_authenticated/errors/$error.tsx
@@ -40,7 +40,10 @@ function RouteComponent() {
           testId='error-header-title'
           iconTestId='error-page-icon'
         />
-        <div className='ms-auto flex items-center space-x-4'>
+        <div
+          className='ms-auto flex items-center space-x-4'
+          data-header-title-avoid='true'
+        >
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />

--- a/ui.web/src/routes/clerk/_authenticated/user-management.tsx
+++ b/ui.web/src/routes/clerk/_authenticated/user-management.tsx
@@ -58,7 +58,10 @@ function UserManagement() {
               testId='clerk-users-header-title'
               iconTestId='clerk-users-page-icon'
             />
-            <div className='ms-auto flex items-center space-x-4'>
+            <div
+              className='ms-auto flex items-center space-x-4'
+              data-header-title-avoid='true'
+            >
               <LanguageSwitch />
               <ThemeSwitch />
               <UserButton />


### PR DESCRIPTION
## Summary

- Adds a measured collision guard to the shared centered `HeaderTitle` so it hides when header actions would cover it.
- Marks right-side header control groups as title-avoid zones across routed pages.
- Extends Cypress coverage for both crowded and wide header layouts.

## Validation

- `npm run build` from `ui.web`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-page-header-title/spec.cy.ts -Browser electron`
- Push hook: OpenSpec validation and fast API docs smoke test

Closes #695.