### PR TITLE
#719 fix(inventory): restore folder tree regression coverage

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-compact-collection-filter/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-compact-collection-filter/spec.cy.ts
@@ -7,7 +7,7 @@ describe("inventory-compact-collection-filter", () => {
     });
   }
 
-  it("uses compact collection filters instead of the folder tree panel", () => {
+  it("keeps compact collection filters alongside the folder tree panel", () => {
     cy.intercept("GET", "/api/items", {
       statusCode: 200,
       body: {
@@ -44,7 +44,8 @@ describe("inventory-compact-collection-filter", () => {
     cy.reload();
     cy.wait("@itemsCollectionFilter");
 
-    cy.get('[data-testid="inventory-folder-tree"]').should("not.exist");
+    cy.get('[data-testid="inventory-folder-tree"]').should("be.visible");
+    cy.get('[data-testid="folder-tree-item-store-1"]').should("be.visible");
     cy.get('[data-testid="inventory-collection-filter"]').should("be.visible");
     cy.get('[data-testid="inventory-collection-add-root"]')
       .should("be.visible")

--- a/ui.web/cypress/e2e/inventory/inventory-folder-tree-presence/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-folder-tree-presence/spec.cy.ts
@@ -1,0 +1,67 @@
+describe('inventory-folder-tree-presence', () => {
+  function openInventory() {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: '/inventory/',
+      })
+    })
+  }
+
+  it('keeps the inventory folder tree visible and wired to context filtering', () => {
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'item-tree-visible-1',
+            part_number: 'PN-TREE-VISIBLE-1',
+            title: 'Store One Tree Item',
+            status: 'active',
+            category: 'Cars',
+          },
+          {
+            id: 'item-tree-visible-2',
+            part_number: 'PN-TREE-VISIBLE-2',
+            title: 'Watch List Tree Item',
+            status: 'active',
+            category: 'Cars',
+          },
+        ],
+      },
+    }).as('itemsForTree')
+
+    openInventory()
+    cy.wait('@itemsForTree')
+    cy.window().then((win) => {
+      win.localStorage.setItem(
+        'cabinet.inventory.item-folder-assignments.v1',
+        JSON.stringify({
+          'item-tree-visible-1': 'Store 1',
+          'item-tree-visible-2': 'Watch List',
+        })
+      )
+    })
+    cy.reload()
+    cy.wait('@itemsForTree')
+
+    cy.get('[data-testid="inventory-folder-tree"][role="tree"]').should(
+      'be.visible'
+    )
+    cy.get('[data-testid="folder-tree-item-all-items"]').should('be.visible')
+    cy.get('[data-testid="folder-tree-item-store-1"]').should('be.visible')
+    cy.get('[data-testid="collection-folder-all-items"]').should(
+      'contain.text',
+      'All Items'
+    )
+
+    cy.get('[data-testid="folder-tree-item-store-1"]').click()
+    cy.get('[data-testid="collection-active-context"]').should(
+      'contain.text',
+      'Store 1'
+    )
+    cy.contains('Store One Tree Item').should('be.visible')
+    cy.contains('Watch List Tree Item').should('not.exist')
+  })
+})

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -615,6 +615,16 @@ function buildWorkspaceCollectionFilterOptions(
   }))
 }
 
+function buildFolderTreeFilterOptions(
+  nodes: FolderNode[],
+  level = 0
+): Array<FolderNode & { level: number }> {
+  return nodes.flatMap((node) => [
+    { ...node, level },
+    ...buildFolderTreeFilterOptions(node.children ?? [], level + 1),
+  ])
+}
+
 function buildUniqueFolderID(name: string, nodes: FolderNode[]): string {
   const slug = slugifyFolderName(name) || 'folder'
   const existingIDs = new Set<string>()
@@ -1471,14 +1481,18 @@ export function Collection({
 
   const selectInventoryFolder = useCallback(
     (nextFolder: string) => {
-      const safeFolder = workspaceCollections.includes(nextFolder)
-        ? nextFolder
-        : 'All Items'
+      const safeFolder =
+        workspaceCollections.includes(nextFolder) ||
+        folderTreeContainsName(folderTree, nextFolder)
+          ? nextFolder
+          : 'All Items'
       setActiveFolder(safeFolder)
       setCollectionBrowserOpen(false)
-      void setActiveWorkspaceCollection(safeFolder)
+      if (workspaceCollections.includes(safeFolder)) {
+        void setActiveWorkspaceCollection(safeFolder)
+      }
     },
-    [setActiveWorkspaceCollection, workspaceCollections]
+    [folderTree, setActiveWorkspaceCollection, workspaceCollections]
   )
 
   const resolveInventoryItemFromTask = useCallback(
@@ -2461,10 +2475,13 @@ export function Collection({
     }),
     [activeFolder, folderTree, tableData.length]
   )
-  const folderFilterOptions = useMemo(
-    () => buildWorkspaceCollectionFilterOptions(workspaceCollections),
-    [workspaceCollections]
-  )
+  const folderFilterOptions = useMemo(() => {
+    const treeOptions = buildFolderTreeFilterOptions(folderTree)
+    if (treeOptions.length > 0) {
+      return treeOptions
+    }
+    return buildWorkspaceCollectionFilterOptions(workspaceCollections)
+  }, [folderTree, workspaceCollections])
   const activeFolderIsAvailable = folderFilterOptions.some(
     (folder) => folder.name === activeFolder
   )
@@ -3556,10 +3573,10 @@ export function Collection({
 
       <Main className='space-y-3'>
         <div
-          className='grid grid-cols-1 gap-4'
+          className='grid grid-cols-1 gap-4 xl:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)]'
           data-testid='inventory-workspace'
         >
-          <Card className='hidden'>
+          <Card className='flex min-h-[32rem] flex-col overflow-hidden'>
             <CardHeader>
               <CardTitle>Folders</CardTitle>
               <CardDescription>
@@ -3607,7 +3624,7 @@ export function Collection({
               <div
                 role='tree'
                 aria-label='Inventory folders'
-                data-testid='inventory-folder-tree-legacy'
+                data-testid='inventory-folder-tree'
                 className='max-h-[42rem] min-h-[26rem] flex-1 overflow-x-auto overflow-y-auto rounded-md border p-2'
               >
                 <div


### PR DESCRIPTION
## Summary

Restores the Inventory folder tree and adds focused regression coverage so the tree cannot silently disappear again.

## Root Cause

A later inventory refactor kept the tree implementation in the component but rendered it inside a hidden card and renamed its canonical test id to `inventory-folder-tree-legacy`. Another Cypress spec then asserted the tree should not exist, so the wrong behavior became protected.

## Changes

- Makes the Inventory folder tree panel visible again beside the inventory table on wide layouts.
- Restores the canonical `inventory-folder-tree` test id.
- Reconnects folder selection/filter options to the actual folder tree, not just `workspaceCollections`.
- Adds a focused Cypress regression proving the tree exists and selecting `Store 1` filters inventory context.
- Updates the compact collection filter spec so it expects compact filters and the tree to coexist.

## Validation

- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-folder-tree-presence/spec.cy.ts -Browser electron`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/inventory-compact-collection-filter/spec.cy.ts -Browser electron`
- Push hook: OpenSpec validation and fast API docs smoke test passed.

Closes #719