### PR TITLE
#707 Allow inventory draft create from any field

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
@@ -144,4 +144,140 @@ describe("inventory item editor modal", () => {
     cy.contains("Bravo Item Updated").should("be.visible");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-BRAVO");
   });
+
+  it("creates a draft item when any single field is provided", () => {
+    const items: Array<{
+      id: string;
+      part_number: string;
+      title: string;
+      status: string;
+      category: string;
+      brand: string;
+      priority: string;
+      description: string;
+    }> = [];
+
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
+    }).as("itemsList");
+
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body.part_number).to.match(/^DRAFT-/);
+      expect(req.body).to.include({
+        title: "Only Title Draft",
+        brand: "Unknown",
+        category: "General",
+      });
+      const created = {
+        id: "item-title-only",
+        part_number: req.body.part_number,
+        title: req.body.title,
+        status: "active",
+        category: req.body.category,
+        brand: req.body.brand,
+        priority: "medium",
+        description: req.body.description,
+      };
+      items.unshift(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createTitleOnlyItem");
+
+    signIn();
+    cy.wait("@itemsList");
+
+    cy.get('[data-testid="inventory-new-action"]').click();
+    cy.get('[data-testid="inventory-item-title"]').type("Only Title Draft");
+    cy.get('[data-testid="inventory-item-save"]').click();
+
+    cy.wait("@createTitleOnlyItem");
+    cy.wait("@itemsList");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.contains("Only Title Draft").should("be.visible");
+  });
+
+  it("creates a draft item from only a captured image", () => {
+    const items: Array<{
+      id: string;
+      part_number: string;
+      title: string;
+      status: string;
+      category: string;
+      brand: string;
+      priority: string;
+      description: string;
+    }> = [];
+
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
+    }).as("itemsList");
+
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body.part_number).to.match(/^DRAFT-/);
+      expect(req.body).to.include({
+        title: "Photo draft item",
+        brand: "Unknown",
+        category: "General",
+      });
+      const created = {
+        id: "item-photo-only",
+        part_number: req.body.part_number,
+        title: req.body.title,
+        status: "active",
+        category: req.body.category,
+        brand: req.body.brand,
+        priority: "medium",
+        description: req.body.description,
+      };
+      items.unshift(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createPhotoOnlyItem");
+
+    cy.intercept("POST", "/api/items/item-photo-only/photos", (req) => {
+      req.reply({
+        statusCode: 201,
+        body: {
+          id: "photo-draft-1",
+          filename: "captured-draft.jpg",
+          is_primary: true,
+        },
+      });
+    }).as("uploadPhotoOnlyItem");
+
+    signIn();
+    cy.wait("@itemsList");
+
+    cy.get('[data-testid="inventory-new-action"]').click();
+    cy.get('[data-testid="inventory-create-take-image"]').should("be.visible");
+    cy.get('[data-testid="inventory-create-photo-input"]').selectFile({
+      contents: Cypress.Buffer.from("captured-photo-binary"),
+      fileName: "captured-draft.jpg",
+      mimeType: "image/jpeg",
+    });
+    cy.get('[data-testid="inventory-item-save"]').click();
+
+    cy.wait("@createPhotoOnlyItem");
+    cy.wait("@uploadPhotoOnlyItem");
+    cy.wait("@itemsList");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.contains("Photo draft item").should("be.visible");
+  });
+
+  it("keeps an empty draft item blocked until a field or image is provided", () => {
+    cy.intercept("GET", "/api/items", {
+      statusCode: 200,
+      body: { items: [] },
+    }).as("itemsList");
+    cy.intercept("POST", "/api/items").as("createItem");
+
+    signIn();
+    cy.wait("@itemsList");
+
+    cy.get('[data-testid="inventory-new-action"]').click();
+    cy.get('[data-testid="inventory-item-save"]').click();
+
+    cy.get('[data-testid="inventory-item-save-error"]')
+      .should("be.visible")
+      .and("contain", "Enter at least one field or add an image before saving.");
+    cy.get("@createItem.all").should("have.length", 0);
+  });
 });

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -435,6 +435,43 @@ function inventoryItemToDraft(item: InventoryItem): InventoryItemDraft {
   }
 }
 
+function hasInventoryDraftValue(draft: InventoryItemDraft): boolean {
+  return Object.values(draft).some((value) => value.trim() !== '')
+}
+
+function buildDraftItemPartNumber(): string {
+  return `DRAFT-${Date.now().toString(36).toUpperCase()}`
+}
+
+function normalizeInventoryCreatePayload(
+  draft: InventoryItemDraft,
+  options: { barcode: string; hasPhoto: boolean }
+): InventoryItemDraft {
+  const trimmed = {
+    part_number: draft.part_number.trim(),
+    title: draft.title.trim(),
+    brand: draft.brand.trim(),
+    category: draft.category.trim(),
+    description: draft.description.trim(),
+  }
+  const titleSeed =
+    trimmed.title ||
+    trimmed.part_number ||
+    trimmed.brand ||
+    trimmed.category ||
+    trimmed.description.slice(0, 80) ||
+    (options.barcode ? `Barcode ${options.barcode}` : '') ||
+    (options.hasPhoto ? 'Photo draft item' : '')
+
+  return {
+    part_number: trimmed.part_number || buildDraftItemPartNumber(),
+    title: titleSeed || 'Draft item',
+    brand: trimmed.brand || 'Unknown',
+    category: trimmed.category || 'General',
+    description: trimmed.description,
+  }
+}
+
 function compactQuickCreateText(value: string): string {
   return value.replace(/\s+/g, ' ').trim()
 }
@@ -2651,37 +2688,44 @@ export function Collection({
 
   const handleSaveItem = useCallback(async () => {
     const wasCreateMode = itemEditorMode === 'create'
-    const payload = {
+    const trimmedDraft = {
       part_number: itemDraft.part_number.trim(),
       title: itemDraft.title.trim(),
       brand: itemDraft.brand.trim(),
       category: itemDraft.category.trim(),
       description: itemDraft.description.trim(),
     }
-    if (payload.part_number === '' || payload.title === '') {
-      setItemSaveError('Part number and title are required before saving.')
-      setItemSaveSuccess(null)
-      return
-    }
+    const pendingCreateBarcode = itemCreateBarcodeInput.trim()
+    const hasCreatePhoto = wasCreateMode && itemCreatePhotoFile !== null
+    const hasCreateBarcode = wasCreateMode && pendingCreateBarcode !== ''
+    const payload = wasCreateMode
+      ? normalizeInventoryCreatePayload(trimmedDraft, {
+          barcode: pendingCreateBarcode,
+          hasPhoto: hasCreatePhoto,
+        })
+      : trimmedDraft
     if (itemEditorMode === 'edit' && !selectedItemID) {
       setItemSaveError('Select an existing inventory item before editing.')
       setItemSaveSuccess(null)
       return
     }
-    if (wasCreateMode && itemCreateIntent === 'photo' && !itemCreatePhotoFile) {
-      setItemSaveError('Choose a photo before creating from the Photos action.')
+    if (
+      wasCreateMode &&
+      !hasInventoryDraftValue(trimmedDraft) &&
+      !hasCreatePhoto &&
+      !hasCreateBarcode
+    ) {
+      setItemSaveError(
+        'Enter at least one field or add an image before saving.'
+      )
       setItemSaveSuccess(null)
       return
     }
-    const pendingCreateBarcode = itemCreateBarcodeInput.trim()
     if (
-      wasCreateMode &&
-      itemCreateIntent === 'barcode' &&
-      pendingCreateBarcode === ''
+      !wasCreateMode &&
+      (payload.part_number === '' || payload.title === '')
     ) {
-      setItemSaveError(
-        'Enter a barcode before creating from the Barcodes action.'
-      )
+      setItemSaveError('Part number and title are required before saving.')
       setItemSaveSuccess(null)
       return
     }
@@ -2704,7 +2748,7 @@ export function Collection({
       }
       const saved = (await response.json()) as { id?: string }
       const savedID = saved.id?.trim() ?? selectedItemID
-      if (wasCreateMode && itemCreateIntent === 'photo' && itemCreatePhotoFile) {
+      if (wasCreateMode && itemCreatePhotoFile) {
         const photoBody = new FormData()
         photoBody.append('file', itemCreatePhotoFile)
         const photoResponse = await fetch(
@@ -2733,9 +2777,9 @@ export function Collection({
       }
       setItemEditorMode('edit')
       setItemSaveSuccess(
-        wasCreateMode && itemCreateIntent === 'photo'
+        wasCreateMode && hasCreatePhoto
           ? 'Item created with photo and selected.'
-          : wasCreateMode && itemCreateIntent === 'barcode'
+          : wasCreateMode && itemCreateIntent === 'barcode' && hasCreateBarcode
             ? 'Item created with barcode and selected.'
             : wasCreateMode
               ? 'Item created and selected for follow-up media attach.'
@@ -4013,33 +4057,38 @@ export function Collection({
                                 <p className='font-medium text-foreground'>
                                   Creation history
                                 </p>
-                                <pre className='mt-1 whitespace-pre-wrap font-sans'>
-                                  {formatPasteCreateHistory(
-                                    pasteCreateHistory
-                                  )}
+                                <pre className='mt-1 font-sans whitespace-pre-wrap'>
+                                  {formatPasteCreateHistory(pasteCreateHistory)}
                                 </pre>
                               </div>
                             ) : null}
                           </div>
                         ) : null}
-                        {itemEditorMode === 'create' &&
-                        itemCreateIntent !== 'manual' ? (
+                        {itemEditorMode === 'create' ? (
                           <div
                             className='rounded-md border bg-muted/30 p-3'
                             data-testid='inventory-create-media-panel'
                           >
-                            {itemCreateIntent === 'photo' ? (
+                            <div className='grid gap-3 md:grid-cols-2'>
                               <div className='space-y-2'>
-                                <label
-                                  className='text-sm font-medium'
-                                  htmlFor='inventory-create-photo-input'
+                                <Button
+                                  asChild
+                                  variant='outline'
+                                  data-testid='inventory-create-take-image'
                                 >
-                                  Photo
-                                </label>
+                                  <label htmlFor='inventory-create-photo-input'>
+                                    <Images
+                                      className='size-4'
+                                      aria-hidden='true'
+                                    />
+                                    Take Image
+                                  </label>
+                                </Button>
                                 <input
                                   id='inventory-create-photo-input'
                                   type='file'
                                   accept='image/*'
+                                  capture='environment'
                                   data-testid='inventory-create-photo-input'
                                   onChange={(event) =>
                                     setItemCreatePhotoFile(
@@ -4048,36 +4097,37 @@ export function Collection({
                                   }
                                 />
                                 <p className='text-xs text-muted-foreground'>
-                                  This photo will be uploaded after the item is
-                                  created.
+                                  {itemCreatePhotoFile
+                                    ? `${itemCreatePhotoFile.name} will be uploaded after the item is created.`
+                                    : 'Take or choose a photo to create an image-only draft.'}
                                 </p>
                               </div>
-                            ) : null}
-                            {itemCreateIntent === 'barcode' ? (
-                              <div className='space-y-2'>
-                                <label
-                                  className='text-sm font-medium'
-                                  htmlFor='inventory-create-barcode-input'
-                                >
-                                  Barcode
-                                </label>
-                                <Input
-                                  id='inventory-create-barcode-input'
-                                  data-testid='inventory-create-barcode-input'
-                                  placeholder='Enter barcode for the new item'
-                                  value={itemCreateBarcodeInput}
-                                  onChange={(event) =>
-                                    setItemCreateBarcodeInput(
-                                      event.target.value
-                                    )
-                                  }
-                                />
-                                <p className='text-xs text-muted-foreground'>
-                                  This barcode will be attached after the item
-                                  is created.
-                                </p>
-                              </div>
-                            ) : null}
+                              {itemCreateIntent === 'barcode' ? (
+                                <div className='space-y-2'>
+                                  <label
+                                    className='text-sm font-medium'
+                                    htmlFor='inventory-create-barcode-input'
+                                  >
+                                    Barcode
+                                  </label>
+                                  <Input
+                                    id='inventory-create-barcode-input'
+                                    data-testid='inventory-create-barcode-input'
+                                    placeholder='Enter barcode for the new item'
+                                    value={itemCreateBarcodeInput}
+                                    onChange={(event) =>
+                                      setItemCreateBarcodeInput(
+                                        event.target.value
+                                      )
+                                    }
+                                  />
+                                  <p className='text-xs text-muted-foreground'>
+                                    This barcode will be attached after the item
+                                    is created.
+                                  </p>
+                                </div>
+                              ) : null}
+                            </div>
                           </div>
                         ) : null}
                         <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
@@ -4696,10 +4746,7 @@ export function Collection({
                                       aria-label={`Rotate ${photo.filename} left`}
                                       title={`Rotate ${photo.filename} left`}
                                       onClick={() =>
-                                        void handleRotatePhoto(
-                                          photo.id,
-                                          'left'
-                                        )
+                                        void handleRotatePhoto(photo.id, 'left')
                                       }
                                       disabled={photosBusy}
                                     >


### PR DESCRIPTION
## Summary\n- Allow Create Item to save when any field is entered, generating draft defaults for missing backend-required fields.\n- Add a camera-capable Take Image control to the create modal so image-only drafts can be saved and processed later.\n- Preserve edit validation and existing header photo/barcode create flows.\n\n## Validation\n- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1\n- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts -Browser electron\n- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron\n\nCloses #707