### PR TITLE
#705 feat(inventory): move paste create into modal

### DIFF
--- a/ui.web/cypress/e2e/general/ui-page-header-title/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-page-header-title/spec.cy.ts
@@ -34,19 +34,37 @@ describe('ui-page-header-title', () => {
     })
   }
 
+  function assertInventoryHeaderTitleBetweenSearchAndActions() {
+    cy.get('[data-testid="inventory-header-title"]')
+      .should('be.visible')
+      .and('contain', 'Inventory')
+    cy.get('[data-testid="inventory-page-icon"]').should('be.visible')
+    cy.get('[data-testid="inventory-header-title"]').then(($title) => {
+      const titleRect = $title[0].getBoundingClientRect()
+      cy.contains('button', 'Search').then(($search) => {
+        const searchRect = $search[0].getBoundingClientRect()
+        expect(titleRect.left).to.be.greaterThan(searchRect.right)
+      })
+      cy.get('[data-testid="inventory-global-header-actions"]').then(
+        ($actions) => {
+          const actionsRect = $actions[0].getBoundingClientRect()
+          expect(titleRect.right).to.be.lessThan(actionsRect.left - 8)
+        }
+      )
+    })
+  }
+
   beforeEach(() => {
     cy.clearCookies()
     cy.clearLocalStorage()
   })
 
-  it('UI-PAGE-HEADER-TITLE-001 hides crowded titles instead of overlapping header actions', () => {
+  it('UI-PAGE-HEADER-TITLE-001 keeps Inventory title visible between search and compact actions', () => {
     cy.viewport(1240, 720)
 
     signInTo('/inventory/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
-    cy.get('[data-testid="inventory-header-title"]')
-      .should('have.attr', 'data-crowded', 'true')
-      .and('not.be.visible')
+    assertInventoryHeaderTitleBetweenSearchAndActions()
     cy.get('[data-testid="inventory-global-header-actions"]').should('be.visible')
     cy.get('header').should('not.contain', 'Active:')
     cy.get('header').should('not.contain', 'Collection:')
@@ -58,8 +76,7 @@ describe('ui-page-header-title', () => {
 
     signInTo('/inventory/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
-    assertCenteredHeader('inventory', 'Inventory')
-    assertHeaderTitleDoesNotOverlapActions('inventory')
+    assertInventoryHeaderTitleBetweenSearchAndActions()
 
     cy.visit('/collections/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/collections\/?$/)

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-ai-assist/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-ai-assist/spec.cy.ts
@@ -1,7 +1,7 @@
-describe('UI-SCREEN-INVENTORY-QUICK-CREATE', () => {
+describe('UI-SCREEN-INVENTORY-PASTE-CREATE', () => {
   function signIn() {
     cy.visit('/sign-in?redirect=%2Finventory%2F')
-    cy.get('input[name="email"]').clear().type('e2e-quick-create@example.com')
+    cy.get('input[name="email"]').clear().type('e2e-paste-create@example.com')
     cy.get('input[name="password"]').clear().type('password123')
     cy.contains('button', 'Sign in').click()
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
@@ -10,11 +10,64 @@ describe('UI-SCREEN-INVENTORY-QUICK-CREATE', () => {
   beforeEach(() => {
     cy.intercept('GET', '/api/profiles/active', {
       statusCode: 200,
-      body: { id: 'profile-quick-create-1', name: 'Quick Create Profile' },
+      body: { id: 'profile-paste-create-1', name: 'Paste Create Profile' },
     }).as('activeProfile')
   })
 
-  it('UI-SCREEN-INVENTORY-QUICK-CREATE-001 creates an item from pasted URL or text on the Collection Browser row', () => {
+  it('UI-SCREEN-INVENTORY-PASTE-CREATE-001 keeps Inventory title visible and header actions compact', () => {
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-header-compact',
+            part_number: 'PN-HEADER',
+            title: 'Header Compact Item',
+            status: 'active',
+            category: 'General',
+          },
+        ],
+      },
+    }).as('items')
+
+    signIn()
+    cy.wait('@items')
+    cy.wait('@activeProfile')
+
+    cy.get('[data-testid="inventory-header-title"]')
+      .should('be.visible')
+      .and('contain', 'Inventory')
+    cy.get('[data-testid="inventory-header-title"]').then(($title) => {
+      const titleRect = $title[0].getBoundingClientRect()
+      cy.contains('button', 'Search').then(($search) => {
+        const searchRect = $search[0].getBoundingClientRect()
+        expect(titleRect.left).to.be.greaterThan(searchRect.right)
+      })
+      cy.get('[data-testid="inventory-global-header-actions"]').then(($actions) => {
+        const actionsRect = $actions[0].getBoundingClientRect()
+        expect(titleRect.right).to.be.lessThan(actionsRect.left)
+      })
+    })
+
+    cy.get('[data-testid="inventory-ai-assist-section"]').should('not.exist')
+    cy.get('[data-testid="inventory-quick-create"]').should('not.exist')
+    cy.contains('Collection Browser')
+      .closest('[data-slot="card"]')
+      .within(() => {
+        cy.get('[data-testid="inventory-quick-create-input"]').should('not.exist')
+      })
+
+    cy.get('[data-testid="inventory-paste-action"]')
+      .should('be.visible')
+      .and('have.attr', 'aria-label', 'Paste URL or text into a new item')
+      .and('not.contain', 'Paste')
+    cy.get('[data-testid="inventory-barcodes-action"]').and('not.contain', 'Barcodes')
+    cy.get('[data-testid="inventory-photos-action"]').and('not.contain', 'Photos')
+    cy.get('[data-testid="inventory-new-action"]').and('not.contain', 'New')
+    cy.get('[data-testid="inventory-create-menu-trigger"]').and('not.contain', 'Create')
+  })
+
+  it('UI-SCREEN-INVENTORY-PASTE-CREATE-002 opens create modal from header paste and processes clipboard URL into editable fields', () => {
     const items: Array<{
       id: string
       part_number: string
@@ -23,15 +76,7 @@ describe('UI-SCREEN-INVENTORY-QUICK-CREATE', () => {
       category: string
       brand?: string
       description?: string
-    }> = [
-      {
-        id: 'item-existing-quick',
-        part_number: 'PN-EXISTING',
-        title: 'Existing Quick Item',
-        status: 'active',
-        category: 'General',
-      },
-    ]
+    }> = []
 
     cy.intercept('GET', '/api/items', (req) => {
       req.reply({ statusCode: 200, body: { items } })
@@ -45,9 +90,15 @@ describe('UI-SCREEN-INVENTORY-QUICK-CREATE', () => {
         title: 'example.test afx-22073',
         brand: 'Unknown',
         category: 'General',
-        description: 'Source URL: https://example.test/listings/afx-22073.jpg',
       })
       expect(req.body.part_number).to.match(/^URL-EXAMPLE-TEST-LISTINGS-AFX-22073/)
+      expect(req.body.description).to.contain(
+        'Source link: https://example.test/listings/afx-22073.jpg'
+      )
+      expect(req.body.description).to.contain('Creation history:')
+      expect(req.body.description).to.contain(
+        '- Pasted URL: https://example.test/listings/afx-22073.jpg'
+      )
       const created = {
         id: 'item-url-created',
         part_number: req.body.part_number,
@@ -59,44 +110,51 @@ describe('UI-SCREEN-INVENTORY-QUICK-CREATE', () => {
       }
       items.unshift(created)
       req.reply({ statusCode: 201, body: created })
-    }).as('createQuickItem')
+    }).as('createPastedItem')
 
     signIn()
     cy.wait('@items')
     cy.wait('@activeProfile')
 
-    cy.get('[data-testid="inventory-ai-assist-section"]').should('not.exist')
-    cy.contains('Collection Browser')
-      .closest('[data-slot="card"]')
-      .within(() => {
-        cy.get('[data-testid="inventory-quick-create"]').should('be.visible')
-        cy.get('[data-testid="inventory-quick-create-paste"]')
-          .should('be.visible')
-          .and('contain', 'Paste')
-        cy.get('[data-testid="inventory-quick-create-input"]')
-          .should('be.visible')
-          .type('https://example.test/listings/afx-22073.jpg')
-        cy.get('[data-testid="inventory-quick-create-save"]')
-          .should('be.visible')
-          .and('contain', 'Save')
-          .click()
+    cy.window().then((win) => {
+      const readText = cy
+        .stub()
+        .resolves('https://example.test/listings/afx-22073.jpg')
+      Object.defineProperty(win.navigator, 'clipboard', {
+        value: { readText },
+        configurable: true,
       })
+    })
 
-    cy.wait('@createQuickItem')
+    cy.get('[data-testid="inventory-paste-action"]').click()
+    cy.get('[data-testid="inventory-item-create-dialog"]').should('be.visible')
+    cy.get('[data-testid="inventory-create-paste-input"]').should(
+      'have.value',
+      'https://example.test/listings/afx-22073.jpg'
+    )
+    cy.get('[data-testid="inventory-item-title"]').should(
+      'have.value',
+      'example.test afx-22073'
+    )
+    cy.get('[data-testid="inventory-item-description"]')
+      .should('contain.value', 'Source link:')
+      .and('contain.value', 'Creation history:')
+
+    cy.get('[data-testid="inventory-item-create-submit"]').click()
+    cy.wait('@createPastedItem')
     cy.wait('@items')
     cy.wait('@urlPhotos')
     cy.contains('example.test afx-22073').should('be.visible')
-    cy.get('[data-testid="collection-selected-item"]').should('contain', 'URL-')
-    cy.get('[data-testid="inventory-quick-create-input"]').should('have.value', '')
   })
 
-  it('UI-SCREEN-INVENTORY-QUICK-CREATE-002 supports clipboard paste and validates empty saves', () => {
+  it('UI-SCREEN-INVENTORY-PASTE-CREATE-003 processes additional prompts into creation history before save', () => {
     const items: Array<{
       id: string
       part_number: string
       title: string
       status: string
       category: string
+      description?: string
     }> = []
 
     cy.intercept('GET', '/api/items', (req) => {
@@ -111,45 +169,53 @@ describe('UI-SCREEN-INVENTORY-QUICK-CREATE', () => {
         title: 'Rare Aurora slot car rescue lot',
         brand: 'Unknown',
         category: 'General',
-        description: 'Rare Aurora slot car rescue lot',
       })
-      expect(req.body.part_number).to.match(/^TXT-RARE-AURORA-SLOT-CAR-RESCUE-LOT/)
+      expect(req.body.description).to.contain(
+        '- Pasted text: Rare Aurora slot car rescue lot'
+      )
+      expect(req.body.description).to.contain(
+        '- Prompt: Include cracked windscreen note'
+      )
       const created = {
         id: 'item-text-created',
         part_number: req.body.part_number,
         title: req.body.title,
         status: 'active',
         category: 'General',
+        description: req.body.description,
       }
       items.push(created)
       req.reply({ statusCode: 201, body: created })
-    }).as('createClipboardItem')
+    }).as('createTextItem')
 
     signIn()
     cy.wait('@items')
     cy.wait('@activeProfile')
 
-    cy.get('[data-testid="inventory-quick-create-save"]').click()
-    cy.get('[data-testid="inventory-quick-create-error"]')
+    cy.get('[data-testid="inventory-new-action"]').click()
+    cy.get('[data-testid="inventory-create-paste-process"]').click()
+    cy.get('[data-testid="inventory-create-paste-error"]')
       .should('be.visible')
       .and('contain', 'Paste a URL or text')
 
-    cy.window().then((win) => {
-      const readText = cy.stub().resolves('Rare Aurora slot car rescue lot')
-      Object.defineProperty(win.navigator, 'clipboard', {
-        value: { readText },
-        configurable: true,
-      })
-    })
-
-    cy.get('[data-testid="inventory-quick-create-paste"]').click()
-    cy.get('[data-testid="inventory-quick-create-input"]').should(
+    cy.get('[data-testid="inventory-create-paste-input"]').type(
+      'Rare Aurora slot car rescue lot'
+    )
+    cy.get('[data-testid="inventory-create-paste-process"]').click()
+    cy.get('[data-testid="inventory-item-title"]').should(
       'have.value',
       'Rare Aurora slot car rescue lot'
     )
-    cy.get('[data-testid="inventory-quick-create-save"]').click()
+    cy.get('[data-testid="inventory-create-paste-input"]')
+      .clear()
+      .type('Include cracked windscreen note')
+    cy.get('[data-testid="inventory-create-paste-process"]').click()
+    cy.get('[data-testid="inventory-create-source-history"]')
+      .should('contain', 'Pasted text: Rare Aurora slot car rescue lot')
+      .and('contain', 'Prompt: Include cracked windscreen note')
 
-    cy.wait('@createClipboardItem')
+    cy.get('[data-testid="inventory-item-create-submit"]').click()
+    cy.wait('@createTextItem')
     cy.wait('@items')
     cy.wait('@textPhotos')
     cy.contains('Rare Aurora slot car rescue lot').should('be.visible')

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -36,8 +36,8 @@ describe("inventory-management", () => {
 
     cy.contains("Inventory").should("be.visible");
     cy.contains("Collection Browser").should("be.visible");
-    cy.contains("button", "New").should("be.visible");
-    cy.contains("button", "Create").should("be.visible");
+    cy.get('[data-testid="inventory-new-action"]').should("be.visible");
+    cy.get('[data-testid="inventory-create-menu-trigger"]').should("be.visible");
 
     cy.get('button[aria-label="Switch to cards view"]').click();
     cy.contains("Status:").should("be.visible");
@@ -192,14 +192,16 @@ describe("inventory-management", () => {
 
     cy.get('[data-testid="inventory-new-action"]')
       .should("be.visible")
-      .and("contain", "New")
+      .and("have.attr", "aria-label", "New item")
+      .and("not.contain", "New")
       .click();
     cy.get('[data-testid="inventory-item-create-dialog"]').should("be.visible");
     cy.get('[data-testid="inventory-item-create-cancel"]').click();
 
     cy.get('[data-testid="inventory-create-menu-trigger"]')
       .should("be.visible")
-      .and("contain", "Create")
+      .and("have.attr", "aria-label", "Create menu")
+      .and("not.contain", "Create")
       .click();
     cy.get('[data-testid="inventory-create-menu-item"]').should("be.visible").click();
     cy.get('[data-testid="inventory-item-create-dialog"]').should("be.visible");

--- a/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
@@ -39,18 +39,34 @@ describe('workspace header action lanes', () => {
   ) {
     cy.get(`[data-testid="${titleTestID}"]`).then(($title) => {
       const titleRect = $title[0].getBoundingClientRect()
-      const titleCenter = titleRect.left + titleRect.width / 2
-      const searchElement = $title[0].parentElement?.previousElementSibling
-
-      expect(searchElement, 'search element before title lane').to.not.equal(null)
-      const searchRect = searchElement.getBoundingClientRect()
 
       cy.get(`[data-testid="${actionsTestID}"]`).then(($actions) => {
         const actionsRect = $actions[0].getBoundingClientRect()
-        const availableCenter = searchRect.right + (actionsRect.left - searchRect.right) / 2
 
-        expect(Math.abs(titleCenter - availableCenter)).to.be.lessThan(8)
         expect(titleRect.right, 'title does not overlap actions').to.be.lessThan(
+          actionsRect.left
+        )
+      })
+    })
+  }
+
+  function assertHeaderTitleBetweenSearchAndActions(
+    titleTestID: string,
+    actionsTestID: string
+  ) {
+    cy.get(`[data-testid="${titleTestID}"]`).then(($title) => {
+      const titleRect = $title[0].getBoundingClientRect()
+
+      cy.contains('button', 'Search').then(($search) => {
+        const searchRect = $search[0].getBoundingClientRect()
+        expect(titleRect.left, 'title starts after search').to.be.greaterThan(
+          searchRect.right
+        )
+      })
+
+      cy.get(`[data-testid="${actionsTestID}"]`).then(($actions) => {
+        const actionsRect = $actions[0].getBoundingClientRect()
+        expect(titleRect.right, 'title stays clear of actions').to.be.lessThan(
           actionsRect.left
         )
       })
@@ -80,19 +96,27 @@ describe('workspace header action lanes', () => {
         'aria-label',
         'Inventory - Browse, organize, and update the items you already own.'
       )
-    assertHeaderTitleCentered('inventory-header-title', 'inventory-global-header-actions')
+    assertHeaderTitleBetweenSearchAndActions(
+      'inventory-header-title',
+      'inventory-global-header-actions'
+    )
     cy.get('[data-testid="inventory-page-header"]').should('not.exist')
     cy.get('[data-testid="inventory-global-header-actions"]')
       .should('be.visible')
       .within(() => {
-        cy.get('[data-testid="inventory-header-context"]').should(
-          'contain.text',
-          'All Items'
-        )
-        cy.get('[data-testid="inventory-new-action"]').should('be.visible')
+        cy.get('[data-testid="inventory-paste-action"]').should('be.visible')
+        cy.get('[data-testid="inventory-barcodes-action"]')
+          .should('be.visible')
+          .and('not.contain.text', 'Barcodes')
+        cy.get('[data-testid="inventory-photos-action"]')
+          .should('be.visible')
+          .and('not.contain.text', 'Photos')
+        cy.get('[data-testid="inventory-new-action"]')
+          .should('be.visible')
+          .and('not.contain.text', 'New')
         cy.get('[data-testid="inventory-create-menu-trigger"]').should(
           'be.visible'
-        )
+        ).and('not.contain.text', 'Create')
       })
     cy.get('[data-testid="inventory-header-action-separator"]').should('be.visible')
     cy.contains('Browse, organize, and update the items you already own.').should(
@@ -103,7 +127,7 @@ describe('workspace header action lanes', () => {
   })
 
   it('keeps Wishlist actions in the same global shell header pattern', () => {
-    cy.viewport(1280, 800)
+    cy.viewport(2048, 900)
     cy.intercept('GET', '/api/wishlist', {
       statusCode: 200,
       body: {
@@ -174,7 +198,7 @@ describe('workspace header action lanes', () => {
   })
 
   it('keeps Collections actions in the same global shell header pattern', () => {
-    cy.viewport(1280, 800)
+    cy.viewport(2048, 900)
     bootstrap('/collections/')
 
     cy.get('[data-testid="collections-shell-header"]').should('be.visible')

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -15,6 +15,7 @@ import {
   Barcode,
   ChevronRight,
   ClipboardPaste,
+  CircleArrowUp,
   Ellipsis,
   GripVertical,
   Images,
@@ -22,7 +23,6 @@ import {
   Plus,
   RotateCcw,
   RotateCw,
-  Save,
   Star,
   Trash2,
 } from 'lucide-react'
@@ -63,7 +63,7 @@ import {
 } from '@/components/ui/sheet'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { LanguageSwitch } from '@/components/language-switch'
-import { Header, HeaderTitle } from '@/components/layout/header'
+import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
@@ -120,6 +120,11 @@ type InventoryItemDraft = {
 }
 
 type InventoryCreateIntent = 'manual' | 'photo' | 'barcode'
+
+type PasteCreateHistoryEntry = {
+  kind: 'url' | 'text' | 'prompt'
+  value: string
+}
 
 type FolderNode = {
   id: string
@@ -454,6 +459,34 @@ function humanizeQuickCreatePathSegment(value: string): string {
   )
 }
 
+function formatPasteCreateHistory(entries: PasteCreateHistoryEntry[]): string {
+  return entries
+    .map((entry) => {
+      const label =
+        entry.kind === 'url'
+          ? 'Pasted URL'
+          : entry.kind === 'text'
+            ? 'Pasted text'
+            : 'Prompt'
+      return `- ${label}: ${entry.value}`
+    })
+    .join('\n')
+}
+
+function buildPasteCreateDescription(
+  entries: PasteCreateHistoryEntry[],
+  sourceURL?: string
+) {
+  const sections: string[] = []
+  if (sourceURL) {
+    sections.push(`Source link: ${sourceURL}`)
+  }
+  if (entries.length > 0) {
+    sections.push(`Creation history:\n${formatPasteCreateHistory(entries)}`)
+  }
+  return sections.join('\n\n')
+}
+
 function buildQuickCreateDraft(value: string): InventoryItemDraft {
   const source = value.trim()
   try {
@@ -476,7 +509,10 @@ function buildQuickCreateDraft(value: string): InventoryItemDraft {
         title,
         brand: 'Unknown',
         category: 'General',
-        description: `Source URL: ${source}`,
+        description: buildPasteCreateDescription(
+          [{ kind: 'url', value: source }],
+          source
+        ),
       }
     }
   } catch {
@@ -489,7 +525,16 @@ function buildQuickCreateDraft(value: string): InventoryItemDraft {
     title,
     brand: 'Unknown',
     category: 'General',
-    description: source,
+    description: buildPasteCreateDescription([{ kind: 'text', value: source }]),
+  }
+}
+
+function isLikelyURL(value: string) {
+  try {
+    const url = new URL(value.trim())
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
   }
 }
 
@@ -1161,12 +1206,15 @@ export function Collection({
   const [barcodeMatches, setBarcodeMatches] = useState<BarcodeMatch[]>([])
   const [barcodeLookupCompleted, setBarcodeLookupCompleted] = useState(false)
   const [lastLookupBarcode, setLastLookupBarcode] = useState('')
-  const [quickCreateInput, setQuickCreateInput] = useState('')
-  const [quickCreateBusy, setQuickCreateBusy] = useState(false)
-  const [quickCreateError, setQuickCreateError] = useState<string | null>(null)
-  const [quickCreateSuccess, setQuickCreateSuccess] = useState<string | null>(
+  const [pasteCreateInput, setPasteCreateInput] = useState('')
+  const [pasteCreateBusy, setPasteCreateBusy] = useState(false)
+  const [pasteCreateError, setPasteCreateError] = useState<string | null>(null)
+  const [pasteCreateSuccess, setPasteCreateSuccess] = useState<string | null>(
     null
   )
+  const [pasteCreateHistory, setPasteCreateHistory] = useState<
+    PasteCreateHistoryEntry[]
+  >([])
   const [selectedPhotoIndex, setSelectedPhotoIndex] = useState<number | null>(
     null
   )
@@ -1211,6 +1259,10 @@ export function Collection({
       setItemCreateBarcodeInput('')
       setItemSaveError(null)
       setItemSaveSuccess(null)
+      setPasteCreateInput('')
+      setPasteCreateError(null)
+      setPasteCreateSuccess(null)
+      setPasteCreateHistory([])
       selectInventoryItem(null)
       setItemEditorOpen(true)
     },
@@ -3038,55 +3090,75 @@ export function Collection({
     )}/external-search?source=ebay&region=AU`
   }, [lastLookupBarcode])
 
-  const handlePasteQuickCreate = useCallback(async () => {
-    setQuickCreateError(null)
-    setQuickCreateSuccess(null)
+  const processPasteCreateInput = useCallback(
+    (rawValue?: string, historyOverride?: PasteCreateHistoryEntry[]) => {
+      const source = (rawValue ?? pasteCreateInput).trim()
+      if (source === '') {
+        setPasteCreateError('Paste a URL or text before processing an item.')
+        setPasteCreateSuccess(null)
+        return false
+      }
+
+      setPasteCreateBusy(true)
+      setPasteCreateError(null)
+      setPasteCreateSuccess(null)
+      try {
+        const baseHistory = historyOverride ?? pasteCreateHistory
+        const nextEntry: PasteCreateHistoryEntry =
+          baseHistory.length === 0
+            ? { kind: isLikelyURL(source) ? 'url' : 'text', value: source }
+            : { kind: 'prompt', value: source }
+        const nextHistory = [...baseHistory, nextEntry]
+        const sourceURL =
+          nextHistory.find((entry) => entry.kind === 'url')?.value ?? undefined
+        const generatedDraft = buildQuickCreateDraft(source)
+
+        setItemDraft((current) => {
+          const shouldHydrateIdentity = nextEntry.kind !== 'prompt'
+          return {
+            part_number: shouldHydrateIdentity
+              ? generatedDraft.part_number
+              : current.part_number,
+            title: shouldHydrateIdentity ? generatedDraft.title : current.title,
+            brand: shouldHydrateIdentity ? generatedDraft.brand : current.brand,
+            category: shouldHydrateIdentity
+              ? generatedDraft.category
+              : current.category,
+            description: buildPasteCreateDescription(nextHistory, sourceURL),
+          }
+        })
+        setPasteCreateHistory(nextHistory)
+        setPasteCreateSuccess('Paste processed into the item draft.')
+        return true
+      } finally {
+        setPasteCreateBusy(false)
+      }
+    },
+    [pasteCreateHistory, pasteCreateInput]
+  )
+
+  const startPasteCreateItem = useCallback(async () => {
+    startCreateItem('manual')
+    setPasteCreateError(null)
+    setPasteCreateSuccess(null)
     if (!navigator.clipboard?.readText) {
-      setQuickCreateError(
+      setPasteCreateError(
         'Clipboard paste is not available here. Paste into the field manually.'
       )
       return
     }
     try {
       const text = await navigator.clipboard.readText()
-      setQuickCreateInput(text)
+      setPasteCreateInput(text)
+      if (text.trim() !== '') {
+        processPasteCreateInput(text, [])
+      }
     } catch {
-      setQuickCreateError(
+      setPasteCreateError(
         'Clipboard paste was blocked. Paste into the field manually.'
       )
     }
-  }, [])
-
-  const handleSaveQuickCreate = useCallback(async () => {
-    const source = quickCreateInput.trim()
-    if (source === '') {
-      setQuickCreateError('Paste a URL or text before saving an item.')
-      setQuickCreateSuccess(null)
-      return
-    }
-    setQuickCreateBusy(true)
-    setQuickCreateError(null)
-    setQuickCreateSuccess(null)
-    try {
-      const payload = buildQuickCreateDraft(source)
-      const response = await fetch('/api/items', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-      if (!response.ok) {
-        throw new Error(`quick_create_item_${response.status}`)
-      }
-      const saved = (await response.json()) as { id?: string }
-      await loadInventoryItems(saved.id?.trim())
-      setQuickCreateInput('')
-      setQuickCreateSuccess('Item created and selected.')
-    } catch {
-      setQuickCreateError('Unable to create an item from this paste. Retry.')
-    } finally {
-      setQuickCreateBusy(false)
-    }
-  }, [loadInventoryItems, quickCreateInput])
+  }, [processPasteCreateInput, startCreateItem])
 
   const folderDragOverlay =
     typeof document !== 'undefined' && draggedFolderNode && dragPreviewPosition
@@ -3242,13 +3314,19 @@ export function Collection({
         data-testid='inventory-shell-header'
       >
         <Search className='hidden min-w-32 sm:flex' />
-        <HeaderTitle
-          title={title}
-          description={description}
-          icon={ListChecks}
-          testId='inventory-header-title'
-          iconTestId='inventory-page-icon'
-        />
+        <h1
+          className='hidden min-w-0 shrink-0 items-center gap-2 truncate text-lg font-bold tracking-tight md:flex'
+          data-testid='inventory-header-title'
+          title={description || title}
+          aria-label={description ? `${title} - ${description}` : title}
+        >
+          <ListChecks
+            className='h-5 w-5 shrink-0 text-muted-foreground'
+            data-testid='inventory-page-icon'
+            aria-hidden
+          />
+          <span className='truncate'>{title}</span>
+        </h1>
         <div
           className='ms-auto flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3'
           data-header-title-avoid='true'
@@ -3262,52 +3340,59 @@ export function Collection({
                 <Button
                   type='button'
                   variant='outline'
-                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
+                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9'
+                  data-testid='inventory-paste-action'
+                  aria-label='Paste URL or text into a new item'
+                  title='Paste URL or text into a new item'
+                  onClick={() => void startPasteCreateItem()}
+                >
+                  <ClipboardPaste className='size-4' aria-hidden />
+                </Button>
+                <Button
+                  type='button'
+                  variant='outline'
+                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9'
                   data-testid='inventory-barcodes-action'
                   aria-label='Create item from barcode'
                   title='Create item from barcode'
                   onClick={startCreateItemFromBarcode}
                 >
-                  <Barcode className='size-4 2xl:mr-2' aria-hidden />
-                  <span className='hidden 2xl:inline'>Barcodes</span>
+                  <Barcode className='size-4' aria-hidden />
                 </Button>
                 <Button
                   type='button'
                   variant='outline'
-                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
+                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9'
                   data-testid='inventory-photos-action'
                   aria-label='Create item from photo'
                   title='Create item from photo'
                   onClick={startCreateItemFromPhoto}
                 >
-                  <Images className='size-4 2xl:mr-2' aria-hidden />
-                  <span className='hidden 2xl:inline'>Photos</span>
+                  <Images className='size-4' aria-hidden />
                 </Button>
               </>
             ) : null}
             <Button
               type='button'
-              className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
+              className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9'
               data-testid='inventory-new-action'
               aria-label='New item'
               title='New'
               onClick={startManualCreateItem}
             >
-              <Plus className='size-4 2xl:mr-2' aria-hidden />
-              <span className='hidden 2xl:inline'>New</span>
+              <Plus className='size-4' aria-hidden />
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   type='button'
                   variant='outline'
-                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9 2xl:w-auto 2xl:px-4 2xl:text-sm'
+                  className='h-8 w-8 px-0 text-xs sm:h-9 sm:w-9'
                   data-testid='inventory-create-menu-trigger'
                   aria-label='Create menu'
                   title='Create'
                 >
-                  <Ellipsis className='size-4 2xl:mr-2' aria-hidden />
-                  <span className='hidden 2xl:inline'>Create</span>
+                  <Ellipsis className='size-4' aria-hidden />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align='end'>
@@ -3652,68 +3737,8 @@ export function Collection({
           </Card>
 
           <Card>
-            <CardHeader className='gap-3 sm:flex-row sm:items-start sm:justify-between'>
-              <CardTitle className='shrink-0'>Collection Browser</CardTitle>
-              {routePath === '/_authenticated/inventory/' ? (
-                <form
-                  className='flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end'
-                  data-testid='inventory-quick-create'
-                  onSubmit={(event) => {
-                    event.preventDefault()
-                    void handleSaveQuickCreate()
-                  }}
-                >
-                  <div className='flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center'>
-                    <Button
-                      type='button'
-                      variant='outline'
-                      data-testid='inventory-quick-create-paste'
-                      onClick={() => void handlePasteQuickCreate()}
-                    >
-                      <ClipboardPaste className='size-4' aria-hidden='true' />
-                      Paste
-                    </Button>
-                    <Input
-                      className='w-full sm:w-72 lg:w-96'
-                      placeholder='Paste URL or text'
-                      aria-label='Paste URL or text to create inventory item'
-                      data-testid='inventory-quick-create-input'
-                      value={quickCreateInput}
-                      onChange={(event) => {
-                        setQuickCreateInput(event.target.value)
-                        setQuickCreateError(null)
-                        setQuickCreateSuccess(null)
-                      }}
-                    />
-                    <Button
-                      type='submit'
-                      data-testid='inventory-quick-create-save'
-                      disabled={quickCreateBusy}
-                    >
-                      <Save className='size-4' aria-hidden='true' />
-                      {quickCreateBusy ? 'Saving...' : 'Save'}
-                    </Button>
-                  </div>
-                  {quickCreateError ? (
-                    <p
-                      className='text-sm text-destructive'
-                      data-testid='inventory-quick-create-error'
-                      role='alert'
-                    >
-                      {quickCreateError}
-                    </p>
-                  ) : null}
-                  {quickCreateSuccess ? (
-                    <p
-                      className='text-sm text-muted-foreground'
-                      data-testid='inventory-quick-create-success'
-                      role='status'
-                    >
-                      {quickCreateSuccess}
-                    </p>
-                  ) : null}
-                </form>
-              ) : null}
+            <CardHeader>
+              <CardTitle>Collection Browser</CardTitle>
             </CardHeader>
             <CardContent className='space-y-4'>
               <p className='text-sm text-muted-foreground'>
@@ -3891,6 +3916,10 @@ export function Collection({
                       if (!open) {
                         setItemSaveError(null)
                         resetCreateAttachments()
+                        setPasteCreateInput('')
+                        setPasteCreateError(null)
+                        setPasteCreateSuccess(null)
+                        setPasteCreateHistory([])
                       }
                     }}
                   >
@@ -3926,6 +3955,73 @@ export function Collection({
                                 : 'Creating new item draft.'
                             : `Editing selected item: ${selectedItemContext}`}
                         </p>
+                        {itemEditorMode === 'create' ? (
+                          <div
+                            className='space-y-3 rounded-md border bg-muted/20 p-3'
+                            data-testid='inventory-create-paste-panel'
+                          >
+                            <div className='flex gap-2'>
+                              <Input
+                                placeholder='Paste URL or text'
+                                aria-label='Paste URL or text to process into item fields'
+                                data-testid='inventory-create-paste-input'
+                                value={pasteCreateInput}
+                                onChange={(event) => {
+                                  setPasteCreateInput(event.target.value)
+                                  setPasteCreateError(null)
+                                  setPasteCreateSuccess(null)
+                                }}
+                              />
+                              <Button
+                                type='button'
+                                size='icon'
+                                data-testid='inventory-create-paste-process'
+                                aria-label='Process pasted URL or text'
+                                title='Process pasted URL or text'
+                                disabled={pasteCreateBusy}
+                                onClick={() => processPasteCreateInput()}
+                              >
+                                <CircleArrowUp
+                                  className='size-5'
+                                  aria-hidden='true'
+                                />
+                              </Button>
+                            </div>
+                            {pasteCreateError ? (
+                              <p
+                                className='text-sm text-destructive'
+                                data-testid='inventory-create-paste-error'
+                                role='alert'
+                              >
+                                {pasteCreateError}
+                              </p>
+                            ) : null}
+                            {pasteCreateSuccess ? (
+                              <p
+                                className='text-sm text-muted-foreground'
+                                data-testid='inventory-create-paste-success'
+                                role='status'
+                              >
+                                {pasteCreateSuccess}
+                              </p>
+                            ) : null}
+                            {pasteCreateHistory.length > 0 ? (
+                              <div
+                                className='rounded-md border bg-background/50 p-2 text-xs text-muted-foreground'
+                                data-testid='inventory-create-source-history'
+                              >
+                                <p className='font-medium text-foreground'>
+                                  Creation history
+                                </p>
+                                <pre className='mt-1 whitespace-pre-wrap font-sans'>
+                                  {formatPasteCreateHistory(
+                                    pasteCreateHistory
+                                  )}
+                                </pre>
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null}
                         {itemEditorMode === 'create' &&
                         itemCreateIntent !== 'manual' ? (
                           <div


### PR DESCRIPTION
## Summary
- Restores the Inventory title as an inline header element between global Search and action buttons.
- Makes Inventory header actions icon-only and adds a compact Paste action.
- Moves paste processing into the create-item modal with a Paste URL/text field and circular up-arrow process button.
- Processes pasted URLs/text into editable item fields while preserving source link and prompt history in the item description.

## Validation
- npm run build (ui.web)
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-ai-assist/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/workspace-header-actions/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-page-header-title/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts -Browser electron
- git diff --check
- pre-push OpenSpec + API docs smoke

Closes #705