### PR TITLE
#699 Rotate item photos

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1692,6 +1692,36 @@ paths:
       responses:
         "204":
           description: Primary set
+  /api/items/{itemID}/photos/{photoID}/rotate:
+    parameters:
+      - $ref: "#/components/parameters/ItemID"
+      - in: path
+        name: photoID
+        required: true
+        schema: { type: string }
+    put:
+      tags: [Collection]
+      summary: Rotate photo orientation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [direction]
+              properties:
+                direction:
+                  type: string
+                  enum: [left, right]
+      responses:
+        "200":
+          description: Rotated photo
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Photo"
+        "400":
+          $ref: "#/components/responses/Error"
   /api/items/{itemID}/photos/{photoID}/file:
     parameters:
       - $ref: "#/components/parameters/ItemID"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4160,6 +4160,31 @@ func New(cfg config.Config) (*App, error) {
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
+			if len(parts) == 4 && parts[3] == "rotate" {
+				photoID := strings.TrimSpace(parts[2])
+				if photoID == "" {
+					http.Error(w, `{"error":"invalid_photo_id"}`, http.StatusBadRequest)
+					return
+				}
+				if r.Method != http.MethodPut {
+					http.Error(w, `{"error":"method_not_allowed"}`, http.StatusMethodNotAllowed)
+					return
+				}
+				var req struct {
+					Direction string `json:"direction"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					http.Error(w, `{"error":"invalid_json"}`, http.StatusBadRequest)
+					return
+				}
+				rotated, err := mediaService.Rotate(r.Context(), itemID, photoID, req.Direction)
+				if err != nil {
+					http.Error(w, `{"error":"failed_to_rotate_photo"}`, http.StatusBadRequest)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(rotated)
+				return
+			}
 			if len(parts) == 4 && parts[3] == "file" {
 				photoID := strings.TrimSpace(parts[2])
 				if photoID == "" {

--- a/internal/app/openapi_parity_test.go
+++ b/internal/app/openapi_parity_test.go
@@ -77,6 +77,7 @@ func TestOpenAPIDocumentsRuntimeEndpoints(t *testing.T) {
 		"/api/items/{itemID}/photos/reorder",
 		"/api/items/{itemID}/photos/{photoID}",
 		"/api/items/{itemID}/photos/{photoID}/primary",
+		"/api/items/{itemID}/photos/{photoID}/rotate",
 		"/api/items/{itemID}/photos/{photoID}/file",
 		"/api/items/{itemID}/photos-rebuild",
 		"/api/barcodes/{barcode}",

--- a/internal/app/photos_api_test.go
+++ b/internal/app/photos_api_test.go
@@ -1,7 +1,11 @@
 package app
 
 import (
+	"bytes"
 	"encoding/json"
+	"image"
+	"image/color"
+	"image/jpeg"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -123,6 +127,53 @@ func TestPhotosReorderEndpoint(t *testing.T) {
 	}
 }
 
+func TestPhotosRotateEndpoint_UpdatesStoredOrientation(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	if _, err := a.db.Exec(`INSERT INTO canonical_items (id, brand, category, part_number, title) VALUES ('item-1','AFX','Slot Car','P-1','Car')`); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	body, contentType := buildMultipartPhoto(t, "wide.jpg", rectangularJPEG(t, 80, 32))
+	resp := doRequest(t, a, http.MethodPost, "/api/items/item-1/photos", body, map[string]string{"Content-Type": contentType})
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("upload status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode upload response: %v", err)
+	}
+
+	rotateRight := doRequest(t, a, http.MethodPut, "/api/items/item-1/photos/"+created.ID+"/rotate", strings.NewReader(`{"direction":"right"}`), map[string]string{"Content-Type": "application/json"})
+	if rotateRight.Code != http.StatusOK {
+		t.Fatalf("rotate right status = %d body=%s", rotateRight.Code, rotateRight.Body.String())
+	}
+	originalRight := doRequest(t, a, http.MethodGet, "/api/items/item-1/photos/"+created.ID+"/file?variant=original", nil, nil)
+	if originalRight.Code != http.StatusOK {
+		t.Fatalf("rotated original status = %d body=%s", originalRight.Code, originalRight.Body.String())
+	}
+	width, height := jpegDimensions(t, originalRight.Body.Bytes())
+	if width != 32 || height != 80 {
+		t.Fatalf("expected right-rotated dimensions 32x80, got %dx%d", width, height)
+	}
+
+	rotateLeft := doRequest(t, a, http.MethodPut, "/api/items/item-1/photos/"+created.ID+"/rotate", strings.NewReader(`{"direction":"left"}`), map[string]string{"Content-Type": "application/json"})
+	if rotateLeft.Code != http.StatusOK {
+		t.Fatalf("rotate left status = %d body=%s", rotateLeft.Code, rotateLeft.Body.String())
+	}
+	originalLeft := doRequest(t, a, http.MethodGet, "/api/items/item-1/photos/"+created.ID+"/file?variant=original", nil, nil)
+	if originalLeft.Code != http.StatusOK {
+		t.Fatalf("restored original status = %d body=%s", originalLeft.Code, originalLeft.Body.String())
+	}
+	width, height = jpegDimensions(t, originalLeft.Body.Bytes())
+	if width != 80 || height != 32 {
+		t.Fatalf("expected left-rotated dimensions 80x32, got %dx%d", width, height)
+	}
+}
+
 func TestPhotosUpload_UsesActiveProfileMediaDirectory(t *testing.T) {
 	t.Parallel()
 
@@ -241,4 +292,28 @@ func TestPhotosUpload_UsesActiveProfileMediaDirectory(t *testing.T) {
 	if !strings.HasPrefix(photoTwo.ThumbnailPath, profileTwoMediaDir) {
 		t.Fatalf("expected profile two thumbnail path in %s, got %s", profileTwoMediaDir, photoTwo.ThumbnailPath)
 	}
+}
+
+func rectangularJPEG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: uint8((x * 255) / width), G: uint8((y * 255) / height), B: 120, A: 255})
+		}
+	}
+	var b bytes.Buffer
+	if err := jpeg.Encode(&b, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("encode rectangular jpeg: %v", err)
+	}
+	return b.Bytes()
+}
+
+func jpegDimensions(t *testing.T, data []byte) (int, int) {
+	t.Helper()
+	cfg, err := jpeg.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode jpeg config: %v", err)
+	}
+	return cfg.Width, cfg.Height
 }

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	_ "image/png"
+	"image/png"
 	"io"
 	"math"
 	"os"
@@ -241,6 +241,55 @@ func (s *Service) Delete(ctx context.Context, itemID, photoID string) error {
 	return nil
 }
 
+func (s *Service) Rotate(ctx context.Context, itemID, photoID, direction string) (Photo, error) {
+	itemID = strings.TrimSpace(itemID)
+	photoID = strings.TrimSpace(photoID)
+	direction = strings.ToLower(strings.TrimSpace(direction))
+	if itemID == "" {
+		return Photo{}, fmt.Errorf("item_id is required")
+	}
+	if photoID == "" {
+		return Photo{}, fmt.Errorf("photo_id is required")
+	}
+	if direction != "left" && direction != "right" {
+		return Photo{}, fmt.Errorf("direction must be left or right")
+	}
+
+	p, err := s.GetByID(ctx, photoID)
+	if err != nil {
+		return Photo{}, err
+	}
+	if p.ItemID != itemID {
+		return Photo{}, fmt.Errorf("photo does not belong to item")
+	}
+
+	srcFile, err := os.Open(p.OriginalPath)
+	if err != nil {
+		return Photo{}, fmt.Errorf("open original image: %w", err)
+	}
+	src, format, err := image.Decode(srcFile)
+	closeErr := srcFile.Close()
+	if err != nil {
+		return Photo{}, fmt.Errorf("decode original image: %w", err)
+	}
+	if closeErr != nil {
+		return Photo{}, fmt.Errorf("close original image: %w", closeErr)
+	}
+
+	rotated := rotateImage(src, direction)
+	if err := encodeOriginalImage(p.OriginalPath, format, rotated); err != nil {
+		return Photo{}, err
+	}
+	if err := generateScaledJPEG(p.OriginalPath, p.PreviewPath, 1024); err != nil {
+		return Photo{}, fmt.Errorf("rebuild rotated preview: %w", err)
+	}
+	if err := generateScaledJPEG(p.OriginalPath, p.ThumbnailPath, 256); err != nil {
+		return Photo{}, fmt.Errorf("rebuild rotated thumbnail: %w", err)
+	}
+
+	return s.GetByID(ctx, photoID)
+}
+
 func (s *Service) RebuildThumbnails(ctx context.Context, itemID string) error {
 	photos, err := s.ListByItem(ctx, itemID)
 	if err != nil {
@@ -356,6 +405,56 @@ func (s *Service) Reorder(ctx context.Context, itemID string, orderedIDs []strin
 		return fmt.Errorf("commit reorder: %w", err)
 	}
 	return nil
+}
+
+func encodeOriginalImage(path, format string, img image.Image) error {
+	tmpPath := path + ".rotate-tmp"
+	outFile, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create rotated original: %w", err)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "png":
+		err = png.Encode(outFile, img)
+	default:
+		err = jpeg.Encode(outFile, img, &jpeg.Options{Quality: 90})
+	}
+	closeErr := outFile.Close()
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("encode rotated original: %w", err)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close rotated original: %w", closeErr)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace rotated original: %w", err)
+	}
+	return nil
+}
+
+func rotateImage(src image.Image, direction string) *image.RGBA {
+	b := src.Bounds()
+	w := b.Dx()
+	h := b.Dy()
+	if w <= 0 || h <= 0 {
+		return image.NewRGBA(image.Rect(0, 0, 1, 1))
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, h, w))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c := src.At(b.Min.X+x, b.Min.Y+y)
+			if direction == "left" {
+				dst.Set(y, w-1-x, c)
+			} else {
+				dst.Set(h-1-y, x, c)
+			}
+		}
+	}
+	return dst
 }
 
 func generateScaledJPEG(inputPath, outputPath string, maxSize int) error {

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
@@ -218,6 +218,12 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
         cy.get('[data-testid="inventory-photo-move-down"]')
           .should('have.attr', 'aria-label', 'Move card-one.jpg down')
           .and('not.contain.text', 'Move Down')
+        cy.get('[data-testid="inventory-photo-rotate-left"]')
+          .should('have.attr', 'aria-label', 'Rotate card-one.jpg left')
+          .and('not.contain.text', 'Rotate Left')
+        cy.get('[data-testid="inventory-photo-rotate-right"]')
+          .should('have.attr', 'aria-label', 'Rotate card-one.jpg right')
+          .and('not.contain.text', 'Rotate Right')
         cy.get('[data-testid="inventory-photo-set-primary"]')
           .should('have.attr', 'aria-label', 'Set card-one.jpg as primary')
           .and('not.contain.text', 'Set Primary')
@@ -226,6 +232,59 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
           .and('not.contain.text', 'Delete')
       }
     )
+  })
+
+  it('PHOTOS-MEDIA-004B rotates photos from the card controls and refreshes the preview', () => {
+    let listCall = 0
+    const photos = [
+      { id: 'rotate-p1', filename: 'rotate-one.jpg', is_primary: true },
+    ]
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-photo-rotate',
+            title: 'Photo Rotate Item',
+            status: 'active',
+            category: 'Cars',
+          },
+        ],
+      },
+    }).as('items')
+    cy.intercept('GET', '/api/items/item-photo-rotate/photos', (req) => {
+      listCall += 1
+      req.reply({
+        statusCode: 200,
+        body: { photos },
+      })
+    }).as('photos')
+    cy.intercept(
+      'PUT',
+      '/api/items/item-photo-rotate/photos/rotate-p1/rotate',
+      (req) => {
+        expect(req.body).to.deep.equal({ direction: 'right' })
+        req.reply({ statusCode: 200, body: { ...photos[0] } })
+      }
+    ).as('rotatePhoto')
+
+    signIn()
+    cy.wait('@items')
+    cy.wait('@photos')
+    openPhotosModal()
+
+    cy.contains('[data-testid="inventory-photo-row"]', 'rotate-one.jpg')
+      .find('[data-testid="inventory-photo-rotate-right"]')
+      .click()
+    cy.wait('@rotatePhoto')
+    cy.wait('@photos')
+    cy.wrap(null).then(() => {
+      expect(listCall).to.be.greaterThan(1)
+    })
+    cy.contains('[data-testid="inventory-photo-row"]', 'rotate-one.jpg')
+      .find('[data-testid="inventory-photo-thumb"] img')
+      .should('have.attr', 'src')
+      .and('include', 'v=')
   })
 
   it('PHOTOS-MEDIA-005 keeps photos scoped to the currently selected item when switching rows', () => {

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -19,6 +19,8 @@ import {
   Images,
   ListChecks,
   Plus,
+  RotateCcw,
+  RotateCw,
   Star,
   Trash2,
 } from 'lucide-react'
@@ -1044,6 +1046,7 @@ export function Collection({
   const [photosLoading, setPhotosLoading] = useState(false)
   const [photosError, setPhotosError] = useState<string | null>(null)
   const [photosBusy, setPhotosBusy] = useState(false)
+  const [photoImageVersion, setPhotoImageVersion] = useState(0)
   const [photoRebuildError, setPhotoRebuildError] = useState<string | null>(
     null
   )
@@ -2657,6 +2660,38 @@ export function Collection({
     [loadInventoryPhotos, selectedItemID]
   )
 
+  const handleRotatePhoto = useCallback(
+    async (photoID: string, direction: 'left' | 'right') => {
+      if (!selectedItemID || !photoID) {
+        return
+      }
+      setPhotosBusy(true)
+      setPhotosError(null)
+      try {
+        const response = await fetch(
+          `/api/items/${encodeURIComponent(
+            selectedItemID
+          )}/photos/${encodeURIComponent(photoID)}/rotate`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ direction }),
+          }
+        )
+        if (!response.ok) {
+          throw new Error(`rotate_photo_${response.status}`)
+        }
+        setPhotoImageVersion((version) => version + 1)
+        await loadInventoryPhotos()
+      } catch {
+        setPhotosError('Unable to rotate this photo. Retry this action.')
+      } finally {
+        setPhotosBusy(false)
+      }
+    },
+    [loadInventoryPhotos, selectedItemID]
+  )
+
   const handleReorderPhotos = useCallback(
     async (photoID: string, direction: 'up' | 'down') => {
       if (!selectedItemID || !photoID) {
@@ -4217,7 +4252,9 @@ export function Collection({
                                   <img
                                     src={`/api/items/${encodeURIComponent(
                                       selectedItemID
-                                    )}/photos/${encodeURIComponent(photo.id)}/file?variant=preview`}
+                                    )}/photos/${encodeURIComponent(
+                                      photo.id
+                                    )}/file?variant=preview&v=${photoImageVersion}`}
                                     alt={photo.filename}
                                     className='h-36 w-full object-cover'
                                   />
@@ -4277,6 +4314,46 @@ export function Collection({
                                       }
                                     >
                                       <ArrowDown
+                                        className='size-4'
+                                        aria-hidden
+                                      />
+                                    </Button>
+                                    <Button
+                                      size='icon'
+                                      variant='outline'
+                                      className='size-8'
+                                      data-testid='inventory-photo-rotate-left'
+                                      aria-label={`Rotate ${photo.filename} left`}
+                                      title={`Rotate ${photo.filename} left`}
+                                      onClick={() =>
+                                        void handleRotatePhoto(
+                                          photo.id,
+                                          'left'
+                                        )
+                                      }
+                                      disabled={photosBusy}
+                                    >
+                                      <RotateCcw
+                                        className='size-4'
+                                        aria-hidden
+                                      />
+                                    </Button>
+                                    <Button
+                                      size='icon'
+                                      variant='outline'
+                                      className='size-8'
+                                      data-testid='inventory-photo-rotate-right'
+                                      aria-label={`Rotate ${photo.filename} right`}
+                                      title={`Rotate ${photo.filename} right`}
+                                      onClick={() =>
+                                        void handleRotatePhoto(
+                                          photo.id,
+                                          'right'
+                                        )
+                                      }
+                                      disabled={photosBusy}
+                                    >
+                                      <RotateCw
                                         className='size-4'
                                         aria-hidden
                                       />
@@ -4625,7 +4702,9 @@ export function Collection({
               <img
                 src={`/api/items/${encodeURIComponent(
                   selectedItemID
-                )}/photos/${encodeURIComponent(selectedPhoto.id)}/file?variant=original`}
+                )}/photos/${encodeURIComponent(
+                  selectedPhoto.id
+                )}/file?variant=original&v=${photoImageVersion}`}
                 alt={selectedPhoto.filename}
                 className='max-h-[70vh] w-full rounded-md object-contain'
               />


### PR DESCRIPTION
## Summary
- adds a real photo rotation API that rewrites the stored original and regenerates preview/thumbnail derivatives
- adds rotate-left and rotate-right icon controls to each inventory photo card
- cache-busts preview/fullscreen image URLs after rotation so the corrected orientation appears immediately
- documents the rotate endpoint in OpenAPI

## Validation
- red first: Go rotate endpoint test returned 404 before implementation
- red first: Cypress photo card tests failed because rotate controls were missing
- go test ./internal/app -run "TestPhotosRotateEndpoint_UpdatesStoredOrientation|TestOpenAPIDocumentsRuntimeEndpoints" -count=1
- go test ./internal/media -count=1
- npm run build --prefix ui.web
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts -Browser electron
- pre-push OpenSpec validation
- pre-push fast API docs smoke test

Closes #699