### PR TITLE
#721 Restore wishlist visible data tests

### DIFF
--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -101,7 +101,7 @@ describe("ui-screen-wishlist", () => {
     signInToWishlist();
 
     cy.contains("Wishlist").should("be.visible");
-    cy.get('[data-testid="wishlist-page-header"]').within(() => {
+    cy.get('[data-testid="wishlist-global-header-actions"]').within(() => {
       cy.get('[data-testid="wishlist-new-action"]').should("be.visible");
       cy.get('[data-testid="wishlist-create-menu-trigger"]').should("be.visible");
     });

--- a/ui.web/cypress/e2e/wishlist/wishlist-visible-data/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-visible-data/spec.cy.ts
@@ -1,0 +1,94 @@
+describe('wishlist-visible-data', () => {
+  const collectionsSettingsKey = 'collections.workspace.v1'
+
+  function openWishlistWithStaleCollectionContext() {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.request('PUT', `/api/profiles/${profile_id}/settings`, {
+        settings: {
+          [collectionsSettingsKey]: JSON.stringify({
+            collections: ['All Items', 'Overflow'],
+            activeCollection: 'Overflow',
+            items: [],
+          }),
+        },
+      }).its('status').should('eq', 200)
+
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: '/wishlist/',
+      })
+    })
+  }
+
+  it('shows seeded wishlist rows even after another screen leaves an empty collection active', () => {
+    cy.intercept('GET', '/api/wishlist').as('wishlistEntries')
+    cy.intercept('GET', '/api/items?status=wishlist').as('wishlistItems')
+    cy.intercept('GET', '/api/profiles/*/settings').as('profileSettings')
+
+    openWishlistWithStaleCollectionContext()
+
+    cy.wait('@wishlistEntries')
+    cy.wait('@wishlistItems')
+    cy.wait('@profileSettings')
+
+    cy.get('[data-testid="wishlist-table-collection-selected"]').should(
+      'contain',
+      'All Items'
+    )
+    cy.contains('Wishlist Sample Grail Chase').should('be.visible')
+    cy.contains('Wishlist Sample Price Drop Watch').should('be.visible')
+    cy.contains('Wishlist Sample Steady Watch').should('be.visible')
+    cy.contains('No results.').should('not.exist')
+  })
+
+  it('does not flash generic task seed rows while wishlist API data is loading', () => {
+    cy.intercept('GET', '/api/wishlist', {
+      delay: 3000,
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'wish-visible-1',
+            item_id: 'wish-item-visible-1',
+            priority: 'high',
+            below_target_now: false,
+          },
+        ],
+      },
+    }).as('slowWishlistEntries')
+    cy.intercept('GET', '/api/items?status=wishlist', {
+      delay: 3000,
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: 'wish-item-visible-1',
+            title: 'Visible Wishlist API Row',
+            part_number: 'WISH-VISIBLE-1',
+            status: 'wishlist',
+            category: 'Cards',
+            priority: 'high',
+          },
+        ],
+      },
+    }).as('slowWishlistItems')
+
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: '/wishlist/',
+      })
+    })
+
+    cy.get('body').then(($body) => {
+      expect($body.text()).not.to.match(/TASK-\d+/)
+    })
+
+    cy.wait('@slowWishlistEntries')
+    cy.wait('@slowWishlistItems')
+    cy.contains('Visible Wishlist API Row').should('be.visible')
+    cy.contains(/TASK-\d+/).should('not.exist')
+  })
+})

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -243,7 +243,10 @@ export function Tasks({
     inlineCollectionValidationMessage,
     setInlineCollectionValidationMessage,
   ] = useState('')
-  const [tableData, setTableData] = useState<Task[]>(tasks)
+  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
+  const [tableData, setTableData] = useState<Task[]>(() =>
+    isWishlistRoute ? [] : tasks
+  )
   const [dialogOpen, setDialogOpen] = useState<TasksDialogType | null>(null)
   const [currentDialogRow, setCurrentDialogRow] = useState<Task | null>(null)
   const [wishlistActionItemID, setWishlistActionItemID] = useState<
@@ -259,8 +262,6 @@ export function Tasks({
         window.localStorage.getItem(WISHLIST_PLANNING_FOCUS_STORAGE_KEY)
       )
     })
-  const isWishlistRoute = routePath === '/_authenticated/wishlist/'
-
   const loadWishlistData = useCallback(async () => {
     const [wishlistResponse, itemsResponse] = await Promise.all([
       fetch('/api/wishlist'),
@@ -317,6 +318,7 @@ export function Tasks({
     }
 
     let cancelled = false
+    setTableData([])
     void loadWishlistData()
       .then((mapped) => {
         if (!cancelled) {


### PR DESCRIPTION
## Summary
- prevent the Wishlist route from rendering generic task seed rows while API-backed wishlist data loads
- add Cypress coverage for stale collection context and delayed wishlist API responses
- update stale Wishlist header selector in the existing screen spec

## Validation
- pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-visible-data/spec.cy.ts -Browser electron
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron
- git diff --check