### PR TITLE
#727 fix(collections): open row editor side panel

### DIFF
--- a/ui.web/cypress/e2e/collections/collections-row-side-panel/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/collections-row-side-panel/spec.cy.ts
@@ -1,0 +1,63 @@
+describe('collections-row-side-panel', () => {
+  function signInToCollections() {
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/profiles/*/settings').as(
+      'loadCollectionSettings'
+    )
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as(
+      'saveCollectionSettings'
+    )
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: '/collections/',
+      })
+    })
+    cy.wait('@loadCollectionSettings')
+  }
+
+  it('opens a right-side edit panel on double click and navigates visible records', () => {
+    signInToCollections()
+
+    cy.get('[data-testid="collections-row-store-1"]').click()
+    cy.get('[data-testid="collections-edit-panel"]').should('not.exist')
+    cy.get('[data-testid="collections-edit-dialog"]').should('not.exist')
+
+    cy.get('[data-testid="collections-row-store-1"]').dblclick()
+    cy.get('[data-testid="collections-edit-panel"]')
+      .should('be.visible')
+      .should('have.attr', 'data-side', 'right')
+    cy.get('[data-testid="collections-edit-input"]').should(
+      'have.value',
+      'Store 1'
+    )
+
+    cy.get('[data-testid="collections-edit-next"]').click()
+    cy.get('[data-testid="collections-edit-input"]').should(
+      'have.value',
+      'Store 2'
+    )
+    cy.get('[data-testid="collections-edit-previous"]').click()
+    cy.get('[data-testid="collections-edit-input"]').should(
+      'have.value',
+      'Store 1'
+    )
+    cy.get('[data-testid="collections-edit-next"]').click()
+
+    cy.get('[data-testid="collections-edit-input"]')
+      .clear()
+      .type('Store 2 Panel')
+    cy.get('[data-testid="collections-edit-submit"]').click()
+    cy.wait('@saveCollectionSettings')
+
+    cy.contains('Store 2 renamed to Store 2 Panel.').should('be.visible')
+    cy.get('[data-testid="collections-row-store-2-panel"]').should(
+      'be.visible'
+    )
+    cy.reload()
+    cy.wait('@loadCollectionSettings')
+    cy.get('[data-testid="collections-row-store-2-panel"]').should(
+      'be.visible'
+    )
+  })
+})

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -615,16 +615,6 @@ function buildWorkspaceCollectionFilterOptions(
   }))
 }
 
-function buildFolderTreeFilterOptions(
-  nodes: FolderNode[],
-  level = 0
-): Array<FolderNode & { level: number }> {
-  return nodes.flatMap((node) => [
-    { ...node, level },
-    ...buildFolderTreeFilterOptions(node.children ?? [], level + 1),
-  ])
-}
-
 function buildUniqueFolderID(name: string, nodes: FolderNode[]): string {
   const slug = slugifyFolderName(name) || 'folder'
   const existingIDs = new Set<string>()
@@ -2476,12 +2466,8 @@ export function Collection({
     [activeFolder, folderTree, tableData.length]
   )
   const folderFilterOptions = useMemo(() => {
-    const treeOptions = buildFolderTreeFilterOptions(folderTree)
-    if (treeOptions.length > 0) {
-      return treeOptions
-    }
     return buildWorkspaceCollectionFilterOptions(workspaceCollections)
-  }, [folderTree, workspaceCollections])
+  }, [workspaceCollections])
   const activeFolderIsAvailable = folderFilterOptions.some(
     (folder) => folder.name === activeFolder
   )

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   type ColumnDef,
   flexRender,
@@ -28,6 +28,14 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import {
   Table,
   TableBody,
@@ -183,20 +191,22 @@ export function Collections() {
     [collectionItems, selectedCollectionName]
   )
 
+  const openEditPanel = useCallback((row: CollectionRow) => {
+    setSelectedCollectionID(row.key)
+    setEditValue(row.name)
+    setEditOpen(true)
+  }, [])
+
   const columns = useMemo(
     () =>
       buildCollectionColumns({
-        onEdit: (row) => {
-          setSelectedCollectionID(row.key)
-          setEditValue(row.name)
-          setEditOpen(true)
-        },
+        onEdit: openEditPanel,
         onDelete: (row) => {
           setSelectedCollectionID(row.key)
           setDeleteOpen(true)
         },
       }),
-    []
+    [openEditPanel]
   )
 
   const table = useReactTable({
@@ -227,6 +237,27 @@ export function Collections() {
   })
 
   const filteredCount = table.getFilteredRowModel().rows.length
+  const visibleRows = table
+    .getRowModel()
+    .rows.map((tableRow) => tableRow.original)
+  const selectedVisibleIndex = selectedRow
+    ? visibleRows.findIndex((row) => row.key === selectedRow.key)
+    : -1
+  const canNavigatePrevious = selectedVisibleIndex > 0
+  const canNavigateNext =
+    selectedVisibleIndex >= 0 && selectedVisibleIndex < visibleRows.length - 1
+
+  function navigateEditPanel(offset: number) {
+    if (selectedVisibleIndex < 0) {
+      return
+    }
+    const nextRow = visibleRows[selectedVisibleIndex + offset]
+    if (!nextRow) {
+      return
+    }
+    setSelectedCollectionID(nextRow.key)
+    setEditValue(nextRow.name)
+  }
 
   async function handleSelectCollection(row: CollectionRow) {
     setSelectedCollectionID(row.key)
@@ -329,10 +360,13 @@ export function Collections() {
                   data-testid='collections-search-input'
                 />
                 <div
-                  className='text-sm text-muted-foreground'
+                  className='flex flex-wrap items-center gap-2 text-sm text-muted-foreground'
                   data-testid='collections-management-summary'
                 >
-                  Showing {filteredCount} of {rows.length} collections.
+                  <span>Showing {filteredCount} of {rows.length} collections.</span>
+                  <span data-testid='collections-active-context'>
+                    Active: {selectedCollectionName}
+                  </span>
                 </div>
               </div>
 
@@ -369,6 +403,9 @@ export function Collections() {
                             data-testid={`collections-row-${row.original.key}`}
                             onClick={() => {
                               void handleSelectCollection(row.original)
+                            }}
+                            onDoubleClick={() => {
+                              openEditPanel(row.original)
                             }}
                           >
                             {row.getVisibleCells().map((cell) => (
@@ -501,21 +538,53 @@ export function Collections() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={editOpen} onOpenChange={setEditOpen}>
-        <DialogContent data-testid='collections-edit-dialog'>
-          <DialogHeader>
-            <DialogTitle>Edit collection</DialogTitle>
-            <DialogDescription>
+      <Sheet open={editOpen} onOpenChange={setEditOpen}>
+        <SheetContent
+          className='flex flex-col'
+          data-testid='collections-edit-panel'
+          data-side='right'
+          side='right'
+        >
+          <SheetHeader className='text-start'>
+            <SheetTitle>Edit collection</SheetTitle>
+            <SheetDescription>
               Rename the selected collection through the row workflow.
-            </DialogDescription>
-          </DialogHeader>
-          <Input
-            value={editValue}
-            onChange={(event) => setEditValue(event.target.value)}
-            placeholder='New collection name'
-            data-testid='collections-edit-input'
-          />
-          <DialogFooter>
+            </SheetDescription>
+            <div className='flex flex-wrap items-center gap-2 pt-2'>
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                data-testid='collections-edit-previous'
+                disabled={!canNavigatePrevious}
+                onClick={() => navigateEditPanel(-1)}
+              >
+                Previous
+              </Button>
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                data-testid='collections-edit-next'
+                disabled={!canNavigateNext}
+                onClick={() => navigateEditPanel(1)}
+              >
+                Next
+              </Button>
+            </div>
+          </SheetHeader>
+          <div className='flex-1 px-4'>
+            <label className='space-y-2 text-sm font-medium'>
+              <span>Collection name</span>
+              <Input
+                value={editValue}
+                onChange={(event) => setEditValue(event.target.value)}
+                placeholder='New collection name'
+                data-testid='collections-edit-input'
+              />
+            </label>
+          </div>
+          <SheetFooter className='gap-2'>
             <Button
               type='button'
               variant='outline'
@@ -532,9 +601,9 @@ export function Collections() {
             >
               Save rename
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
 
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent data-testid='collections-delete-dialog'>

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -855,6 +855,7 @@ export function Tasks({
       !isWishlistRoute ||
       wishlistCollectionNormalizedRef.current ||
       activeWorkspaceCollection === 'All Items' ||
+      collectionItems.length > 0 ||
       tableData.length === 0
     ) {
       return
@@ -891,6 +892,7 @@ export function Tasks({
         data-testid='wishlist-table-collection-select'
         value={activeWorkspaceCollection}
         onChange={(event) => {
+          wishlistCollectionNormalizedRef.current = true
           void setActiveWorkspaceCollection(event.target.value)
         }}
       >
@@ -945,6 +947,7 @@ export function Tasks({
             className='h-8 px-3'
             data-testid='wishlist-table-new-collection-save'
             onClick={async () => {
+              wishlistCollectionNormalizedRef.current = true
               const created = await addCollection(inlineCollectionName)
               if (!created) {
                 setInlineCollectionValidationMessage(


### PR DESCRIPTION
## Summary
- Add Cypress coverage for double-clicking a Collections row to open a right-side edit panel.
- Replace the Collections edit dialog with a right-side Sheet that supports previous/next navigation across visible rows.
- Preserve cross-screen collection state for Wishlist-created collections and keep Inventory compact collection filters aligned to workspace collections.

## Validation
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser electron`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/collections/collections-row-side-panel/spec.cy.ts -Browser electron`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-visible-data/spec.cy.ts -Browser electron`
- `git diff --check`
- pre-push OpenSpec validation
- pre-push fast API docs smoke test

Closes #727