### PR TITLE
#725 Open Wishlist row editor side panel on double click

### DIFF
--- a/ui.web/cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts
@@ -1,0 +1,120 @@
+describe("wishlist-row-side-panel", () => {
+  function signInToWishlistWithRows() {
+    let wishlistEntries = [
+      {
+        id: "wish-panel-1",
+        item_id: "item-panel-1",
+        priority: "medium",
+        below_target_now: false,
+        notes: "First panel note",
+        target_price: 40,
+      },
+      {
+        id: "wish-panel-2",
+        item_id: "item-panel-2",
+        priority: "high",
+        below_target_now: false,
+        notes: "Second panel note",
+        target_price: 80,
+      },
+    ];
+    let wishlistItems = [
+      {
+        id: "item-panel-1",
+        title: "Panel Wishlist Alpha",
+        part_number: "PANEL-001",
+        status: "wishlist",
+        category: "Cards",
+        priority: "medium",
+      },
+      {
+        id: "item-panel-2",
+        title: "Panel Wishlist Beta",
+        part_number: "PANEL-002",
+        status: "wishlist",
+        category: "Comics",
+        priority: "high",
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistItems } });
+    }).as("catalogItems");
+    cy.intercept("PUT", "/api/items/item-panel-2", (req) => {
+      wishlistItems = wishlistItems.map((item) =>
+        item.id === "item-panel-2"
+          ? {
+              ...item,
+              title: req.body.title,
+              part_number: req.body.part_number,
+              category: req.body.category,
+            }
+          : item
+      );
+      req.reply({
+        statusCode: 200,
+        body: wishlistItems.find((item) => item.id === "item-panel-2"),
+      });
+    }).as("updateWishlistItem");
+    cy.intercept("PUT", "/api/wishlist", (req) => {
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === req.body.id
+          ? {
+              ...entry,
+              priority: req.body.priority,
+              notes: req.body.notes,
+              target_price: req.body.target_price,
+            }
+          : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("updateWishlistEntry");
+    cy.intercept("GET", "/api/profiles/*/settings").as("profileSettings");
+
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: "/wishlist/",
+      });
+    });
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.wait("@profileSettings");
+    cy.wait("@profileSettings");
+  }
+
+  it("opens a right-side edit panel on double click and navigates visible records", () => {
+    signInToWishlistWithRows();
+
+    cy.contains("tr", "Panel Wishlist Alpha").click();
+    cy.get('[data-testid="wishlist-edit-panel"]').should("not.exist");
+    cy.get('[data-testid="row-edit-modal"]').should("not.exist");
+
+    cy.contains("tr", "Panel Wishlist Alpha").dblclick();
+    cy.get('[data-testid="wishlist-edit-panel"]')
+      .should("be.visible")
+      .should("have.attr", "data-side", "right");
+    cy.get('input[name="title"]').should("have.value", "Panel Wishlist Alpha");
+
+    cy.get('[data-testid="wishlist-edit-next"]').click();
+    cy.get('input[name="title"]').should("have.value", "Panel Wishlist Beta");
+    cy.get('[data-testid="wishlist-edit-previous"]').click();
+    cy.get('input[name="title"]').should("have.value", "Panel Wishlist Alpha");
+    cy.get('[data-testid="wishlist-edit-next"]').click();
+
+    cy.get('input[name="title"]').clear().type("Panel Wishlist Beta Updated");
+    cy.get('textarea[name="notes"]').clear().type("Updated from side panel");
+    cy.contains("button", "Save changes").click();
+
+    cy.wait("@updateWishlistItem");
+    cy.wait("@updateWishlistEntry");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("Panel Wishlist Beta Updated").should("be.visible");
+    cy.contains("Updated from side panel").should("be.visible");
+  });
+});

--- a/ui.web/src/features/tasks/components/tasks-dialogs.tsx
+++ b/ui.web/src/features/tasks/components/tasks-dialogs.tsx
@@ -16,6 +16,7 @@ type TasksDialogsProps = {
   setOpen: (open: TasksDialogType | null) => void
   currentRow: Task | null
   setCurrentRow: (task: Task | null) => void
+  navigationRows?: Task[]
   onWishlistSubmit?: (
     draft: WishlistEntryDraft,
     currentRow?: Task
@@ -31,6 +32,7 @@ export function TasksDialogs({
   setOpen,
   currentRow,
   setCurrentRow,
+  navigationRows = [],
   onWishlistSubmit,
   onWishlistDelete,
   onWishlistImport,
@@ -52,6 +54,26 @@ export function TasksDialogs({
       setCurrentRow(null)
       clearCurrentRowTimerRef.current = null
     }, 500)
+  }
+
+  const currentRowIndex = currentRow
+    ? navigationRows.findIndex((task) => task.id === currentRow.id)
+    : -1
+  const canNavigatePrevious = currentRowIndex > 0
+  const canNavigateNext =
+    currentRowIndex >= 0 && currentRowIndex < navigationRows.length - 1
+
+  const navigateCurrentRow = (offset: number) => {
+    if (currentRowIndex < 0) {
+      return
+    }
+    const nextRow = navigationRows[currentRowIndex + offset]
+    if (!nextRow) {
+      return
+    }
+    cancelPendingClearCurrentRow()
+    setCurrentRow(nextRow)
+    setOpen('update')
   }
 
   useEffect(() => {
@@ -110,6 +132,10 @@ export function TasksDialogs({
             routePath={routePath}
             onWishlistSubmit={onWishlistSubmit}
             isLoading={isWishlistMutating}
+            canNavigatePrevious={canNavigatePrevious}
+            canNavigateNext={canNavigateNext}
+            onNavigatePrevious={() => navigateCurrentRow(-1)}
+            onNavigateNext={() => navigateCurrentRow(1)}
           />
 
           <ConfirmDialog

--- a/ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx
+++ b/ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx
@@ -46,6 +46,10 @@ type TaskMutateDrawerProps = {
     currentRow?: Task
   ) => Promise<void>
   isLoading?: boolean
+  canNavigatePrevious?: boolean
+  canNavigateNext?: boolean
+  onNavigatePrevious?: () => void
+  onNavigateNext?: () => void
 }
 
 const taskFormSchema = z.object({
@@ -93,6 +97,10 @@ export function TasksMutateDrawer({
   routePath,
   onWishlistSubmit,
   isLoading = false,
+  canNavigatePrevious = false,
+  canNavigateNext = false,
+  onNavigatePrevious,
+  onNavigateNext,
 }: TaskMutateDrawerProps) {
   const isUpdate = !!currentRow
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
@@ -153,7 +161,14 @@ export function TasksMutateDrawer({
   if (isWishlistRoute) {
     return (
       <Sheet open={open} onOpenChange={handleClose}>
-        <SheetContent className='flex flex-col'>
+        <SheetContent
+          className='flex flex-col'
+          data-testid={
+            isUpdate ? 'wishlist-edit-panel' : 'wishlist-create-panel'
+          }
+          data-side='right'
+          side='right'
+        >
           <SheetHeader className='text-start'>
             <SheetTitle>
               {isUpdate ? 'Edit Wishlist Entry' : 'Create Wishlist Entry'}
@@ -163,6 +178,30 @@ export function TasksMutateDrawer({
                 ? 'Update the selected wishlist entry and keep planning details in sync.'
                 : 'Create a new wishlist entry with the details you want to track.'}
             </SheetDescription>
+            {isUpdate ? (
+              <div className='flex flex-wrap items-center gap-2 pt-2'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  data-testid='wishlist-edit-previous'
+                  disabled={!canNavigatePrevious || isLoading}
+                  onClick={onNavigatePrevious}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  data-testid='wishlist-edit-next'
+                  disabled={!canNavigateNext || isLoading}
+                  onClick={onNavigateNext}
+                >
+                  Next
+                </Button>
+              </div>
+            ) : null}
           </SheetHeader>
           <Form {...wishlistForm}>
             <form

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -56,7 +56,7 @@ type DataTableProps = {
   routePath: TasksRoutePath
   currentRecordID?: string
   onRecordFocus?: (itemID: string, recordID: string, title: string) => void
-  onEditRow?: (task: Task) => void
+  onEditRow?: (task: Task, navigationRows?: Task[]) => void
   onPhotoRow?: (task: Task) => void
   onBarcodeRow?: (task: Task) => void
   onAssignCollectionRow?: (task: Task) => void
@@ -430,7 +430,7 @@ export function TasksTable({
     if (record) {
       onRecordFocus?.(record.itemID ?? record.id, record.id, record.title)
     }
-    if (isInventoryRoute) {
+    if (isInventoryRoute || routePath === '/_authenticated/wishlist/') {
       return
     }
     if (clickTimerRef.current !== null) {
@@ -453,8 +453,11 @@ export function TasksTable({
       window.clearTimeout(clickTimerRef.current)
       clickTimerRef.current = null
     }
-    if (isInventoryRoute && record && onEditRow) {
-      onEditRow(record)
+    if (record && onEditRow) {
+      onEditRow(
+        record,
+        table.getRowModel().rows.map((row) => row.original)
+      )
       return
     }
     openEdit(id)

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -309,6 +309,7 @@ export function Tasks({
   const tableDataRef = useRef(tableData)
   const [dialogOpen, setDialogOpen] = useState<TasksDialogType | null>(null)
   const [currentDialogRow, setCurrentDialogRow] = useState<Task | null>(null)
+  const [dialogNavigationRows, setDialogNavigationRows] = useState<Task[]>([])
   const [wishlistActionItemID, setWishlistActionItemID] = useState<
     string | null
   >(null)
@@ -1072,11 +1073,13 @@ export function Tasks({
             data={displayedData}
             routePath={routePath}
             customFilters={wishlistCollectionFilter}
-            onEditRow={(task) => {
+            onEditRow={(task, navigationRows) => {
+              setDialogNavigationRows(navigationRows ?? displayedData)
               setCurrentDialogRow(task)
               setDialogOpen('update')
             }}
             onDeleteRow={(task) => {
+              setDialogNavigationRows([])
               setCurrentDialogRow(task)
               setDialogOpen('delete')
             }}
@@ -1110,6 +1113,7 @@ export function Tasks({
         setOpen={setDialogOpen}
         currentRow={currentDialogRow}
         setCurrentRow={setCurrentDialogRow}
+        navigationRows={dialogNavigationRows}
         onWishlistSubmit={isWishlistRoute ? handleWishlistSubmit : undefined}
         onWishlistDelete={isWishlistRoute ? handleWishlistDelete : undefined}
         onWishlistImport={isWishlistRoute ? handleWishlistImport : undefined}


### PR DESCRIPTION
## Summary
- Route Wishlist row double-clicks into the existing right-side edit drawer instead of the generic row modal.
- Keep single-click from opening edit UI.
- Add Previous/Next navigation controls to the Wishlist edit drawer across the current visible table rows.
- Add Cypress coverage for double-click, right-side drawer, record navigation, and edit persistence.

## Validation
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts -Browser electron`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron`
- pre-push OpenSpec validation and fast API docs smoke test passed

Closes #725