### PR TITLE
#709 Remove Inventory Collection Browser heading

### DIFF
--- a/ui.web/cypress/e2e/general/ui-semantic-component-layer/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-semantic-component-layer/spec.cy.ts
@@ -11,7 +11,8 @@ describe("ui-semantic-component-layer", () => {
     signInToInventory();
     cy.get('[data-slot="sidebar"]').should("be.visible");
     cy.get("header").first().should("be.visible");
-    cy.contains("Collection Browser").should("be.visible");
+    cy.contains("Collection Browser").should("not.exist");
+    cy.contains(/Folders:\s*\d+/).should("be.visible");
     cy.get('[data-testid="profile-dropdown-trigger"]:visible').first().click();
     cy.contains('[data-slot="dropdown-menu-item"]', "Sign out").click();
     cy.contains(/sign out/i).should("be.visible");
@@ -21,7 +22,7 @@ describe("ui-semantic-component-layer", () => {
     signInToInventory();
     cy.get('[data-slot="card"]').its("length").should("be.greaterThan", 1);
     cy.get("button").contains("New").should("be.visible");
-    cy.contains("Collection Browser").closest('[data-slot="card"]').should("be.visible");
+    cy.contains(/Folders:\s*\d+/).closest('[data-slot="card"]').should("be.visible");
   });
 
   it("UI-SEMANTIC-COMPONENT-LAYER-003 keeps shell stable across top-level route switches", () => {
@@ -55,7 +56,7 @@ describe("ui-semantic-component-layer", () => {
 
   it("UI-SEMANTIC-COMPONENT-LAYER-005 reuses domain blocks in inventory and wishlist", () => {
     signInToInventory();
-    cy.get('input[placeholder="Filter by title or ID..."]').should("be.visible");
+    cy.get('input[placeholder="Filter by title or part number..."]').should("be.visible");
     cy.visit("/wishlist");
     cy.get('input[placeholder="Filter by title or ID..."]').should("be.visible");
     cy.get("table").should("be.visible");
@@ -72,9 +73,9 @@ describe("ui-semantic-component-layer", () => {
 
   it("UI-SEMANTIC-COMPONENT-LAYER-007 keeps keyboard-accessible shell interactions", () => {
     signInToInventory();
-    cy.get('[data-testid="folder-tree-item-store-1"]').focus().type("{enter}");
+    cy.get('[data-testid="inventory-collection-filter-select"]').select("Store 1");
     cy.get('[data-testid="collection-active-context"]').should("contain", "Store 1");
-    cy.get('[data-testid="folder-tree-item-store-2"]').focus().type("{enter}");
+    cy.get('[data-testid="inventory-collection-filter-select"]').select("Store 2");
     cy.get('[data-testid="collection-active-context"]').should("contain", "Store 2");
   });
 });

--- a/ui.web/cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts
@@ -92,7 +92,7 @@ describe("inventory responsive table-first redesign", () => {
     signIn();
     cy.wait("@alphaPhotos");
 
-    cy.contains("Collection Browser").should("be.visible");
+    cy.contains("Collection Browser").should("not.exist");
     cy.get('[data-testid="inventory-folder-tree"]').should("not.exist");
     cy.get('[data-testid="inventory-folder-tree-legacy"]').should("not.be.visible");
     cy.get('[data-testid="inventory-collection-filter"]').should("be.visible");

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-ai-assist/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-ai-assist/spec.cy.ts
@@ -51,7 +51,7 @@ describe('UI-SCREEN-INVENTORY-PASTE-CREATE', () => {
 
     cy.get('[data-testid="inventory-ai-assist-section"]').should('not.exist')
     cy.get('[data-testid="inventory-quick-create"]').should('not.exist')
-    cy.contains('Collection Browser')
+    cy.contains(/Folders:\s*\d+/)
       .closest('[data-slot="card"]')
       .within(() => {
         cy.get('[data-testid="inventory-quick-create-input"]').should('not.exist')

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -35,7 +35,7 @@ describe("inventory-management", () => {
     cy.contains("Oops! Something went wrong").should("not.exist");
 
     cy.contains("Inventory").should("be.visible");
-    cy.contains("Collection Browser").should("be.visible");
+    cy.contains("Collection Browser").should("not.exist");
     cy.get('[data-testid="inventory-new-action"]').should("be.visible");
     cy.get('[data-testid="inventory-create-menu-trigger"]').should("be.visible");
 
@@ -137,7 +137,7 @@ describe("inventory-management", () => {
     cy.get("table").should("be.visible");
   });
 
-  it("UI-SCREEN-INVENTORY-ITEMS-004 keeps summary compact in Collection Browser header and removes duplicate strips", () => {
+  it("UI-SCREEN-INVENTORY-ITEMS-004 keeps summary compact without duplicate strips or redundant section heading", () => {
     cy.intercept("GET", "/api/items", {
       statusCode: 200,
       body: {
@@ -158,8 +158,9 @@ describe("inventory-management", () => {
 
     cy.contains("Command Row").should("not.exist");
     cy.contains("Summary Strip").should("not.exist");
+    cy.contains("Collection Browser").should("not.exist");
 
-    cy.contains("Collection Browser")
+    cy.contains(/Folders:\s*\d+/)
       .closest('[data-slot="card"]')
       .within(() => {
         cy.contains(/Folders:\s*\d+/).should("be.visible");

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -3781,10 +3781,7 @@ export function Collection({
           </Card>
 
           <Card>
-            <CardHeader>
-              <CardTitle>Collection Browser</CardTitle>
-            </CardHeader>
-            <CardContent className='space-y-4'>
+            <CardContent className='space-y-4 pt-6'>
               <p className='text-sm text-muted-foreground'>
                 Folders: <strong>{summary.folders}</strong>{' '}
                 <span className='mx-2'>


### PR DESCRIPTION
## Summary
- Remove the redundant "Collection Browser" card heading from Inventory.
- Keep the summary, compact filters, table, and actions in place.
- Update Cypress locators to assert the heading is absent and use current stable controls.

## Validation
- Red-first Cypress inventory spec failed before implementation while heading was still rendered.
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-responsive-table-first/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-ai-assist/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-semantic-component-layer/spec.cy.ts -Browser electron

Closes #709