### PR TITLE
#711 Make Inventory create collection action icon-only

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-compact-collection-filter/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-compact-collection-filter/spec.cy.ts
@@ -46,6 +46,11 @@ describe("inventory-compact-collection-filter", () => {
 
     cy.get('[data-testid="inventory-folder-tree"]').should("not.exist");
     cy.get('[data-testid="inventory-collection-filter"]').should("be.visible");
+    cy.get('[data-testid="inventory-collection-add-root"]')
+      .should("be.visible")
+      .and("have.attr", "aria-label", "Create collection")
+      .and("have.attr", "title", "Create collection")
+      .and("not.contain", "New Collection");
     cy.get('[data-testid="inventory-collection-filter-selected"]').should(
       "contain",
       "All Items"

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -390,6 +390,9 @@ describe("inventory-management", () => {
     signIn();
     cy.wait("@itemsInline");
 
+    cy.get('[data-testid="inventory-collection-add-root"]')
+      .should("have.attr", "aria-label", "Create collection")
+      .and("not.contain", "New Collection");
     cy.get('[data-testid="inventory-collection-add-root"]').click();
     cy.get('[data-testid="folder-tree-name-input"]').type("Inline Alpha");
     cy.get('[data-testid="folder-tree-create-submit"]').click();

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -3336,15 +3336,18 @@ export function Collection({
       <Button
         type='button'
         variant='outline'
-        className='h-8 px-2 text-xs'
+        size='icon'
+        className='size-8'
         data-testid='inventory-collection-add-root'
+        aria-label='Create collection'
+        title='Create collection'
         onClick={() => {
           setFolderCreateParentID(null)
           setFolderCreateName('')
           setFolderCreateOpen(true)
         }}
       >
-        + New Collection
+        <Plus className='size-4' aria-hidden='true' />
       </Button>
       {folderDragOverlay}
     </div>


### PR DESCRIPTION
## Summary
- Replace the Inventory compact filter "+ New Collection" text button with an icon-only create collection action.
- Preserve the existing create collection flow and selection behavior.
- Add Cypress coverage for the icon-only accessible action.

## Validation
- Red-first compact collection filter spec failed before implementation.
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-compact-collection-filter/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron

Closes #711