### PR TITLE
#713 feat(inventory): add create modal collection assignment

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
@@ -195,6 +195,139 @@ describe("inventory item editor modal", () => {
     cy.contains("Only Title Draft").should("be.visible");
   });
 
+  it("creates an item into an existing collection from the create modal", () => {
+    const items: Array<{
+      id: string;
+      part_number: string;
+      title: string;
+      status: string;
+      category: string;
+      brand: string;
+      priority: string;
+      description: string;
+    }> = [];
+
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
+    }).as("itemsList");
+
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body).to.include({
+        part_number: "PN-STORE-1",
+        title: "Store One Created Item",
+      });
+      const created = {
+        id: "item-store-one-created",
+        part_number: req.body.part_number,
+        title: req.body.title,
+        status: "active",
+        category: req.body.category,
+        brand: req.body.brand,
+        priority: "medium",
+        description: req.body.description,
+      };
+      items.unshift(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createStoreOneItem");
+
+    signIn();
+    cy.wait("@itemsList");
+
+    cy.get('[data-testid="inventory-new-action"]').click();
+    cy.get('[data-testid="inventory-item-collection"]')
+      .should("be.visible")
+      .clear()
+      .type("Store 1");
+    cy.get('[data-testid="inventory-item-part-number"]').type("PN-STORE-1");
+    cy.get('[data-testid="inventory-item-title"]').type("Store One Created Item");
+    cy.get('[data-testid="inventory-item-save"]').click();
+
+    cy.wait("@createStoreOneItem");
+    cy.wait("@itemsList");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.get('[data-testid="collection-active-context"]').should("contain", "Store 1");
+    cy.get('[data-testid="inventory-collection-filter-selected"]').should(
+      "contain",
+      "Store 1"
+    );
+    cy.contains("Store One Created Item").should("be.visible");
+    cy.window().then((win) => {
+      expect(
+        JSON.parse(
+          win.localStorage.getItem("cabinet.inventory.item-folder-assignments.v1") ??
+            "{}"
+        )
+      ).to.include({ "item-store-one-created": "Store 1" });
+    });
+  });
+
+  it("creates a new collection from typed create modal collection text", () => {
+    const items: Array<{
+      id: string;
+      part_number: string;
+      title: string;
+      status: string;
+      category: string;
+      brand: string;
+      priority: string;
+      description: string;
+    }> = [];
+
+    cy.intercept("GET", "/api/items", (req) => {
+      req.reply({ statusCode: 200, body: { items } });
+    }).as("itemsList");
+
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body).to.include({
+        part_number: "PN-MODAL-SHELF",
+        title: "Modal Shelf Item",
+      });
+      const created = {
+        id: "item-modal-shelf",
+        part_number: req.body.part_number,
+        title: req.body.title,
+        status: "active",
+        category: req.body.category,
+        brand: req.body.brand,
+        priority: "medium",
+        description: req.body.description,
+      };
+      items.unshift(created);
+      req.reply({ statusCode: 201, body: created });
+    }).as("createModalShelfItem");
+
+    signIn();
+    cy.wait("@itemsList");
+
+    cy.get('[data-testid="inventory-new-action"]').click();
+    cy.get('[data-testid="inventory-item-collection"]').clear().type("Modal Shelf");
+    cy.get('[data-testid="inventory-item-part-number"]').type("PN-MODAL-SHELF");
+    cy.get('[data-testid="inventory-item-title"]').type("Modal Shelf Item");
+    cy.get('[data-testid="inventory-item-save"]').click();
+
+    cy.wait("@createModalShelfItem");
+    cy.wait("@itemsList");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.get('[data-testid="collection-active-context"]').should("contain", "Modal Shelf");
+    cy.get('[data-testid="inventory-collection-filter-selected"]').should(
+      "contain",
+      "Modal Shelf"
+    );
+    cy.get('[data-testid="inventory-collection-filter-select"]').should(
+      "contain",
+      "Modal Shelf"
+    );
+    cy.contains("Modal Shelf Item").should("be.visible");
+    cy.window().then((win) => {
+      expect(
+        JSON.parse(
+          win.localStorage.getItem("cabinet.inventory.item-folder-assignments.v1") ??
+            "{}"
+        )
+      ).to.include({ "item-modal-shelf": "Modal Shelf" });
+    });
+  });
+
   it("creates a draft item from only a captured image", () => {
     const items: Array<{
       id: string;

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -472,6 +472,10 @@ function normalizeInventoryCreatePayload(
   }
 }
 
+function normalizeCollectionInput(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
 function compactQuickCreateText(value: string): string {
   return value.replace(/\s+/g, ' ').trim()
 }
@@ -1216,6 +1220,7 @@ export function Collection({
     null
   )
   const [itemCreateBarcodeInput, setItemCreateBarcodeInput] = useState('')
+  const [itemCreateCollectionName, setItemCreateCollectionName] = useState('')
   const [itemSaveBusy, setItemSaveBusy] = useState(false)
   const [itemSaveError, setItemSaveError] = useState<string | null>(null)
   const [itemSaveSuccess, setItemSaveSuccess] = useState<string | null>(null)
@@ -1263,6 +1268,7 @@ export function Collection({
     setActiveWorkspaceCollection,
     addCollection,
     assignWorkspaceItemToCollection,
+    ensureWorkspaceCollectionAndAssignItem,
   } = useWorkspaceCollections()
   const assignableWorkspaceCollections = useMemo(
     () =>
@@ -1284,6 +1290,7 @@ export function Collection({
     setItemCreateIntent('manual')
     setItemCreatePhotoFile(null)
     setItemCreateBarcodeInput('')
+    setItemCreateCollectionName('')
   }, [])
 
   const startCreateItem = useCallback(
@@ -1294,6 +1301,9 @@ export function Collection({
       setItemCreateIntent(intent)
       setItemCreatePhotoFile(null)
       setItemCreateBarcodeInput('')
+      setItemCreateCollectionName(
+        activeFolder !== 'All Items' ? activeFolder : ''
+      )
       setItemSaveError(null)
       setItemSaveSuccess(null)
       setPasteCreateInput('')
@@ -1303,7 +1313,7 @@ export function Collection({
       selectInventoryItem(null)
       setItemEditorOpen(true)
     },
-    [selectInventoryItem]
+    [activeFolder, selectInventoryItem]
   )
 
   const startCreateItemFromPhoto = useCallback(() => {
@@ -2698,6 +2708,16 @@ export function Collection({
     const pendingCreateBarcode = itemCreateBarcodeInput.trim()
     const hasCreatePhoto = wasCreateMode && itemCreatePhotoFile !== null
     const hasCreateBarcode = wasCreateMode && pendingCreateBarcode !== ''
+    const pendingCreateCollection = wasCreateMode
+      ? normalizeCollectionInput(itemCreateCollectionName)
+      : ''
+    const targetCreateCollection =
+      pendingCreateCollection && pendingCreateCollection !== 'All Items'
+        ? (workspaceCollections.find(
+            (collection) =>
+              collection.toLowerCase() === pendingCreateCollection.toLowerCase()
+          ) ?? pendingCreateCollection)
+        : ''
     const payload = wasCreateMode
       ? normalizeInventoryCreatePayload(trimmedDraft, {
           barcode: pendingCreateBarcode,
@@ -2748,6 +2768,39 @@ export function Collection({
       }
       const saved = (await response.json()) as { id?: string }
       const savedID = saved.id?.trim() ?? selectedItemID
+      if (wasCreateMode && targetCreateCollection) {
+        setFolderTree((previous) =>
+          folderTreeContainsName(previous, targetCreateCollection)
+            ? previous
+            : [
+                ...previous,
+                {
+                  id: buildUniqueFolderID(targetCreateCollection, previous),
+                  name: targetCreateCollection,
+                },
+              ]
+        )
+        const workspaceItem: WorkspaceCollectionItem = {
+          id: savedID,
+          name: payload.title || payload.part_number,
+          detail:
+            [payload.brand, payload.category].filter(Boolean).join(' - ') ||
+            'Inventory item',
+          collectionName: targetCreateCollection,
+        }
+        const assigned = await ensureWorkspaceCollectionAndAssignItem(
+          workspaceItem,
+          targetCreateCollection
+        )
+        if (!assigned) {
+          throw new Error('create_item_collection_assignment')
+        }
+        setItemFolderAssignments((current) => ({
+          ...current,
+          [savedID]: targetCreateCollection,
+        }))
+        setActiveFolder(targetCreateCollection)
+      }
       if (wasCreateMode && itemCreatePhotoFile) {
         const photoBody = new FormData()
         photoBody.append('file', itemCreatePhotoFile)
@@ -2795,13 +2848,16 @@ export function Collection({
     }
   }, [
     itemCreateBarcodeInput,
+    itemCreateCollectionName,
     itemCreateIntent,
     itemCreatePhotoFile,
     itemDraft,
     itemEditorMode,
+    ensureWorkspaceCollectionAndAssignItem,
     loadInventoryItems,
     resetCreateAttachments,
     selectedItemID,
+    workspaceCollections,
   ])
 
   const handlePhotoUpload = useCallback(
@@ -4128,6 +4184,37 @@ export function Collection({
                                 </div>
                               ) : null}
                             </div>
+                          </div>
+                        ) : null}
+                        {itemEditorMode === 'create' ? (
+                          <div className='space-y-2'>
+                            <label
+                              className='text-sm font-medium'
+                              htmlFor='inventory-item-collection'
+                            >
+                              Collection
+                            </label>
+                            <Input
+                              id='inventory-item-collection'
+                              list='inventory-item-collection-options'
+                              data-testid='inventory-item-collection'
+                              placeholder='Choose or type a collection'
+                              value={itemCreateCollectionName}
+                              onChange={(event) =>
+                                setItemCreateCollectionName(event.target.value)
+                              }
+                            />
+                            <datalist id='inventory-item-collection-options'>
+                              {assignableWorkspaceCollections.map(
+                                (collection) => (
+                                  <option key={collection} value={collection} />
+                                )
+                              )}
+                            </datalist>
+                            <p className='text-xs text-muted-foreground'>
+                              Type a new collection name to create it with this
+                              item.
+                            </p>
                           </div>
                         ) : null}
                         <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>

--- a/ui.web/src/features/collections/use-workspace-collections.ts
+++ b/ui.web/src/features/collections/use-workspace-collections.ts
@@ -140,7 +140,8 @@ function buildDefaultSummary(name: string): WorkspaceCollectionSummary {
     scopeLabel: 'Custom collection',
     statusLabel: 'Active',
     updatedLabel: 'Updated just now',
-    description: 'Custom workspace collection created from the management surface.',
+    description:
+      'Custom workspace collection created from the management surface.',
   }
 }
 
@@ -235,12 +236,8 @@ function serializeWorkspaceCollectionsState(
 }
 
 export function useWorkspaceCollections() {
-  const {
-    activeProfileId,
-    loading,
-    settings,
-    saveSettings,
-  } = useProfileSettings()
+  const { activeProfileId, loading, settings, saveSettings } =
+    useProfileSettings()
   const persistedState = useMemo(
     () =>
       loading
@@ -281,9 +278,13 @@ export function useWorkspaceCollections() {
       return {
         ...base,
         itemCount:
-          name === 'All Items' ? Math.max(base.itemCount, assignedCount) : assignedCount,
+          name === 'All Items'
+            ? Math.max(base.itemCount, assignedCount)
+            : assignedCount,
         updatedLabel:
-          assignedCount > 0 && name !== 'All Items' ? 'Updated just now' : base.updatedLabel,
+          assignedCount > 0 && name !== 'All Items'
+            ? 'Updated just now'
+            : base.updatedLabel,
       }
     })
   }, [workspaceCollections, workspaceItems])
@@ -317,7 +318,11 @@ export function useWorkspaceCollections() {
     const normalizedNext = normalizeCollectionName(nextName)
     const currentKey = collectionKey(normalizedCurrent)
     const nextKey = collectionKey(normalizedNext)
-    if (!normalizedCurrent || !normalizedNext || normalizedCurrent === 'All Items') {
+    if (
+      !normalizedCurrent ||
+      !normalizedNext ||
+      normalizedCurrent === 'All Items'
+    ) {
       return null
     }
     const exists = workspaceCollections.some(
@@ -331,9 +336,7 @@ export function useWorkspaceCollections() {
 
     await persistWorkspaceCollectionsState({
       collections: workspaceCollections.map((collection) =>
-        collectionKey(collection) === currentKey
-          ? normalizedNext
-          : collection
+        collectionKey(collection) === currentKey ? normalizedNext : collection
       ),
       activeCollection:
         collectionKey(activeWorkspaceCollection) === currentKey
@@ -371,7 +374,8 @@ export function useWorkspaceCollections() {
           ? 'All Items'
           : activeWorkspaceCollection,
       items: workspaceItems.map((item) =>
-        item.collectionName && collectionKey(item.collectionName) === normalizedKey
+        item.collectionName &&
+        collectionKey(item.collectionName) === normalizedKey
           ? { ...item, collectionName: null }
           : item
       ),
@@ -385,10 +389,18 @@ export function useWorkspaceCollections() {
     collectionName: string
   ): Promise<WorkspaceCollectionItem | null> => {
     const normalizedCollection = normalizeCollectionName(collectionName)
-    if (!itemID || !normalizedCollection || normalizedCollection === 'All Items') {
+    if (
+      !itemID ||
+      !normalizedCollection ||
+      normalizedCollection === 'All Items'
+    ) {
       return Promise.resolve(null)
     }
-    if (!workspaceCollections.some((collection) => collection === normalizedCollection)) {
+    if (
+      !workspaceCollections.some(
+        (collection) => collection === normalizedCollection
+      )
+    ) {
       return Promise.resolve(null)
     }
 
@@ -397,8 +409,7 @@ export function useWorkspaceCollections() {
         ? { ...item, collectionName: normalizedCollection }
         : item
     )
-    const updatedItem =
-      updatedItems.find((item) => item.id === itemID) ?? null
+    const updatedItem = updatedItems.find((item) => item.id === itemID) ?? null
 
     if (!updatedItem) {
       return Promise.resolve(null)
@@ -453,6 +464,50 @@ export function useWorkspaceCollections() {
     }).then(() => normalizedItem)
   }
 
+  const ensureWorkspaceCollectionAndAssignItem = (
+    item: WorkspaceCollectionItem,
+    collectionName: string
+  ): Promise<WorkspaceCollectionItem | null> => {
+    const normalizedCollection = normalizeCollectionName(collectionName)
+    if (
+      !item.id ||
+      !normalizedCollection ||
+      normalizedCollection === 'All Items'
+    ) {
+      return Promise.resolve(null)
+    }
+
+    const existingCollection =
+      workspaceCollections.find(
+        (collection) =>
+          collection.toLowerCase() === normalizedCollection.toLowerCase()
+      ) ?? null
+    const targetCollection = existingCollection ?? normalizedCollection
+    const nextCollections = existingCollection
+      ? workspaceCollections
+      : [...workspaceCollections, targetCollection]
+    const normalizedItem = normalizeWorkspaceCollectionItem({
+      ...item,
+      collectionName: targetCollection,
+    })
+    const existingItem = workspaceItems.some(
+      (workspaceItem) => workspaceItem.id === normalizedItem.id
+    )
+    const updatedItems = existingItem
+      ? workspaceItems.map((workspaceItem) =>
+          workspaceItem.id === normalizedItem.id
+            ? normalizedItem
+            : workspaceItem
+        )
+      : [...workspaceItems, normalizedItem]
+
+    return persistWorkspaceCollectionsState({
+      collections: nextCollections,
+      activeCollection: targetCollection,
+      items: updatedItems,
+    }).then(() => normalizedItem)
+  }
+
   const unassignItemFromCollection = (
     itemID: string
   ): Promise<WorkspaceCollectionItem | null> => {
@@ -502,6 +557,7 @@ export function useWorkspaceCollections() {
     collectionItems,
     assignItemToCollection,
     assignWorkspaceItemToCollection,
+    ensureWorkspaceCollectionAndAssignItem,
     unassignItemFromCollection,
   }
 }


### PR DESCRIPTION
## Summary
- adds a Collection field to the inventory create-item modal with existing collection suggestions
- creates typed new collections as part of item save and assigns the new item into them
- selects the target collection after create so the new item is visible in context

## Validation
- PASS: pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- PASS: pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts -Browser electron
- PASS: pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron
- NOTE: collections ui spec was attempted separately but the Cypress process hung with no spec output before timeout; no product failure output was produced.

Closes #713