### PR TITLE
#723 Add wishlist pricing columns and inline buying edits

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2826,9 +2826,42 @@ func New(cfg config.Config) (*App, error) {
 			_ = json.NewEncoder(w).Encode(created)
 		case http.MethodPut:
 			var req wishlist.Entry
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var raw map[string]json.RawMessage
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 				http.Error(w, `{"error":"invalid_json"}`, http.StatusBadRequest)
 				return
+			}
+			encoded, err := json.Marshal(raw)
+			if err != nil {
+				http.Error(w, `{"error":"invalid_json"}`, http.StatusBadRequest)
+				return
+			}
+			if err := json.Unmarshal(encoded, &req); err != nil {
+				http.Error(w, `{"error":"invalid_json"}`, http.StatusBadRequest)
+				return
+			}
+			if strings.TrimSpace(req.ID) != "" {
+				existing, err := wishlistSvc.GetByIDForProfile(r.Context(), profileID, req.ID)
+				if err == nil {
+					if _, ok := raw["item_id"]; !ok {
+						req.ItemID = existing.ItemID
+					}
+					if _, ok := raw["target_price"]; !ok {
+						req.TargetPrice = existing.TargetPrice
+					}
+					if _, ok := raw["priority"]; !ok {
+						req.Priority = existing.Priority
+					}
+					if _, ok := raw["notes"]; !ok {
+						req.Notes = existing.Notes
+					}
+					if _, ok := raw["highlight_hit"]; !ok {
+						req.HighlightHit = existing.HighlightHit
+					}
+					if _, ok := raw["below_target_now"]; !ok {
+						req.BelowTargetNow = existing.BelowTargetNow
+					}
+				}
 			}
 			if err := wishlistSvc.UpdateForProfile(r.Context(), profileID, req); err != nil {
 				http.Error(w, `{"error":"failed_to_update_wishlist"}`, http.StatusBadRequest)

--- a/internal/app/wishlist_planning_metadata_api_test.go
+++ b/internal/app/wishlist_planning_metadata_api_test.go
@@ -103,4 +103,42 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	if listPayload.Items[0].Notes != "updated manual watch state" {
 		t.Fatalf("expected updated wishlist notes to persist, got %+v", listPayload.Items[0])
 	}
+
+	partialUpdate := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+created.ID+`","priority":"high"}`), map[string]string{"Content-Type": "application/json"})
+	if partialUpdate.Code != http.StatusOK {
+		t.Fatalf("partial update wishlist status=%d body=%s", partialUpdate.Code, partialUpdate.Body.String())
+	}
+
+	listAfterPartialUpdate := doRequest(t, a, http.MethodGet, "/api/wishlist", nil, nil)
+	if listAfterPartialUpdate.Code != http.StatusOK {
+		t.Fatalf("list wishlist after partial update status=%d body=%s", listAfterPartialUpdate.Code, listAfterPartialUpdate.Body.String())
+	}
+	var partialPayload struct {
+		Items []struct {
+			ID             string  `json:"id"`
+			TargetPrice    float64 `json:"target_price"`
+			BelowTargetNow bool    `json:"below_target_now"`
+			HighlightHit   bool    `json:"highlight_hit"`
+			Priority       string  `json:"priority"`
+			Notes          string  `json:"notes"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(listAfterPartialUpdate.Body).Decode(&partialPayload); err != nil {
+		t.Fatalf("decode partial wishlist payload: %v", err)
+	}
+	if len(partialPayload.Items) != 1 {
+		t.Fatalf("expected one wishlist entry after partial update, got %+v", partialPayload.Items)
+	}
+	if partialPayload.Items[0].Priority != "high" {
+		t.Fatalf("expected partial update to set priority=high, got %+v", partialPayload.Items[0])
+	}
+	if partialPayload.Items[0].TargetPrice != 42 {
+		t.Fatalf("expected partial update to preserve target_price=42, got %+v", partialPayload.Items[0])
+	}
+	if partialPayload.Items[0].Notes != "updated manual watch state" {
+		t.Fatalf("expected partial update to preserve notes, got %+v", partialPayload.Items[0])
+	}
+	if partialPayload.Items[0].BelowTargetNow || partialPayload.Items[0].HighlightHit {
+		t.Fatalf("expected partial update to preserve false watch flags, got %+v", partialPayload.Items[0])
+	}
 }

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -117,7 +117,7 @@ describe("ui-screen-wishlist", () => {
     cy.contains("Status:").should("be.visible");
 
     cy.contains("button", "Rows").click();
-    cy.get('input[placeholder="Filter by title or ID..."]').type("no-match-wishlist");
+    cy.get('input[placeholder="Filter by title or part number..."]').type("no-match-wishlist");
     cy.contains("No results.").should("be.visible");
   });
 
@@ -128,9 +128,19 @@ describe("ui-screen-wishlist", () => {
     cy.contains("Wishlist Sample Grail Chase").should("be.visible");
     cy.contains("Wishlist Sample Price Drop Watch").should("be.visible");
     cy.contains("Wishlist Sample Steady Watch").should("be.visible");
-    cy.contains("Below target").should("be.visible");
-    cy.contains("High").should("be.visible");
-    cy.contains("Low").should("be.visible");
+    cy.get('[data-testid="wishlist-planning-focus-below-target"]').should(
+      "contain",
+      "1"
+    );
+    cy.get('select[data-testid^="wishlist-priority-select-"]').then(
+      ($selects) => {
+        const values = [...$selects].map(
+          (select) => (select as HTMLSelectElement).value
+        );
+        expect(values).to.include("high");
+        expect(values).to.include("low");
+      }
+    );
   });
 
   it("UI-SCREEN-WISHLIST-003 supports multi-select with bulk action toolbar", () => {
@@ -241,15 +251,17 @@ describe("ui-screen-wishlist", () => {
     signInToWishlist();
 
     cy.get('button[aria-label="Switch to rows view"]').click();
-    cy.contains("th", "Item ID").should("be.visible");
+    cy.contains("th", "Item ID").should("not.exist");
     cy.contains("th", "Title").should("be.visible");
-    cy.contains("th", "Watch Status").should("be.visible");
-    cy.contains("th", "Target Priority").should("be.visible");
+    cy.contains("th", "Watch Status").should("not.exist");
+    cy.contains("th", "Market Price").should("be.visible");
+    cy.contains("th", "Price Graph").should("be.visible");
+    cy.contains("th", "Cost").should("be.visible");
+    cy.contains("th", "Priority").should("be.visible");
+    cy.contains("th", "Target Priority").should("not.exist");
     cy.contains("th", "Task").should("not.exist");
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
-    cy.contains("item-collector-1").should("be.visible");
-    cy.contains("Watching").should("be.visible");
-    cy.contains("Below target").should("be.visible");
+    cy.contains("22073").should("not.exist");
     cy.contains(/TASK-\d+/).should("not.exist");
     cy.contains("Backlog").should("not.exist");
   });

--- a/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
@@ -1,0 +1,130 @@
+describe("wishlist-pricing-columns", () => {
+  function openWishlist() {
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: "/wishlist/",
+      });
+    });
+  }
+
+  it("shows buying columns and persists inline cost and priority edits", () => {
+    let wishlistEntries = [
+      {
+        id: "wish-price-1",
+        item_id: "item-price-1",
+        priority: "medium",
+        below_target_now: false,
+        notes: "Watch clean boxed examples",
+        target_price: 25,
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "item-price-1",
+            title: "Wishlist Pricing Candidate",
+            part_number: "WPC-001",
+            status: "wishlist",
+            category: "Cards",
+            priority: "medium",
+          },
+        ],
+      },
+    }).as("catalogItems");
+    cy.intercept("GET", "/api/pricing/stats?item_id=item-price-1", {
+      statusCode: 200,
+      body: { min: 18, median: 21, latest: 22.5 },
+    }).as("priceStats");
+    cy.intercept("GET", "/api/pricing/trend?item_id=item-price-1", {
+      statusCode: 200,
+      body: {
+        points: [
+          { date: "2026-04-25", latest: 24 },
+          { date: "2026-04-26", latest: 22.5 },
+        ],
+      },
+    }).as("priceTrend");
+    cy.intercept("PUT", "/api/wishlist", (req) => {
+      expect(req.body.id).to.eq("wish-price-1");
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === req.body.id
+          ? {
+              ...entry,
+              priority: req.body.priority ?? entry.priority,
+              target_price: req.body.target_price ?? entry.target_price,
+              notes: req.body.notes ?? entry.notes,
+              highlight_hit: req.body.highlight_hit ?? entry.highlight_hit,
+              below_target_now:
+                req.body.below_target_now ?? entry.below_target_now,
+            }
+          : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("updateWishlistEntry");
+
+    openWishlist();
+
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.wait("@priceStats");
+    cy.wait("@priceTrend");
+
+    cy.get('button[aria-label="Switch to rows view"]').click();
+    cy.contains("th", "Item ID").should("not.exist");
+    cy.contains("th", "Market Price").should("be.visible");
+    cy.contains("th", "Price Graph").should("be.visible");
+    cy.contains("th", "Cost").should("be.visible");
+    cy.contains("th", "Priority").should("be.visible");
+    cy.contains("th", "Target Priority").should("not.exist");
+
+    cy.contains("Wishlist Pricing Candidate").should("be.visible");
+    cy.contains("$22.50").should("be.visible");
+    cy.get('[data-testid="wishlist-price-trend-item-price-1"]')
+      .should("have.attr", "aria-label", "Price trending down")
+      .and("be.visible");
+
+    cy.get('[data-testid="wishlist-cost-input-item-price-1"]')
+      .clear()
+      .type("19.75{enter}");
+    cy.wait("@updateWishlistEntry")
+      .its("request.body")
+      .should("include", {
+        id: "wish-price-1",
+        target_price: 19.75,
+      });
+
+    cy.get('[data-testid="wishlist-priority-select-item-price-1"]').then(
+      ($select) => {
+        const select = $select[0] as HTMLSelectElement;
+        select.value = "high";
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    );
+    cy.wait("@updateWishlistEntry")
+      .its("request.body")
+      .should("include", {
+        id: "wish-price-1",
+        priority: "high",
+      });
+
+    cy.reload();
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.get('[data-testid="wishlist-cost-input-item-price-1"]').should(
+      "have.value",
+      "19.75"
+    );
+    cy.get('[data-testid="wishlist-priority-select-item-price-1"]').should(
+      "have.value",
+      "high"
+    );
+  });
+});

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -1,8 +1,17 @@
+import { useEffect, useState } from 'react'
 import { type ColumnDef } from '@tanstack/react-table'
-import { BarcodeIcon, ImageIcon, TagsIcon } from 'lucide-react'
+import {
+  BarcodeIcon,
+  ImageIcon,
+  TagsIcon,
+  TrendingDownIcon,
+  TrendingUpIcon,
+  MinusIcon,
+} from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
 import { DataTableColumnHeader } from '@/components/data-table'
 import { labels, priorities, statuses } from '../data/data'
 import { type Task } from '../data/schema'
@@ -20,16 +29,159 @@ type TasksColumnsOptions = {
   onAssignCollectionRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
   onWishlistMarkOwned?: (task: Task) => Promise<void>
+  onWishlistInlineUpdate?: (
+    task: Task,
+    changes: { targetPrice?: number; priority?: string }
+  ) => Promise<void>
   wishlistActionItemID?: string | null
 }
 
-const wishlistStatusLabels: Record<string, string> = {
-  wishlist: 'Watching',
-  discovered: 'Below target',
+function formatMoney(value: number | undefined) {
+  if (typeof value !== 'number' || value <= 0) {
+    return '-'
+  }
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(value)
 }
 
-function formatWishlistStatus(status: string) {
-  return wishlistStatusLabels[status] ?? status
+function formatCostDraft(value: number | undefined) {
+  if (typeof value !== 'number' || value <= 0) {
+    return ''
+  }
+  return Number.isInteger(value) ? String(value) : value.toFixed(2)
+}
+
+function WishlistPriceTrendCell({ task }: { task: Task }) {
+  const trend = task.priceTrend ?? 'unknown'
+  const trendConfig = {
+    up: {
+      label: 'Price trending up',
+      icon: TrendingUpIcon,
+      className: 'text-red-300',
+    },
+    steady: {
+      label: 'Price steady',
+      icon: MinusIcon,
+      className: 'text-muted-foreground',
+    },
+    down: {
+      label: 'Price trending down',
+      icon: TrendingDownIcon,
+      className: 'text-emerald-300',
+    },
+    unknown: {
+      label: 'Price trend unknown',
+      icon: MinusIcon,
+      className: 'text-muted-foreground',
+    },
+  }[trend]
+  const Icon = trendConfig.icon
+
+  return (
+    <span
+      className='flex min-w-[44px] items-center justify-center'
+      data-testid={`wishlist-price-trend-${task.id}`}
+      aria-label={trendConfig.label}
+      title={trendConfig.label}
+    >
+      <Icon className={`size-4 ${trendConfig.className}`} />
+    </span>
+  )
+}
+
+function WishlistCostCell({
+  task,
+  onWishlistInlineUpdate,
+}: {
+  task: Task
+  onWishlistInlineUpdate?: (
+    task: Task,
+    changes: { targetPrice?: number; priority?: string }
+  ) => Promise<void>
+}) {
+  const [draft, setDraft] = useState(formatCostDraft(task.targetPrice))
+
+  useEffect(() => {
+    setDraft(formatCostDraft(task.targetPrice))
+  }, [task.targetPrice])
+
+  const persist = async () => {
+    const trimmed = draft.trim()
+    const nextValue = trimmed === '' ? 0 : Number(trimmed)
+    if (Number.isNaN(nextValue) || nextValue < 0) {
+      setDraft(formatCostDraft(task.targetPrice))
+      return
+    }
+    if ((task.targetPrice ?? 0) === nextValue) {
+      return
+    }
+    await onWishlistInlineUpdate?.(task, { targetPrice: nextValue })
+  }
+
+  return (
+    <Input
+      type='number'
+      min='0'
+      step='0.01'
+      inputMode='decimal'
+      value={draft}
+      data-testid={`wishlist-cost-input-${task.id}`}
+      aria-label={`Cost for ${task.title}`}
+      className='h-8 w-[6.5rem]'
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={() => {
+        void persist()
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          event.currentTarget.blur()
+        }
+      }}
+    />
+  )
+}
+
+function WishlistPriorityCell({
+  task,
+  onWishlistInlineUpdate,
+}: {
+  task: Task
+  onWishlistInlineUpdate?: (
+    task: Task,
+    changes: { targetPrice?: number; priority?: string }
+  ) => Promise<void>
+}) {
+  const persistPriority = (nextPriority: string) => {
+    if (nextPriority === task.priority) {
+      return
+    }
+    void onWishlistInlineUpdate?.(task, { priority: nextPriority })
+  }
+
+  return (
+    <select
+      className='h-8 min-w-[6.75rem] rounded-md border bg-background px-2 text-sm'
+      value={task.priority}
+      data-testid={`wishlist-priority-select-${task.id}`}
+      aria-label={`Priority for ${task.title}`}
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onChange={(event) => {
+        persistPriority(event.target.value)
+      }}
+    >
+      {priorities.map((priority) => (
+        <option key={priority.value} value={priority.value}>
+          {priority.label}
+        </option>
+      ))}
+    </select>
+  )
 }
 
 export function getTasksColumns({
@@ -40,6 +192,7 @@ export function getTasksColumns({
   onAssignCollectionRow,
   onDeleteRow,
   onWishlistMarkOwned,
+  onWishlistInlineUpdate,
   wishlistActionItemID,
 }: TasksColumnsOptions): ColumnDef<Task>[] {
   const isInventoryRoute = routePath === '/_authenticated/inventory/'
@@ -70,27 +223,33 @@ export function getTasksColumns({
       enableSorting: false,
       enableHiding: false,
     },
-    {
-      accessorKey: 'id',
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          column={column}
-          title={
-            isInventoryRoute ? 'Part #' : isWishlistRoute ? 'Item ID' : 'Task'
-          }
-        />
-      ),
-      cell: ({ row }) => <div className='w-[120px]'>{row.getValue('id')}</div>,
-      enableSorting: false,
-      enableHiding: false,
-    },
+    ...(isWishlistRoute
+      ? []
+      : [
+          {
+            accessorKey: 'id',
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                column={column}
+                title={isInventoryRoute ? 'Part #' : 'Task'}
+              />
+            ),
+            cell: ({ row }) => (
+              <div className='w-[120px]'>{row.getValue('id')}</div>
+            ),
+            enableSorting: false,
+            enableHiding: false,
+          } satisfies ColumnDef<Task>,
+        ]),
     {
       accessorKey: 'title',
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title='Title' />
       ),
       meta: {
-        className: 'ps-1 max-w-0 w-2/3',
+        className: isWishlistRoute
+          ? 'ps-1 min-w-[12rem]'
+          : 'ps-1 max-w-0 w-2/3',
         tdClassName: 'ps-4',
       },
       cell: ({ row }) => {
@@ -115,79 +274,110 @@ export function getTasksColumns({
         )
       },
     },
-    {
-      accessorKey: 'status',
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          column={column}
-          title={
-            isInventoryRoute
-              ? 'Condition'
-              : isWishlistRoute
-                ? 'Watch Status'
-                : 'Status'
-          }
-        />
-      ),
-      meta: { className: 'ps-1', tdClassName: 'ps-4' },
-      cell: ({ row }) => {
-        if (isInventoryRoute) {
-          return (
-            <div className='flex min-w-[100px] items-center gap-2'>
-              <span className='capitalize'>
-                {String(row.getValue('status'))}
+    ...(isWishlistRoute
+      ? []
+      : [
+          {
+            accessorKey: 'status',
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                column={column}
+                title={isInventoryRoute ? 'Condition' : 'Status'}
+              />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => {
+              if (isInventoryRoute) {
+                return (
+                  <div className='flex min-w-[100px] items-center gap-2'>
+                    <span className='capitalize'>
+                      {String(row.getValue('status'))}
+                    </span>
+                  </div>
+                )
+              }
+
+              const status = statuses.find(
+                (status) => status.value === row.getValue('status')
+              )
+
+              if (!status) {
+                return null
+              }
+
+              return (
+                <div className='flex w-[100px] items-center gap-2'>
+                  {status.icon && (
+                    <status.icon className='size-4 text-muted-foreground' />
+                  )}
+                  <span>{status.label}</span>
+                </div>
+              )
+            },
+            filterFn: (row, id, value) => {
+              return value.includes(row.getValue(id))
+            },
+          } satisfies ColumnDef<Task>,
+        ]),
+    ...(isWishlistRoute
+      ? [
+          {
+            accessorKey: 'marketPrice',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Market Price' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => (
+              <span className='min-w-[76px] font-medium'>
+                {formatMoney(row.original.marketPrice)}
               </span>
-            </div>
-          )
-        }
-
-        if (isWishlistRoute) {
-          return (
-            <div className='flex min-w-[120px] items-center gap-2'>
-              <span>{formatWishlistStatus(row.original.status)}</span>
-            </div>
-          )
-        }
-
-        const status = statuses.find(
-          (status) => status.value === row.getValue('status')
-        )
-
-        if (!status) {
-          return null
-        }
-
-        return (
-          <div className='flex w-[100px] items-center gap-2'>
-            {status.icon && (
-              <status.icon className='size-4 text-muted-foreground' />
-            )}
-            <span>{status.label}</span>
-          </div>
-        )
-      },
-      filterFn: (row, id, value) => {
-        return value.includes(row.getValue(id))
-      },
-    },
+            ),
+          } satisfies ColumnDef<Task>,
+          {
+            accessorKey: 'priceTrend',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Price Graph' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => <WishlistPriceTrendCell task={row.original} />,
+            enableSorting: false,
+          } satisfies ColumnDef<Task>,
+          {
+            accessorKey: 'targetPrice',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Cost' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => (
+              <WishlistCostCell
+                task={row.original}
+                onWishlistInlineUpdate={onWishlistInlineUpdate}
+              />
+            ),
+          } satisfies ColumnDef<Task>,
+        ]
+      : []),
     {
       accessorKey: 'priority',
       header: ({ column }) => (
         <DataTableColumnHeader
           column={column}
-          title={
-            isInventoryRoute
-              ? 'Category'
-              : isWishlistRoute
-                ? 'Target Priority'
-                : 'Priority'
-          }
+          title={isInventoryRoute ? 'Category' : 'Priority'}
         />
       ),
       meta: { className: 'ps-1', tdClassName: 'ps-3' },
       cell: ({ row }) => {
         if (isInventoryRoute) {
           return <span>{row.original.label || 'Uncategorized'}</span>
+        }
+
+        if (isWishlistRoute) {
+          return (
+            <WishlistPriorityCell
+              task={row.original}
+              onWishlistInlineUpdate={onWishlistInlineUpdate}
+            />
+          )
         }
 
         const priority = priorities.find(

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -69,6 +69,10 @@ type DataTableProps = {
   ) => Promise<void>
   onWishlistBulkDelete?: (tasks: Task[]) => Promise<void>
   onWishlistExport?: (tasks: Task[]) => void
+  onWishlistInlineUpdate?: (
+    task: Task,
+    changes: { targetPrice?: number; priority?: string }
+  ) => Promise<void>
   wishlistActionItemID?: string | null
   isWishlistMutating?: boolean
   customFilters?: ReactNode
@@ -216,6 +220,7 @@ export function TasksTable({
   onWishlistBulkPriorityChange,
   onWishlistBulkDelete,
   onWishlistExport,
+  onWishlistInlineUpdate,
   wishlistActionItemID,
   isWishlistMutating,
   customFilters,
@@ -231,6 +236,7 @@ export function TasksTable({
         onAssignCollectionRow,
         onDeleteRow,
         onWishlistMarkOwned,
+        onWishlistInlineUpdate,
         wishlistActionItemID,
       }),
     [
@@ -241,6 +247,7 @@ export function TasksTable({
       onAssignCollectionRow,
       onDeleteRow,
       onWishlistMarkOwned,
+      onWishlistInlineUpdate,
       wishlistActionItemID,
     ]
   )
@@ -319,10 +326,15 @@ export function TasksTable({
     onSortingChange: setSorting,
     onColumnVisibilityChange: setColumnVisibility,
     globalFilterFn: (row, _columnId, filterValue) => {
-      const id = String(row.getValue('id')).toLowerCase()
+      const id = row.original.id.toLowerCase()
+      const partNumber = (row.original.partNumber ?? '').toLowerCase()
       const title = String(row.getValue('title')).toLowerCase()
       const searchValue = String(filterValue).toLowerCase()
-      return id.includes(searchValue) || title.includes(searchValue)
+      return (
+        id.includes(searchValue) ||
+        partNumber.includes(searchValue) ||
+        title.includes(searchValue)
+      )
     },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -653,7 +665,7 @@ export function TasksTable({
         searchPlaceholder={
           isInventoryRoute
             ? 'Filter by title or part number...'
-            : 'Filter by title or ID...'
+            : 'Filter by title or part number...'
         }
         filters={[
           {
@@ -792,7 +804,12 @@ export function TasksTable({
 
       {viewMode === 'rows' ? (
         <div className='overflow-x-auto rounded-md border'>
-          <Table className='min-w-[42rem]'>
+          <Table
+            className={cn(
+              'min-w-[42rem]',
+              routePath === '/_authenticated/wishlist/' ? 'min-w-[56rem]' : ''
+            )}
+          >
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -14,6 +14,8 @@ export const taskSchema = z.object({
   notes: z.string().optional(),
   belowTargetNow: z.boolean().optional(),
   targetPrice: z.number().optional(),
+  marketPrice: z.number().optional(),
+  priceTrend: z.enum(['up', 'steady', 'down', 'unknown']).optional(),
   highlightHit: z.boolean().optional(),
 })
 

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Heart } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -107,6 +107,13 @@ type WishlistItemPayload = {
   priority?: string
 }
 
+type WishlistPriceTrend = 'up' | 'steady' | 'down' | 'unknown'
+
+type WishlistPricingSummary = {
+  marketPrice?: number
+  priceTrend: WishlistPriceTrend
+}
+
 type WishlistEntryPayload = {
   id?: string
   item_id?: string
@@ -131,6 +138,58 @@ function normalizeTargetPrice(raw: string) {
     throw new Error('invalid_target_price')
   }
   return parsed
+}
+
+function inferWishlistPriceTrend(
+  points: Array<{ latest?: number }> | undefined
+): WishlistPriceTrend {
+  const values = (points ?? [])
+    .map((point) => point.latest)
+    .filter((value): value is number => typeof value === 'number')
+
+  if (values.length < 2) {
+    return 'unknown'
+  }
+
+  const previous = values[values.length - 2] ?? 0
+  const latest = values[values.length - 1] ?? 0
+  const difference = latest - previous
+  if (Math.abs(difference) < 0.01) {
+    return 'steady'
+  }
+  return difference > 0 ? 'up' : 'down'
+}
+
+async function loadWishlistPricingSummary(
+  itemID: string
+): Promise<WishlistPricingSummary> {
+  try {
+    const [statsResponse, trendResponse] = await Promise.all([
+      fetch(`/api/pricing/stats?item_id=${encodeURIComponent(itemID)}`),
+      fetch(`/api/pricing/trend?item_id=${encodeURIComponent(itemID)}`),
+    ])
+
+    let marketPrice: number | undefined
+    if (statsResponse.ok) {
+      const statsPayload = (await statsResponse.json()) as { latest?: number }
+      marketPrice =
+        typeof statsPayload.latest === 'number' && statsPayload.latest > 0
+          ? statsPayload.latest
+          : undefined
+    }
+
+    let priceTrend: WishlistPriceTrend = 'unknown'
+    if (trendResponse.ok) {
+      const trendPayload = (await trendResponse.json()) as {
+        points?: Array<{ latest?: number }>
+      }
+      priceTrend = inferWishlistPriceTrend(trendPayload.points)
+    }
+
+    return { marketPrice, priceTrend }
+  } catch {
+    return { priceTrend: 'unknown' }
+  }
 }
 
 function buildWishlistCsv(tasksToExport: Task[]) {
@@ -247,6 +306,7 @@ export function Tasks({
   const [tableData, setTableData] = useState<Task[]>(() =>
     isWishlistRoute ? [] : tasks
   )
+  const tableDataRef = useRef(tableData)
   const [dialogOpen, setDialogOpen] = useState<TasksDialogType | null>(null)
   const [currentDialogRow, setCurrentDialogRow] = useState<Task | null>(null)
   const [wishlistActionItemID, setWishlistActionItemID] = useState<
@@ -262,6 +322,7 @@ export function Tasks({
         window.localStorage.getItem(WISHLIST_PLANNING_FOCUS_STORAGE_KEY)
       )
     })
+  const wishlistCollectionNormalizedRef = useRef(false)
   const loadWishlistData = useCallback(async () => {
     const [wishlistResponse, itemsResponse] = await Promise.all([
       fetch('/api/wishlist'),
@@ -284,32 +345,43 @@ export function Tasks({
       }
       wishlistByItemID.set(itemID, entry)
     })
-    return (itemsPayload.items ?? []).map((item, index) => {
-      const itemID = item.id?.trim() || `wishlist-item-${index + 1}`
-      const wishlistEntry = wishlistByItemID.get(itemID)
-      return {
-        id: itemID,
-        itemID: itemID,
-        wishlistEntryID: wishlistEntry?.id?.trim(),
-        title:
-          item.title?.trim() ||
-          item.part_number?.trim() ||
-          `Wishlist item ${index + 1}`,
-        partNumber: item.part_number?.trim(),
-        status: wishlistEntry?.below_target_now ? 'discovered' : 'wishlist',
-        label: item.category?.trim() || 'collection',
-        priority:
-          wishlistEntry?.priority?.trim() || item.priority?.trim() || 'medium',
-        notes: wishlistEntry?.notes?.trim(),
-        belowTargetNow: Boolean(wishlistEntry?.below_target_now),
-        targetPrice:
-          typeof wishlistEntry?.target_price === 'number'
-            ? wishlistEntry.target_price
-            : undefined,
-        highlightHit: Boolean(wishlistEntry?.highlight_hit),
-      } satisfies Task
-    })
+    return Promise.all(
+      (itemsPayload.items ?? []).map(async (item, index) => {
+        const itemID = item.id?.trim() || `wishlist-item-${index + 1}`
+        const wishlistEntry = wishlistByItemID.get(itemID)
+        const pricingSummary = await loadWishlistPricingSummary(itemID)
+        return {
+          id: itemID,
+          itemID: itemID,
+          wishlistEntryID: wishlistEntry?.id?.trim(),
+          title:
+            item.title?.trim() ||
+            item.part_number?.trim() ||
+            `Wishlist item ${index + 1}`,
+          partNumber: item.part_number?.trim(),
+          status: wishlistEntry?.below_target_now ? 'discovered' : 'wishlist',
+          label: item.category?.trim() || 'collection',
+          priority:
+            wishlistEntry?.priority?.trim() ||
+            item.priority?.trim() ||
+            'medium',
+          notes: wishlistEntry?.notes?.trim(),
+          belowTargetNow: Boolean(wishlistEntry?.below_target_now),
+          targetPrice:
+            typeof wishlistEntry?.target_price === 'number'
+              ? wishlistEntry.target_price
+              : undefined,
+          marketPrice: pricingSummary.marketPrice,
+          priceTrend: pricingSummary.priceTrend,
+          highlightHit: Boolean(wishlistEntry?.highlight_hit),
+        } satisfies Task
+      })
+    )
   }, [])
+
+  useEffect(() => {
+    tableDataRef.current = tableData
+  }, [tableData])
 
   useEffect(() => {
     if (!isWishlistRoute) {
@@ -449,6 +521,97 @@ export function Tasks({
       }
     },
     [refreshWishlistTable, saveWishlistDraft]
+  )
+
+  const handleWishlistInlineUpdate = useCallback(
+    async (
+      task: Task,
+      changes: { targetPrice?: number; priority?: string }
+    ) => {
+      const wishlistEntryID = task.wishlistEntryID?.trim()
+      if (!wishlistEntryID) {
+        toast.error('Wishlist entry is missing update metadata.')
+        return
+      }
+
+      const currentTask =
+        tableDataRef.current.find((candidate) => candidate.id === task.id) ??
+        task
+      const nextPriority = normalizeWishlistPriority(
+        changes.priority ?? currentTask.priority
+      )
+      let nextTargetPrice = changes.targetPrice ?? currentTask.targetPrice ?? 0
+
+      if (changes.targetPrice === undefined) {
+        try {
+          const latestWishlistResponse = await fetch('/api/wishlist')
+          if (latestWishlistResponse.ok) {
+            const latestWishlistPayload =
+              (await latestWishlistResponse.json()) as {
+                items?: WishlistEntryPayload[]
+              }
+            const latestEntry = (latestWishlistPayload.items ?? []).find(
+              (entry) => entry.id?.trim() === wishlistEntryID
+            )
+            if (typeof latestEntry?.target_price === 'number') {
+              nextTargetPrice = latestEntry.target_price
+            }
+          }
+        } catch {
+          // Keep the local row value if the latest entry cannot be read.
+        }
+      }
+
+      const nextTableData = tableDataRef.current.map((candidate) =>
+        candidate.id === task.id
+          ? {
+              ...candidate,
+              priority: nextPriority,
+              targetPrice: nextTargetPrice,
+            }
+          : candidate
+      )
+      tableDataRef.current = nextTableData
+      setTableData((previous) =>
+        previous.map((candidate) =>
+          candidate.id === task.id
+            ? {
+                ...candidate,
+                priority: nextPriority,
+                targetPrice: nextTargetPrice,
+              }
+            : candidate
+        )
+      )
+      setIsWishlistMutating(true)
+      try {
+        const requestBody: Record<string, unknown> = {
+          id: wishlistEntryID,
+          item_id: task.itemID,
+          priority: nextPriority,
+        }
+        if (changes.targetPrice !== undefined) {
+          requestBody.target_price = nextTargetPrice
+        }
+
+        const response = await fetch('/api/wishlist', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        })
+        if (!response.ok) {
+          throw new Error('wishlist_inline_update_failed')
+        }
+        await refreshWishlistTable()
+        toast.success('Wishlist row updated.')
+      } catch {
+        toast.error('Wishlist row update failed. Try again.')
+        throw new Error('wishlist_inline_update_failed')
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable]
   )
 
   const handleWishlistDelete = useCallback(
@@ -686,6 +849,37 @@ export function Tasks({
     wishlistPlanningFocus,
   ])
 
+  useEffect(() => {
+    if (
+      !isWishlistRoute ||
+      wishlistCollectionNormalizedRef.current ||
+      activeWorkspaceCollection === 'All Items' ||
+      tableData.length === 0
+    ) {
+      return
+    }
+
+    wishlistCollectionNormalizedRef.current = true
+    const wishlistItemIDs = new Set(
+      tableData.map((task) => task.itemID ?? task.id)
+    )
+    const collectionHasWishlistRows = collectionItems.some(
+      (item) =>
+        item.collectionName === activeWorkspaceCollection &&
+        wishlistItemIDs.has(item.id)
+    )
+
+    if (!collectionHasWishlistRows) {
+      void setActiveWorkspaceCollection('All Items')
+    }
+  }, [
+    activeWorkspaceCollection,
+    collectionItems,
+    isWishlistRoute,
+    setActiveWorkspaceCollection,
+    tableData,
+  ])
+
   const wishlistCollectionFilter = isWishlistRoute ? (
     <div
       className='flex flex-wrap items-center gap-2'
@@ -900,6 +1094,9 @@ export function Tasks({
             }
             onWishlistExport={
               isWishlistRoute ? handleWishlistExport : undefined
+            }
+            onWishlistInlineUpdate={
+              isWishlistRoute ? handleWishlistInlineUpdate : undefined
             }
             wishlistActionItemID={wishlistActionItemID}
             isWishlistMutating={isWishlistMutating}


### PR DESCRIPTION
## Summary
- Remove the visible Item ID column from Wishlist rows and add Market Price, Price Graph, Cost, and editable Priority columns.
- Enrich Wishlist rows from pricing stats/trend endpoints and show trend icons for up, steady, down, or unknown.
- Persist inline Cost and Priority updates without clobbering omitted wishlist fields.
- Reset stale cross-screen collection filters on Wishlist first load when they would hide all wishlist rows.

## Validation
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts -Browser electron`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-visible-data/spec.cy.ts -Browser electron`
- `go test ./internal/app -run TestWishlistEndpointPersistsManualWatchStatusForActiveProfile -count=1`
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- pre-push OpenSpec validation and fast API docs smoke test passed

Closes #723