### PR TITLE
#701 Create inventory items from header media actions

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts
@@ -7,7 +7,7 @@ describe('inventory barcode modal', () => {
     })
   }
 
-  it('opens item-scoped barcodes from page and row actions without inline barcodes section', () => {
+  it('opens item-scoped barcodes from row actions without inline barcodes section', () => {
     cy.intercept('GET', '/api/items', {
       statusCode: 200,
       body: {
@@ -51,7 +51,9 @@ describe('inventory barcode modal', () => {
 
     cy.get('[data-testid="inventory-barcodes-section"]').should('not.exist')
 
-    cy.get('[data-testid="inventory-barcodes-action"]').click()
+    cy.get(
+      '[data-testid="inventory-item-row-item-barcode-alpha"] [data-testid="inventory-row-barcodes-action"]'
+    ).click()
     cy.get('[data-testid="inventory-barcodes-dialog"]')
       .should('be.visible')
       .and('contain', 'Barcode Alpha')

--- a/ui.web/cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts
@@ -7,7 +7,7 @@ describe('inventory photo modal', () => {
     })
   }
 
-  it('opens item-scoped photos from page and row actions without inline photos section', () => {
+  it('opens item-scoped photos from row actions without inline photos section', () => {
     cy.intercept('GET', '/api/items', {
       statusCode: 200,
       body: {
@@ -52,7 +52,9 @@ describe('inventory photo modal', () => {
 
     cy.get('[data-testid="inventory-photos-section"]').should('not.exist')
 
-    cy.get('[data-testid="inventory-photos-action"]').click()
+    cy.get(
+      '[data-testid="inventory-item-row-item-photo-alpha"] [data-testid="inventory-row-photos-action"]'
+    ).click()
     cy.get('[data-testid="inventory-photos-dialog"]')
       .should('be.visible')
       .and('contain', 'Photo Alpha')

--- a/ui.web/cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts
@@ -106,8 +106,12 @@ describe("inventory responsive table-first redesign", () => {
     cy.get('[data-testid="inventory-collection-filter-select"]').select("Store 1");
     cy.get('[data-testid="inventory-collection-filter-selected"]').should("contain", "Store 1");
     cy.get('[data-testid="collection-active-context"]').should("contain", "Store 1");
+    cy.get('[data-testid="inventory-collection-filter-select"]').select("All Items");
+    cy.get('[data-testid="inventory-collection-filter-selected"]').should("contain", "All Items");
 
-    cy.get('[data-testid="inventory-photos-action"]').click();
+    cy.get(
+      '[data-testid="inventory-item-row-item-responsive-alpha"] [data-testid="inventory-row-photos-action"]'
+    ).click();
     cy.get('[data-testid="inventory-photos-dialog"]')
       .should("be.visible")
       .and("contain", "Responsive Alpha");
@@ -117,7 +121,9 @@ describe("inventory responsive table-first redesign", () => {
     cy.get('[data-testid="inventory-photos-dialog-close"]').click();
     cy.get('[data-testid="inventory-photos-dialog"]').should("not.exist");
 
-    cy.get('[data-testid="inventory-barcodes-action"]').click();
+    cy.get(
+      '[data-testid="inventory-item-row-item-responsive-alpha"] [data-testid="inventory-row-barcodes-action"]'
+    ).click();
     cy.get('[data-testid="inventory-barcodes-dialog"]')
       .should("be.visible")
       .and("contain", "Responsive Alpha");

--- a/ui.web/cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts
@@ -41,7 +41,9 @@ describe('MOBILE-CAMERA-CAPTURE', () => {
     cy.wait('@items')
     cy.wait('@photos')
     cy.wait('@activeProfile')
-    cy.get('[data-testid="inventory-photos-action"]').click()
+    cy.get(
+      '[data-testid="inventory-item-row-item-camera-1"] [data-testid="inventory-row-photos-action"]'
+    ).click()
     cy.get('[data-testid="inventory-photos-dialog"]').should('be.visible')
   }
 

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -245,6 +245,129 @@ describe("inventory-management", () => {
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
   });
 
+  it("UI-SCREEN-INVENTORY-ITEMS-007A creates a new item from the header Photos action", () => {
+    const items: Array<{
+      id: string;
+      part_number: string;
+      title: string;
+      status: string;
+      category: string;
+    }> = [];
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
+    }).as("itemsPhotoCreate");
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body).to.include({
+        part_number: "PN-PHOTO-NEW",
+        title: "Photo Created Item",
+      });
+      const created = {
+        id: "item-photo-new",
+        part_number: req.body.part_number,
+        title: req.body.title,
+        status: "active",
+        category: "General",
+      };
+      items.push(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createPhotoItem");
+    cy.intercept("POST", "/api/items/item-photo-new/photos", (req) => {
+      req.reply({
+        statusCode: 201,
+        body: {
+          id: "photo-new-1",
+          filename: "new-inventory-photo.jpg",
+          is_primary: true,
+        },
+      });
+    }).as("uploadNewItemPhoto");
+
+    signIn();
+    cy.wait("@itemsPhotoCreate");
+
+    cy.get('[data-testid="inventory-photos-action"]').click();
+    cy.get('[data-testid="inventory-item-create-dialog"]').should("be.visible");
+    cy.get('[data-testid="inventory-item-editor-mode"]').should(
+      "contain",
+      "Creating new item from photo"
+    );
+    cy.get('[data-testid="inventory-create-photo-input"]').selectFile({
+      contents: Cypress.Buffer.from("new-item-photo-binary"),
+      fileName: "new-inventory-photo.jpg",
+      mimeType: "image/jpeg",
+    });
+    cy.get('[data-testid="inventory-item-part-number"]').type("PN-PHOTO-NEW");
+    cy.get('[data-testid="inventory-item-title"]').type("Photo Created Item");
+    cy.get('[data-testid="inventory-item-create-submit"]').click();
+
+    cy.wait("@createPhotoItem");
+    cy.wait("@uploadNewItemPhoto");
+    cy.wait("@itemsPhotoCreate");
+    cy.get('[data-testid="inventory-item-create-dialog"]').should("not.exist");
+    cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-PHOTO-NEW");
+    cy.contains("Photo Created Item").should("be.visible");
+  });
+
+  it("UI-SCREEN-INVENTORY-ITEMS-007B creates a new item from the header Barcodes action", () => {
+    const items: Array<{
+      id: string;
+      part_number: string;
+      title: string;
+      status: string;
+      category: string;
+    }> = [];
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
+    }).as("itemsBarcodeCreate");
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body).to.include({
+        part_number: "PN-BARCODE-NEW",
+        title: "Barcode Created Item",
+      });
+      const created = {
+        id: "item-barcode-new",
+        part_number: req.body.part_number,
+        title: req.body.title,
+        status: "active",
+        category: "General",
+      };
+      items.push(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createBarcodeItem");
+    cy.intercept("POST", "/api/items/item-barcode-new/barcodes", (req) => {
+      expect(req.body).to.deep.equal({ barcode: "012345678905" });
+      req.reply({
+        statusCode: 201,
+        body: {
+          id: "barcode-new-1",
+          item_id: "item-barcode-new",
+          barcode: "012345678905",
+        },
+      });
+    }).as("attachNewItemBarcode");
+
+    signIn();
+    cy.wait("@itemsBarcodeCreate");
+
+    cy.get('[data-testid="inventory-barcodes-action"]').click();
+    cy.get('[data-testid="inventory-item-create-dialog"]').should("be.visible");
+    cy.get('[data-testid="inventory-item-editor-mode"]').should(
+      "contain",
+      "Creating new item from barcode"
+    );
+    cy.get('[data-testid="inventory-create-barcode-input"]').type("012345678905");
+    cy.get('[data-testid="inventory-item-part-number"]').type("PN-BARCODE-NEW");
+    cy.get('[data-testid="inventory-item-title"]').type("Barcode Created Item");
+    cy.get('[data-testid="inventory-item-create-submit"]').click();
+
+    cy.wait("@createBarcodeItem");
+    cy.wait("@attachNewItemBarcode");
+    cy.wait("@itemsBarcodeCreate");
+    cy.get('[data-testid="inventory-item-create-dialog"]').should("not.exist");
+    cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-BARCODE-NEW");
+    cy.contains("Barcode Created Item").should("be.visible");
+  });
+
   it("UI-SCREEN-INVENTORY-ITEMS-006 creates collection from the compact filter and auto-selects it", () => {
     cy.intercept("GET", "/api/items", {
       statusCode: 200,
@@ -364,7 +487,9 @@ describe("inventory-management", () => {
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
     cy.contains("Created Inventory Item").should("be.visible");
 
-    cy.get('[data-testid="inventory-photos-action"]').click();
+    cy.get(
+      '[data-testid="inventory-item-row-item-created-1"] [data-testid="inventory-row-photos-action"]'
+    ).click();
     cy.get('[data-testid="inventory-photos-dialog"]').should("be.visible");
     cy.get('[data-testid="inventory-photo-upload-input"]').selectFile({
       contents: Cypress.Buffer.from("created-photo-binary"),
@@ -391,7 +516,9 @@ describe("inventory-management", () => {
     cy.get('[data-testid="inventory-item-editor-panel"]').should("not.exist");
     cy.contains("Created Inventory Item Updated").should("be.visible");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
-    cy.get('[data-testid="inventory-photos-action"]').click();
+    cy.get(
+      '[data-testid="inventory-item-row-item-created-1"] [data-testid="inventory-row-photos-action"]'
+    ).click();
     cy.get('[data-testid="inventory-photos-dialog"]').should("be.visible");
     cy.contains('[data-testid="inventory-photo-row"]', "created-photo.jpg").should(
       "be.visible"

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts
@@ -34,7 +34,10 @@ describe('UI-SCREEN-INVENTORY-PHOTOS', () => {
   }
 
   function openPhotosModal() {
-    cy.get('[data-testid="inventory-photos-action"]').click()
+    cy.get('[data-testid^="inventory-item-row-"]')
+      .first()
+      .find('[data-testid="inventory-row-photos-action"]')
+      .click()
     cy.get('[data-testid="inventory-photos-dialog"]').should('be.visible')
     cy.get('[data-testid="inventory-photos-panel"]').should('be.visible')
   }

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -117,6 +117,8 @@ type InventoryItemDraft = {
   description: string
 }
 
+type InventoryCreateIntent = 'manual' | 'photo' | 'barcode'
+
 type AISuggestion = {
   part_number?: string
   brand?: string
@@ -1069,6 +1071,12 @@ export function Collection({
   const [itemDraft, setItemDraft] = useState<InventoryItemDraft>(
     emptyInventoryItemDraft
   )
+  const [itemCreateIntent, setItemCreateIntent] =
+    useState<InventoryCreateIntent>('manual')
+  const [itemCreatePhotoFile, setItemCreatePhotoFile] = useState<File | null>(
+    null
+  )
+  const [itemCreateBarcodeInput, setItemCreateBarcodeInput] = useState('')
   const [itemSaveBusy, setItemSaveBusy] = useState(false)
   const [itemSaveError, setItemSaveError] = useState<string | null>(null)
   const [itemSaveSuccess, setItemSaveSuccess] = useState<string | null>(null)
@@ -1135,15 +1143,39 @@ export function Collection({
     selectedItemIDRef.current = selectedItemID
   }, [selectedItemID])
 
-  const startCreateItem = useCallback(() => {
-    setItemEditorMode('create')
-    setItemEditorSurface('dialog')
-    setItemDraft(emptyInventoryItemDraft())
-    setItemSaveError(null)
-    setItemSaveSuccess(null)
-    selectInventoryItem(null)
-    setItemEditorOpen(true)
-  }, [selectInventoryItem])
+  const resetCreateAttachments = useCallback(() => {
+    setItemCreateIntent('manual')
+    setItemCreatePhotoFile(null)
+    setItemCreateBarcodeInput('')
+  }, [])
+
+  const startCreateItem = useCallback(
+    (intent: InventoryCreateIntent = 'manual') => {
+      setItemEditorMode('create')
+      setItemEditorSurface('dialog')
+      setItemDraft(emptyInventoryItemDraft())
+      setItemCreateIntent(intent)
+      setItemCreatePhotoFile(null)
+      setItemCreateBarcodeInput('')
+      setItemSaveError(null)
+      setItemSaveSuccess(null)
+      selectInventoryItem(null)
+      setItemEditorOpen(true)
+    },
+    [selectInventoryItem]
+  )
+
+  const startCreateItemFromPhoto = useCallback(() => {
+    startCreateItem('photo')
+  }, [startCreateItem])
+
+  const startCreateItemFromBarcode = useCallback(() => {
+    startCreateItem('barcode')
+  }, [startCreateItem])
+
+  const startManualCreateItem = useCallback(() => {
+    startCreateItem('manual')
+  }, [startCreateItem])
 
   const openInventoryItemEditor = useCallback(
     (item: InventoryItem | null) => {
@@ -2532,6 +2564,23 @@ export function Collection({
       setItemSaveSuccess(null)
       return
     }
+    if (wasCreateMode && itemCreateIntent === 'photo' && !itemCreatePhotoFile) {
+      setItemSaveError('Choose a photo before creating from the Photos action.')
+      setItemSaveSuccess(null)
+      return
+    }
+    const pendingCreateBarcode = itemCreateBarcodeInput.trim()
+    if (
+      wasCreateMode &&
+      itemCreateIntent === 'barcode' &&
+      pendingCreateBarcode === ''
+    ) {
+      setItemSaveError(
+        'Enter a barcode before creating from the Barcodes action.'
+      )
+      setItemSaveSuccess(null)
+      return
+    }
     setItemSaveBusy(true)
     setItemSaveError(null)
     setItemSaveSuccess(null)
@@ -2551,20 +2600,61 @@ export function Collection({
       }
       const saved = (await response.json()) as { id?: string }
       const savedID = saved.id?.trim() ?? selectedItemID
+      if (wasCreateMode && itemCreateIntent === 'photo' && itemCreatePhotoFile) {
+        const photoBody = new FormData()
+        photoBody.append('file', itemCreatePhotoFile)
+        const photoResponse = await fetch(
+          `/api/items/${encodeURIComponent(savedID)}/photos`,
+          {
+            method: 'POST',
+            body: photoBody,
+          }
+        )
+        if (!photoResponse.ok) {
+          throw new Error(`create_item_photo_${photoResponse.status}`)
+        }
+      }
+      if (wasCreateMode && itemCreateIntent === 'barcode') {
+        const barcodeResponse = await fetch(
+          `/api/items/${encodeURIComponent(savedID)}/barcodes`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ barcode: pendingCreateBarcode }),
+          }
+        )
+        if (!barcodeResponse.ok) {
+          throw new Error(`create_item_barcode_${barcodeResponse.status}`)
+        }
+      }
       setItemEditorMode('edit')
       setItemSaveSuccess(
-        wasCreateMode
-          ? 'Item created and selected for follow-up media attach.'
-          : 'Item changes saved and reloaded from the API.'
+        wasCreateMode && itemCreateIntent === 'photo'
+          ? 'Item created with photo and selected.'
+          : wasCreateMode && itemCreateIntent === 'barcode'
+            ? 'Item created with barcode and selected.'
+            : wasCreateMode
+              ? 'Item created and selected for follow-up media attach.'
+              : 'Item changes saved and reloaded from the API.'
       )
       await loadInventoryItems(savedID)
       setItemEditorOpen(false)
+      resetCreateAttachments()
     } catch {
       setItemSaveError('Inventory save failed. Review the fields and retry.')
     } finally {
       setItemSaveBusy(false)
     }
-  }, [itemDraft, itemEditorMode, loadInventoryItems, selectedItemID])
+  }, [
+    itemCreateBarcodeInput,
+    itemCreateIntent,
+    itemCreatePhotoFile,
+    itemDraft,
+    itemEditorMode,
+    loadInventoryItems,
+    resetCreateAttachments,
+    selectedItemID,
+  ])
 
   const handlePhotoUpload = useCallback(
     async (file: File | null) => {
@@ -3109,13 +3199,9 @@ export function Collection({
                   variant='outline'
                   className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
                   data-testid='inventory-barcodes-action'
-                  aria-label='Manage barcodes'
-                  title='Barcodes'
-                  onClick={() =>
-                    openInventoryBarcodesForItem(
-                      selectedInventoryItem ?? inventoryItems[0] ?? null
-                    )
-                  }
+                  aria-label='Create item from barcode'
+                  title='Create item from barcode'
+                  onClick={startCreateItemFromBarcode}
                 >
                   <Barcode className='size-4 2xl:mr-2' aria-hidden />
                   <span className='hidden 2xl:inline'>Barcodes</span>
@@ -3125,13 +3211,9 @@ export function Collection({
                   variant='outline'
                   className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
                   data-testid='inventory-photos-action'
-                  aria-label='Manage photos'
-                  title='Photos'
-                  onClick={() =>
-                    openInventoryPhotosForItem(
-                      selectedInventoryItem ?? inventoryItems[0] ?? null
-                    )
-                  }
+                  aria-label='Create item from photo'
+                  title='Create item from photo'
+                  onClick={startCreateItemFromPhoto}
                 >
                   <Images className='size-4 2xl:mr-2' aria-hidden />
                   <span className='hidden 2xl:inline'>Photos</span>
@@ -3144,7 +3226,7 @@ export function Collection({
               data-testid='inventory-new-action'
               aria-label='New item'
               title='New'
-              onClick={startCreateItem}
+              onClick={startManualCreateItem}
             >
               <Plus className='size-4 2xl:mr-2' aria-hidden />
               <span className='hidden 2xl:inline'>New</span>
@@ -3166,7 +3248,7 @@ export function Collection({
               <DropdownMenuContent align='end'>
                 <DropdownMenuItem
                   data-testid='inventory-create-menu-item'
-                  onClick={startCreateItem}
+                  onClick={startManualCreateItem}
                 >
                   New Item
                 </DropdownMenuItem>
@@ -3683,6 +3765,7 @@ export function Collection({
                       setItemEditorOpen(open)
                       if (!open) {
                         setItemSaveError(null)
+                        resetCreateAttachments()
                       }
                     }}
                   >
@@ -3698,7 +3781,11 @@ export function Collection({
                         <DialogHeader>
                           <DialogTitle>
                             {itemEditorMode === 'create'
-                              ? 'Create Item'
+                              ? itemCreateIntent === 'photo'
+                                ? 'Create Item From Photo'
+                                : itemCreateIntent === 'barcode'
+                                  ? 'Create Item From Barcode'
+                                  : 'Create Item'
                               : 'Edit Item'}
                           </DialogTitle>
                         </DialogHeader>
@@ -3707,9 +3794,71 @@ export function Collection({
                           data-testid='inventory-item-editor-mode'
                         >
                           {itemEditorMode === 'create'
-                            ? 'Creating new item draft.'
+                            ? itemCreateIntent === 'photo'
+                              ? 'Creating new item from photo.'
+                              : itemCreateIntent === 'barcode'
+                                ? 'Creating new item from barcode.'
+                                : 'Creating new item draft.'
                             : `Editing selected item: ${selectedItemContext}`}
                         </p>
+                        {itemEditorMode === 'create' &&
+                        itemCreateIntent !== 'manual' ? (
+                          <div
+                            className='rounded-md border bg-muted/30 p-3'
+                            data-testid='inventory-create-media-panel'
+                          >
+                            {itemCreateIntent === 'photo' ? (
+                              <div className='space-y-2'>
+                                <label
+                                  className='text-sm font-medium'
+                                  htmlFor='inventory-create-photo-input'
+                                >
+                                  Photo
+                                </label>
+                                <input
+                                  id='inventory-create-photo-input'
+                                  type='file'
+                                  accept='image/*'
+                                  data-testid='inventory-create-photo-input'
+                                  onChange={(event) =>
+                                    setItemCreatePhotoFile(
+                                      event.target.files?.[0] ?? null
+                                    )
+                                  }
+                                />
+                                <p className='text-xs text-muted-foreground'>
+                                  This photo will be uploaded after the item is
+                                  created.
+                                </p>
+                              </div>
+                            ) : null}
+                            {itemCreateIntent === 'barcode' ? (
+                              <div className='space-y-2'>
+                                <label
+                                  className='text-sm font-medium'
+                                  htmlFor='inventory-create-barcode-input'
+                                >
+                                  Barcode
+                                </label>
+                                <Input
+                                  id='inventory-create-barcode-input'
+                                  data-testid='inventory-create-barcode-input'
+                                  placeholder='Enter barcode for the new item'
+                                  value={itemCreateBarcodeInput}
+                                  onChange={(event) =>
+                                    setItemCreateBarcodeInput(
+                                      event.target.value
+                                    )
+                                  }
+                                />
+                                <p className='text-xs text-muted-foreground'>
+                                  This barcode will be attached after the item
+                                  is created.
+                                </p>
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null}
                         <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
                           <div className='space-y-2'>
                             <label


### PR DESCRIPTION
## Summary
- changes inventory header Photos/Barcodes actions to start create-item flows
- lets the Photos flow choose a pending image and upload it immediately after the item is created
- lets the Barcodes flow enter a pending barcode and attach it immediately after the item is created
- keeps row-level photo/barcode buttons as the manage-existing-item path
- updates related Cypress specs to use row-level media controls where appropriate

## Validation
- red first: new Cypress tests failed because header Photos/Barcodes did not open create-item dialog
- npm run build --prefix ui.web
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-photos/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-photo-modal/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-barcode-modal/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/mobile-camera-capture/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts -Browser electron
- pre-push OpenSpec validation
- pre-push fast API docs smoke test

Note: one attempted parallel Cypress run caused a shared test-server collision; the affected suite passed when rerun serially.

Closes #701