### PR TITLE
#729 feat(wishlist): add owned purchase planning fields

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1910,6 +1910,18 @@ components:
             item_id: { type: string }
             created_at: { type: string }
             updated_at: { type: string }
+    Photo:
+      type: object
+      properties:
+        id: { type: string }
+        item_id: { type: string }
+        filename: { type: string }
+        original_path: { type: string }
+        preview_path: { type: string }
+        thumbnail_path: { type: string }
+        is_primary: { type: boolean }
+        display_order: { type: integer }
+        created_at: { type: string }
     ScannerQuerySetInput:
       type: object
       required: [name, keywords]
@@ -1981,6 +1993,12 @@ components:
         priority: { type: string }
         notes: { type: string }
         highlight_hit: { type: boolean }
+        owned: { type: boolean }
+        price_paid: { type: number }
+        purchase_url: { type: string }
+        purchase_date: { type: string, format: date }
+        quantity: { type: integer }
+        needed_quantity: { type: integer }
     WishlistEntry:
       allOf:
         - $ref: "#/components/schemas/WishlistEntryInput"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2861,6 +2861,24 @@ func New(cfg config.Config) (*App, error) {
 					if _, ok := raw["below_target_now"]; !ok {
 						req.BelowTargetNow = existing.BelowTargetNow
 					}
+					if _, ok := raw["owned"]; !ok {
+						req.Owned = existing.Owned
+					}
+					if _, ok := raw["price_paid"]; !ok {
+						req.PricePaid = existing.PricePaid
+					}
+					if _, ok := raw["purchase_url"]; !ok {
+						req.PurchaseURL = existing.PurchaseURL
+					}
+					if _, ok := raw["purchase_date"]; !ok {
+						req.PurchaseDate = existing.PurchaseDate
+					}
+					if _, ok := raw["quantity"]; !ok {
+						req.Quantity = existing.Quantity
+					}
+					if _, ok := raw["needed_quantity"]; !ok {
+						req.NeededQuantity = existing.NeededQuantity
+					}
 				}
 			}
 			if err := wishlistSvc.UpdateForProfile(r.Context(), profileID, req); err != nil {

--- a/internal/app/wishlist_planning_metadata_api_test.go
+++ b/internal/app/wishlist_planning_metadata_api_test.go
@@ -45,7 +45,7 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 		t.Fatal("expected item id")
 	}
 
-	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"manual watch state","below_target_now":true,"highlight_hit":true}`), map[string]string{"Content-Type": "application/json"})
+	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"manual watch state","below_target_now":true,"highlight_hit":true,"owned":true,"price_paid":37.5,"purchase_url":"https://example.test/receipt","purchase_date":"2026-04-27","quantity":2,"needed_quantity":5}`), map[string]string{"Content-Type": "application/json"})
 	if createWish.Code != http.StatusCreated {
 		t.Fatalf("create wishlist status=%d body=%s", createWish.Code, createWish.Body.String())
 	}
@@ -53,6 +53,7 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 		ID             string `json:"id"`
 		BelowTargetNow bool   `json:"below_target_now"`
 		HighlightHit   bool   `json:"highlight_hit"`
+		Owned          bool   `json:"owned"`
 	}
 	if err := json.NewDecoder(createWish.Body).Decode(&created); err != nil {
 		t.Fatalf("decode created wishlist: %v", err)
@@ -66,8 +67,11 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	if !created.HighlightHit {
 		t.Fatalf("expected created wishlist to persist highlight_hit=true, got %+v", created)
 	}
+	if !created.Owned {
+		t.Fatalf("expected created wishlist to persist owned=true, got %+v", created)
+	}
 
-	updateWish := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+created.ID+`","item_id":"`+item.ID+`","target_price":42,"priority":"medium","notes":"updated manual watch state","below_target_now":false,"highlight_hit":false}`), map[string]string{"Content-Type": "application/json"})
+	updateWish := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+created.ID+`","item_id":"`+item.ID+`","target_price":42,"priority":"medium","notes":"updated manual watch state","below_target_now":false,"highlight_hit":false,"owned":true,"price_paid":35.25,"purchase_url":"https://example.test/updated-receipt","purchase_date":"2026-04-28","quantity":3,"needed_quantity":4}`), map[string]string{"Content-Type": "application/json"})
 	if updateWish.Code != http.StatusOK {
 		t.Fatalf("update wishlist status=%d body=%s", updateWish.Code, updateWish.Body.String())
 	}
@@ -78,11 +82,17 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	}
 	var listPayload struct {
 		Items []struct {
-			ID             string `json:"id"`
-			BelowTargetNow bool   `json:"below_target_now"`
-			HighlightHit   bool   `json:"highlight_hit"`
-			Priority       string `json:"priority"`
-			Notes          string `json:"notes"`
+			ID             string  `json:"id"`
+			BelowTargetNow bool    `json:"below_target_now"`
+			HighlightHit   bool    `json:"highlight_hit"`
+			Priority       string  `json:"priority"`
+			Notes          string  `json:"notes"`
+			Owned          bool    `json:"owned"`
+			PricePaid      float64 `json:"price_paid"`
+			PurchaseURL    string  `json:"purchase_url"`
+			PurchaseDate   string  `json:"purchase_date"`
+			Quantity       int     `json:"quantity"`
+			NeededQuantity int     `json:"needed_quantity"`
 		} `json:"items"`
 	}
 	if err := json.NewDecoder(listWish.Body).Decode(&listPayload); err != nil {
@@ -103,6 +113,9 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	if listPayload.Items[0].Notes != "updated manual watch state" {
 		t.Fatalf("expected updated wishlist notes to persist, got %+v", listPayload.Items[0])
 	}
+	if !listPayload.Items[0].Owned || listPayload.Items[0].PricePaid != 35.25 || listPayload.Items[0].PurchaseURL != "https://example.test/updated-receipt" || listPayload.Items[0].PurchaseDate != "2026-04-28" || listPayload.Items[0].Quantity != 3 || listPayload.Items[0].NeededQuantity != 4 {
+		t.Fatalf("expected ownership metadata round-trip after update, got %+v", listPayload.Items[0])
+	}
 
 	partialUpdate := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+created.ID+`","priority":"high"}`), map[string]string{"Content-Type": "application/json"})
 	if partialUpdate.Code != http.StatusOK {
@@ -121,6 +134,12 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 			HighlightHit   bool    `json:"highlight_hit"`
 			Priority       string  `json:"priority"`
 			Notes          string  `json:"notes"`
+			Owned          bool    `json:"owned"`
+			PricePaid      float64 `json:"price_paid"`
+			PurchaseURL    string  `json:"purchase_url"`
+			PurchaseDate   string  `json:"purchase_date"`
+			Quantity       int     `json:"quantity"`
+			NeededQuantity int     `json:"needed_quantity"`
 		} `json:"items"`
 	}
 	if err := json.NewDecoder(listAfterPartialUpdate.Body).Decode(&partialPayload); err != nil {
@@ -140,5 +159,8 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	}
 	if partialPayload.Items[0].BelowTargetNow || partialPayload.Items[0].HighlightHit {
 		t.Fatalf("expected partial update to preserve false watch flags, got %+v", partialPayload.Items[0])
+	}
+	if !partialPayload.Items[0].Owned || partialPayload.Items[0].PricePaid != 35.25 || partialPayload.Items[0].PurchaseURL != "https://example.test/updated-receipt" || partialPayload.Items[0].PurchaseDate != "2026-04-28" || partialPayload.Items[0].Quantity != 3 || partialPayload.Items[0].NeededQuantity != 4 {
+		t.Fatalf("expected partial update to preserve ownership metadata, got %+v", partialPayload.Items[0])
 	}
 }

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -282,6 +282,12 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 			notes TEXT NOT NULL DEFAULT '',
 			highlight_hit INTEGER NOT NULL DEFAULT 1,
 			below_target_now INTEGER NOT NULL DEFAULT 0,
+			owned INTEGER NOT NULL DEFAULT 0,
+			price_paid REAL NOT NULL DEFAULT 0,
+			purchase_url TEXT NOT NULL DEFAULT '',
+			purchase_date TEXT NOT NULL DEFAULT '',
+			quantity INTEGER NOT NULL DEFAULT 0,
+			needed_quantity INTEGER NOT NULL DEFAULT 1,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			FOREIGN KEY (item_id) REFERENCES canonical_items(id) ON DELETE CASCADE
@@ -552,6 +558,30 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "below_target_now", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("ensure wishlist_entries.below_target_now: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "owned", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.owned: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "price_paid", "REAL NOT NULL DEFAULT 0"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.price_paid: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "purchase_url", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.purchase_url: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "purchase_date", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.purchase_date: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "quantity", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.quantity: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "needed_quantity", "INTEGER NOT NULL DEFAULT 1"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.needed_quantity: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_wishlist_entries_profile_id ON wishlist_entries(profile_id);`); err != nil {
 		conn.Close()

--- a/internal/wishlist/service.go
+++ b/internal/wishlist/service.go
@@ -17,6 +17,12 @@ type Entry struct {
 	Notes          string  `json:"notes"`
 	HighlightHit   bool    `json:"highlight_hit"`
 	BelowTargetNow bool    `json:"below_target_now"`
+	Owned          bool    `json:"owned"`
+	PricePaid      float64 `json:"price_paid"`
+	PurchaseURL    string  `json:"purchase_url"`
+	PurchaseDate   string  `json:"purchase_date"`
+	Quantity       int     `json:"quantity"`
+	NeededQuantity int     `json:"needed_quantity"`
 	CreatedAt      string  `json:"created_at"`
 	UpdatedAt      string  `json:"updated_at"`
 }
@@ -57,10 +63,16 @@ func (s *Service) CreateForProfile(ctx context.Context, profileID string, in Ent
 	if in.BelowTargetNow {
 		belowTargetNow = 1
 	}
+	owned := 0
+	if in.Owned {
+		owned = 1
+	}
+	in.Quantity = normalizeWishlistCount(in.Quantity)
+	in.NeededQuantity = normalizeWishlistCount(in.NeededQuantity)
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit, below_target_now)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, in.ID, trimmedProfileID, in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow)
+		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, price_paid, purchase_url, purchase_date, quantity, needed_quantity)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, in.ID, trimmedProfileID, in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, owned, in.PricePaid, strings.TrimSpace(in.PurchaseURL), strings.TrimSpace(in.PurchaseDate), in.Quantity, in.NeededQuantity)
 	if err != nil {
 		return Entry{}, fmt.Errorf("create wishlist entry: %w", err)
 	}
@@ -92,11 +104,17 @@ func (s *Service) UpdateForProfile(ctx context.Context, profileID string, in Ent
 	if in.BelowTargetNow {
 		belowTargetNow = 1
 	}
+	owned := 0
+	if in.Owned {
+		owned = 1
+	}
+	in.Quantity = normalizeWishlistCount(in.Quantity)
+	in.NeededQuantity = normalizeWishlistCount(in.NeededQuantity)
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE wishlist_entries
-		SET target_price = ?, priority = ?, notes = ?, highlight_hit = ?, below_target_now = ?, updated_at = CURRENT_TIMESTAMP
+		SET target_price = ?, priority = ?, notes = ?, highlight_hit = ?, below_target_now = ?, owned = ?, price_paid = ?, purchase_url = ?, purchase_date = ?, quantity = ?, needed_quantity = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, in.ID, trimmedProfileID, trimmedProfileID)
+	`, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, owned, in.PricePaid, strings.TrimSpace(in.PurchaseURL), strings.TrimSpace(in.PurchaseDate), in.Quantity, in.NeededQuantity, in.ID, trimmedProfileID, trimmedProfileID)
 	if err != nil {
 		return err
 	}
@@ -140,10 +158,11 @@ func (s *Service) GetByIDForProfile(ctx context.Context, profileID, id string) (
 	var e Entry
 	var highlight int
 	var belowTargetNow int
+	var owned int
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, item_id, target_price, priority, notes, highlight_hit, below_target_now, created_at, updated_at
+		SELECT id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, price_paid, purchase_url, purchase_date, quantity, needed_quantity, created_at, updated_at
 		FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &belowTargetNow, &e.CreatedAt, &e.UpdatedAt)
+	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &belowTargetNow, &owned, &e.PricePaid, &e.PurchaseURL, &e.PurchaseDate, &e.Quantity, &e.NeededQuantity, &e.CreatedAt, &e.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return Entry{}, fmt.Errorf("wishlist entry not found")
@@ -152,6 +171,7 @@ func (s *Service) GetByIDForProfile(ctx context.Context, profileID, id string) (
 	}
 	e.HighlightHit = highlight == 1
 	e.BelowTargetNow = belowTargetNow == 1 || s.isBelowTarget(ctx, e.ItemID, e.TargetPrice)
+	e.Owned = owned == 1
 	return e, nil
 }
 
@@ -234,6 +254,13 @@ func normalizeWishlistPriority(raw string) string {
 		return "medium"
 	}
 	return priority
+}
+
+func normalizeWishlistCount(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
 }
 
 func (s *Service) itemIDForEntry(ctx context.Context, profileID, entryID string) (string, error) {

--- a/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
@@ -1,4 +1,8 @@
 describe("wishlist-pricing-columns", () => {
+  function expectHeaderVisible(title: string) {
+    cy.contains("th", title).scrollIntoView().should("be.visible");
+  }
+
   function openWishlist() {
     cy.e2eReset();
     cy.e2eSetSetupState("present");
@@ -79,19 +83,23 @@ describe("wishlist-pricing-columns", () => {
 
     cy.get('button[aria-label="Switch to rows view"]').click();
     cy.contains("th", "Item ID").should("not.exist");
-    cy.contains("th", "Market Price").should("be.visible");
-    cy.contains("th", "Price Graph").should("be.visible");
-    cy.contains("th", "Cost").should("be.visible");
-    cy.contains("th", "Priority").should("be.visible");
+    expectHeaderVisible("Market Price");
+    expectHeaderVisible("Price Graph");
+    expectHeaderVisible("Cost");
+    expectHeaderVisible("Priority");
     cy.contains("th", "Target Priority").should("not.exist");
 
-    cy.contains("Wishlist Pricing Candidate").should("be.visible");
+    cy.contains("Wishlist Pricing Candidate")
+      .scrollIntoView()
+      .should("be.visible");
     cy.contains("$22.50").should("be.visible");
     cy.get('[data-testid="wishlist-price-trend-item-price-1"]')
+      .scrollIntoView()
       .should("have.attr", "aria-label", "Price trending down")
       .and("be.visible");
 
     cy.get('[data-testid="wishlist-cost-input-item-price-1"]')
+      .scrollIntoView()
       .clear()
       .type("19.75{enter}");
     cy.wait("@updateWishlistEntry")
@@ -101,13 +109,13 @@ describe("wishlist-pricing-columns", () => {
         target_price: 19.75,
       });
 
-    cy.get('[data-testid="wishlist-priority-select-item-price-1"]').then(
-      ($select) => {
+    cy.get('[data-testid="wishlist-priority-select-item-price-1"]')
+      .scrollIntoView()
+      .then(($select) => {
         const select = $select[0] as HTMLSelectElement;
         select.value = "high";
         select.dispatchEvent(new Event("change", { bubbles: true }));
-      }
-    );
+      });
     cy.wait("@updateWishlistEntry")
       .its("request.body")
       .should("include", {
@@ -118,13 +126,168 @@ describe("wishlist-pricing-columns", () => {
     cy.reload();
     cy.wait("@wishlistItems");
     cy.wait("@catalogItems");
-    cy.get('[data-testid="wishlist-cost-input-item-price-1"]').should(
-      "have.value",
-      "19.75"
-    );
+    cy.get('[data-testid="wishlist-cost-input-item-price-1"]')
+      .scrollIntoView()
+      .should("have.value", "19.75");
     cy.get('[data-testid="wishlist-priority-select-item-price-1"]').should(
       "have.value",
       "high"
+    );
+  });
+
+  it("tracks owned state, purchase details, quantity, and needs inline", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    let wishlistEntries = [
+      {
+        id: "wish-price-1",
+        item_id: "item-price-1",
+        priority: "medium",
+        below_target_now: false,
+        notes: "Watch clean boxed examples",
+        target_price: 25,
+        owned: false,
+        price_paid: 0,
+        purchase_url: "",
+        purchase_date: "",
+        quantity: 0,
+        needed_quantity: 1,
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "item-price-1",
+            title: "Wishlist Pricing Candidate",
+            part_number: "WPC-001",
+            status: "wishlist",
+            category: "Cards",
+            priority: "medium",
+          },
+        ],
+      },
+    }).as("catalogItems");
+    cy.intercept("GET", "/api/pricing/stats?item_id=item-price-1", {
+      statusCode: 200,
+      body: { min: 18, median: 21, latest: 22.5 },
+    }).as("priceStats");
+    cy.intercept("GET", "/api/pricing/trend?item_id=item-price-1", {
+      statusCode: 200,
+      body: {
+        points: [
+          { date: "2026-04-25", latest: 22.5 },
+          { date: "2026-04-26", latest: 22.5 },
+        ],
+      },
+    }).as("priceTrend");
+    cy.intercept("PUT", "/api/wishlist", (req) => {
+      expect(req.body.id).to.eq("wish-price-1");
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === req.body.id ? { ...entry, ...req.body } : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("updateWishlistEntry");
+
+    openWishlist();
+
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.wait("@priceStats");
+    cy.wait("@priceTrend");
+
+    cy.get('button[aria-label="Switch to rows view"]').click();
+    expectHeaderVisible("Owned");
+    expectHeaderVisible("Price Paid");
+    expectHeaderVisible("Qty");
+    expectHeaderVisible("Needs");
+
+    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').then(
+      ($checkbox) => {
+        expect($checkbox.prop("checked")).to.eq(false);
+      }
+    );
+    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').click({
+      force: true,
+    });
+    cy.wait("@updateWishlistEntry")
+      .its("request.body")
+      .should("include", { id: "wish-price-1", owned: true });
+    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').then(
+      ($checkbox) => {
+        expect($checkbox.prop("checked")).to.eq(true);
+      }
+    );
+
+    cy.get('[data-testid="wishlist-purchase-open-item-price-1"]')
+      .click({ force: true });
+    cy.get('[data-testid="wishlist-purchase-dialog"]').should("be.visible");
+    cy.get('[data-testid="wishlist-purchase-price-paid"]').should(
+      "have.value",
+      "22.50"
+    );
+    cy.get('[data-testid="wishlist-purchase-date"]').should(
+      "have.value",
+      today
+    );
+    cy.get('[data-testid="wishlist-purchase-price-paid"]')
+      .click()
+      .should("have.value", "")
+      .type("18.25");
+    cy.get('[data-testid="wishlist-purchase-url"]').type(
+      "https://example.test/purchase"
+    );
+    cy.get('[data-testid="wishlist-purchase-save"]').click();
+    cy.wait("@updateWishlistEntry")
+      .its("request.body")
+      .should("include", {
+        id: "wish-price-1",
+        owned: true,
+        price_paid: 18.25,
+        purchase_url: "https://example.test/purchase",
+        purchase_date: today,
+      });
+    cy.get('[data-testid="wishlist-price-paid-value-item-price-1"]').should(
+      "contain.text",
+      "$18.25"
+    );
+
+    cy.get('[data-testid="wishlist-qty-input-item-price-1"]').type(
+      "{selectall}2{enter}",
+      { force: true }
+    );
+    cy.wait("@updateWishlistEntry")
+      .its("request.body")
+      .should("include", { id: "wish-price-1", quantity: 2 });
+    cy.get('[data-testid="wishlist-needs-input-item-price-1"]').type(
+      "{selectall}5{enter}",
+      { force: true }
+    );
+    cy.wait("@updateWishlistEntry")
+      .its("request.body")
+      .should("include", { id: "wish-price-1", needed_quantity: 5 });
+
+    cy.reload();
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').should(
+      "be.checked"
+    );
+    cy.get('[data-testid="wishlist-price-paid-value-item-price-1"]').should(
+      "contain.text",
+      "$18.25"
+    );
+    cy.get('[data-testid="wishlist-qty-input-item-price-1"]').should(
+      "have.value",
+      "2"
+    );
+    cy.get('[data-testid="wishlist-needs-input-item-price-1"]').should(
+      "have.value",
+      "5"
     );
   });
 });

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -3,10 +3,11 @@ import { type ColumnDef } from '@tanstack/react-table'
 import {
   BarcodeIcon,
   ImageIcon,
+  MinusIcon,
+  PlusIcon,
   TagsIcon,
   TrendingDownIcon,
   TrendingUpIcon,
-  MinusIcon,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -31,9 +32,21 @@ type TasksColumnsOptions = {
   onWishlistMarkOwned?: (task: Task) => Promise<void>
   onWishlistInlineUpdate?: (
     task: Task,
-    changes: { targetPrice?: number; priority?: string }
+    changes: WishlistInlineChanges
   ) => Promise<void>
+  onWishlistPurchaseRow?: (task: Task) => void
   wishlistActionItemID?: string | null
+}
+
+type WishlistInlineChanges = {
+  targetPrice?: number
+  priority?: string
+  owned?: boolean
+  pricePaid?: number
+  purchaseUrl?: string
+  purchaseDate?: string
+  quantity?: number
+  neededQuantity?: number
 }
 
 function formatMoney(value: number | undefined) {
@@ -98,7 +111,7 @@ function WishlistCostCell({
   task: Task
   onWishlistInlineUpdate?: (
     task: Task,
-    changes: { targetPrice?: number; priority?: string }
+    changes: WishlistInlineChanges
   ) => Promise<void>
 }) {
   const [draft, setDraft] = useState(formatCostDraft(task.targetPrice))
@@ -153,7 +166,7 @@ function WishlistPriorityCell({
   task: Task
   onWishlistInlineUpdate?: (
     task: Task,
-    changes: { targetPrice?: number; priority?: string }
+    changes: WishlistInlineChanges
   ) => Promise<void>
 }) {
   const persistPriority = (nextPriority: string) => {
@@ -184,6 +197,124 @@ function WishlistPriorityCell({
   )
 }
 
+function WishlistOwnedCell({
+  task,
+  onWishlistInlineUpdate,
+  onWishlistPurchaseRow,
+}: {
+  task: Task
+  onWishlistInlineUpdate?: (
+    task: Task,
+    changes: WishlistInlineChanges
+  ) => Promise<void>
+  onWishlistPurchaseRow?: (task: Task) => void
+}) {
+  return (
+    <div
+      className='flex min-w-[5rem] items-center gap-1'
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+    >
+      <input
+        type='checkbox'
+        checked={Boolean(task.owned)}
+        data-testid={`wishlist-owned-checkbox-${task.id}`}
+        aria-label={`Owned status for ${task.title}`}
+        className='h-4 w-4 rounded border'
+        onChange={(event) => {
+          void onWishlistInlineUpdate?.(task, { owned: event.target.checked })
+        }}
+      />
+      <Button
+        type='button'
+        variant='outline'
+        size='icon'
+        className='h-8 w-8'
+        data-testid={`wishlist-purchase-open-${task.id}`}
+        aria-label={`Add purchase details for ${task.title}`}
+        onClick={() => onWishlistPurchaseRow?.(task)}
+      >
+        <PlusIcon className='h-4 w-4' />
+      </Button>
+    </div>
+  )
+}
+
+function WishlistPricePaidCell({ task }: { task: Task }) {
+  return (
+    <span
+      className='min-w-[76px] font-medium'
+      data-testid={`wishlist-price-paid-value-${task.id}`}
+    >
+      {formatMoney(task.pricePaid)}
+    </span>
+  )
+}
+
+function WishlistNumberCell({
+  task,
+  field,
+  label,
+  value,
+  onWishlistInlineUpdate,
+}: {
+  task: Task
+  field: 'quantity' | 'neededQuantity'
+  label: string
+  value: number | undefined
+  onWishlistInlineUpdate?: (
+    task: Task,
+    changes: WishlistInlineChanges
+  ) => Promise<void>
+}) {
+  const [draft, setDraft] = useState(String(value ?? 0))
+
+  useEffect(() => {
+    setDraft(String(value ?? 0))
+  }, [value])
+
+  const persist = async () => {
+    const parsed = Number(draft.trim())
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      setDraft(String(value ?? 0))
+      return
+    }
+    if ((value ?? 0) === parsed) {
+      return
+    }
+    await onWishlistInlineUpdate?.(task, { [field]: parsed })
+  }
+
+  return (
+    <Input
+      type='number'
+      min='0'
+      step='1'
+      inputMode='numeric'
+      value={draft}
+      data-testid={
+        field === 'quantity'
+          ? `wishlist-qty-input-${task.id}`
+          : `wishlist-needs-input-${task.id}`
+      }
+      aria-label={`${label} for ${task.title}`}
+      className='h-8 w-[4.5rem]'
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={() => {
+        void persist()
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          event.currentTarget.blur()
+        }
+      }}
+    />
+  )
+}
+
 export function getTasksColumns({
   routePath,
   onEditRow,
@@ -193,6 +324,7 @@ export function getTasksColumns({
   onDeleteRow,
   onWishlistMarkOwned,
   onWishlistInlineUpdate,
+  onWishlistPurchaseRow,
   wishlistActionItemID,
 }: TasksColumnsOptions): ColumnDef<Task>[] {
   const isInventoryRoute = routePath === '/_authenticated/inventory/'
@@ -322,6 +454,29 @@ export function getTasksColumns({
     ...(isWishlistRoute
       ? [
           {
+            accessorKey: 'owned',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Owned' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => (
+              <WishlistOwnedCell
+                task={row.original}
+                onWishlistInlineUpdate={onWishlistInlineUpdate}
+                onWishlistPurchaseRow={onWishlistPurchaseRow}
+              />
+            ),
+            enableSorting: false,
+          } satisfies ColumnDef<Task>,
+          {
+            accessorKey: 'pricePaid',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Price Paid' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => <WishlistPricePaidCell task={row.original} />,
+          } satisfies ColumnDef<Task>,
+          {
             accessorKey: 'marketPrice',
             header: ({ column }) => (
               <DataTableColumnHeader column={column} title='Market Price' />
@@ -351,6 +506,38 @@ export function getTasksColumns({
             cell: ({ row }) => (
               <WishlistCostCell
                 task={row.original}
+                onWishlistInlineUpdate={onWishlistInlineUpdate}
+              />
+            ),
+          } satisfies ColumnDef<Task>,
+          {
+            accessorKey: 'quantity',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Qty' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => (
+              <WishlistNumberCell
+                task={row.original}
+                field='quantity'
+                label='Quantity'
+                value={row.original.quantity}
+                onWishlistInlineUpdate={onWishlistInlineUpdate}
+              />
+            ),
+          } satisfies ColumnDef<Task>,
+          {
+            accessorKey: 'neededQuantity',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Needs' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => (
+              <WishlistNumberCell
+                task={row.original}
+                field='neededQuantity'
+                label='Needs'
+                value={row.original.neededQuantity}
                 onWishlistInlineUpdate={onWishlistInlineUpdate}
               />
             ),

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -71,7 +71,16 @@ type DataTableProps = {
   onWishlistExport?: (tasks: Task[]) => void
   onWishlistInlineUpdate?: (
     task: Task,
-    changes: { targetPrice?: number; priority?: string }
+    changes: {
+      targetPrice?: number
+      priority?: string
+      owned?: boolean
+      pricePaid?: number
+      purchaseUrl?: string
+      purchaseDate?: string
+      quantity?: number
+      neededQuantity?: number
+    }
   ) => Promise<void>
   wishlistActionItemID?: string | null
   isWishlistMutating?: boolean
@@ -205,6 +214,17 @@ function formatWishlistStatus(status: string) {
   return status
 }
 
+function formatMoneyDraft(value: number | undefined) {
+  if (typeof value !== 'number' || value <= 0) {
+    return ''
+  }
+  return Number.isInteger(value) ? String(value) : value.toFixed(2)
+}
+
+function todayISODate() {
+  return new Date().toISOString().slice(0, 10)
+}
+
 export function TasksTable({
   data,
   routePath,
@@ -226,6 +246,18 @@ export function TasksTable({
   customFilters,
 }: DataTableProps) {
   const isInventoryRoute = routePath === '/_authenticated/inventory/'
+  const [purchaseTask, setPurchaseTask] = useState<Task | null>(null)
+  const [purchasePricePaid, setPurchasePricePaid] = useState('')
+  const [purchaseUrl, setPurchaseUrl] = useState('')
+  const [purchaseDate, setPurchaseDate] = useState(todayISODate())
+  const priceClearedOnFocusRef = useRef(false)
+  const openPurchaseDialog = useCallback((task: Task) => {
+    setPurchaseTask(task)
+    setPurchasePricePaid(formatMoneyDraft(task.pricePaid || task.marketPrice))
+    setPurchaseUrl(task.purchaseUrl ?? '')
+    setPurchaseDate(task.purchaseDate || todayISODate())
+    priceClearedOnFocusRef.current = false
+  }, [])
   const columns = useMemo(
     () =>
       getTasksColumns({
@@ -237,6 +269,7 @@ export function TasksTable({
         onDeleteRow,
         onWishlistMarkOwned,
         onWishlistInlineUpdate,
+        onWishlistPurchaseRow: openPurchaseDialog,
         wishlistActionItemID,
       }),
     [
@@ -248,6 +281,7 @@ export function TasksTable({
       onDeleteRow,
       onWishlistMarkOwned,
       onWishlistInlineUpdate,
+      openPurchaseDialog,
       wishlistActionItemID,
     ]
   )
@@ -656,6 +690,34 @@ export function TasksTable({
       }))
   }, [data, isInventoryRoute])
 
+  const savePurchaseDetails = useCallback(async () => {
+    if (!purchaseTask) {
+      return
+    }
+
+    const parsedPrice = Number(purchasePricePaid.trim())
+    if (Number.isNaN(parsedPrice) || parsedPrice < 0) {
+      setPurchasePricePaid(
+        formatMoneyDraft(purchaseTask.pricePaid || purchaseTask.marketPrice)
+      )
+      return
+    }
+
+    await onWishlistInlineUpdate?.(purchaseTask, {
+      owned: true,
+      pricePaid: parsedPrice,
+      purchaseUrl: purchaseUrl.trim(),
+      purchaseDate: purchaseDate || todayISODate(),
+    })
+    setPurchaseTask(null)
+  }, [
+    onWishlistInlineUpdate,
+    purchaseDate,
+    purchasePricePaid,
+    purchaseTask,
+    purchaseUrl,
+  ])
+
   return (
     <div
       className={cn(
@@ -985,6 +1047,80 @@ export function TasksTable({
         onWishlistExport={onWishlistExport}
         isWishlistMutating={isWishlistMutating}
       />
+      <Dialog
+        open={purchaseTask !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPurchaseTask(null)
+          }
+        }}
+      >
+        <DialogContent
+          data-testid='wishlist-purchase-dialog'
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle>Add purchase details</DialogTitle>
+            <DialogDescription>
+              Record what you paid and where this wishlist item was purchased.
+            </DialogDescription>
+          </DialogHeader>
+          <div className='grid gap-4 sm:grid-cols-2'>
+            <label className='space-y-2 text-sm font-medium'>
+              <span>Price paid</span>
+              <Input
+                type='number'
+                min='0'
+                step='0.01'
+                inputMode='decimal'
+                value={purchasePricePaid}
+                data-testid='wishlist-purchase-price-paid'
+                onFocus={() => {
+                  if (!priceClearedOnFocusRef.current) {
+                    setPurchasePricePaid('')
+                    priceClearedOnFocusRef.current = true
+                  }
+                }}
+                onChange={(event) => setPurchasePricePaid(event.target.value)}
+              />
+            </label>
+            <label className='space-y-2 text-sm font-medium'>
+              <span>Purchase date</span>
+              <Input
+                type='date'
+                value={purchaseDate}
+                data-testid='wishlist-purchase-date'
+                onChange={(event) => setPurchaseDate(event.target.value)}
+              />
+            </label>
+            <label className='space-y-2 text-sm font-medium sm:col-span-2'>
+              <span>URL</span>
+              <Input
+                value={purchaseUrl}
+                data-testid='wishlist-purchase-url'
+                placeholder='https://'
+                onChange={(event) => setPurchaseUrl(event.target.value)}
+              />
+            </label>
+          </div>
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setPurchaseTask(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type='button'
+              data-testid='wishlist-purchase-save'
+              onClick={() => void savePurchaseDetails()}
+            >
+              Save purchase
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
         <DialogContent data-testid='row-details-modal'>
           <DialogHeader>

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -17,6 +17,12 @@ export const taskSchema = z.object({
   marketPrice: z.number().optional(),
   priceTrend: z.enum(['up', 'steady', 'down', 'unknown']).optional(),
   highlightHit: z.boolean().optional(),
+  owned: z.boolean().optional(),
+  pricePaid: z.number().optional(),
+  purchaseUrl: z.string().optional(),
+  purchaseDate: z.string().optional(),
+  quantity: z.number().optional(),
+  neededQuantity: z.number().optional(),
 })
 
 export type Task = z.infer<typeof taskSchema>

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -122,6 +122,23 @@ type WishlistEntryPayload = {
   below_target_now?: boolean
   target_price?: number
   highlight_hit?: boolean
+  owned?: boolean
+  price_paid?: number
+  purchase_url?: string
+  purchase_date?: string
+  quantity?: number
+  needed_quantity?: number
+}
+
+type WishlistInlineChanges = {
+  targetPrice?: number
+  priority?: string
+  owned?: boolean
+  pricePaid?: number
+  purchaseUrl?: string
+  purchaseDate?: string
+  quantity?: number
+  neededQuantity?: number
 }
 
 function normalizeWishlistPriority(raw: string) {
@@ -375,6 +392,21 @@ export function Tasks({
           marketPrice: pricingSummary.marketPrice,
           priceTrend: pricingSummary.priceTrend,
           highlightHit: Boolean(wishlistEntry?.highlight_hit),
+          owned: Boolean(wishlistEntry?.owned),
+          pricePaid:
+            typeof wishlistEntry?.price_paid === 'number'
+              ? wishlistEntry.price_paid
+              : undefined,
+          purchaseUrl: wishlistEntry?.purchase_url?.trim(),
+          purchaseDate: wishlistEntry?.purchase_date?.trim(),
+          quantity:
+            typeof wishlistEntry?.quantity === 'number'
+              ? wishlistEntry.quantity
+              : 0,
+          neededQuantity:
+            typeof wishlistEntry?.needed_quantity === 'number'
+              ? wishlistEntry.needed_quantity
+              : 1,
         } satisfies Task
       })
     )
@@ -527,7 +559,7 @@ export function Tasks({
   const handleWishlistInlineUpdate = useCallback(
     async (
       task: Task,
-      changes: { targetPrice?: number; priority?: string }
+      changes: WishlistInlineChanges
     ) => {
       const wishlistEntryID = task.wishlistEntryID?.trim()
       if (!wishlistEntryID) {
@@ -542,6 +574,14 @@ export function Tasks({
         changes.priority ?? currentTask.priority
       )
       let nextTargetPrice = changes.targetPrice ?? currentTask.targetPrice ?? 0
+      const nextOwned = changes.owned ?? currentTask.owned ?? false
+      const nextPricePaid = changes.pricePaid ?? currentTask.pricePaid ?? 0
+      const nextPurchaseUrl = changes.purchaseUrl ?? currentTask.purchaseUrl ?? ''
+      const nextPurchaseDate =
+        changes.purchaseDate ?? currentTask.purchaseDate ?? ''
+      const nextQuantity = changes.quantity ?? currentTask.quantity ?? 0
+      const nextNeededQuantity =
+        changes.neededQuantity ?? currentTask.neededQuantity ?? 1
 
       if (changes.targetPrice === undefined) {
         try {
@@ -569,6 +609,12 @@ export function Tasks({
               ...candidate,
               priority: nextPriority,
               targetPrice: nextTargetPrice,
+              owned: nextOwned,
+              pricePaid: nextPricePaid,
+              purchaseUrl: nextPurchaseUrl,
+              purchaseDate: nextPurchaseDate,
+              quantity: nextQuantity,
+              neededQuantity: nextNeededQuantity,
             }
           : candidate
       )
@@ -580,6 +626,12 @@ export function Tasks({
                 ...candidate,
                 priority: nextPriority,
                 targetPrice: nextTargetPrice,
+                owned: nextOwned,
+                pricePaid: nextPricePaid,
+                purchaseUrl: nextPurchaseUrl,
+                purchaseDate: nextPurchaseDate,
+                quantity: nextQuantity,
+                neededQuantity: nextNeededQuantity,
               }
             : candidate
         )
@@ -593,6 +645,24 @@ export function Tasks({
         }
         if (changes.targetPrice !== undefined) {
           requestBody.target_price = nextTargetPrice
+        }
+        if (changes.owned !== undefined) {
+          requestBody.owned = nextOwned
+        }
+        if (changes.pricePaid !== undefined) {
+          requestBody.price_paid = nextPricePaid
+        }
+        if (changes.purchaseUrl !== undefined) {
+          requestBody.purchase_url = nextPurchaseUrl
+        }
+        if (changes.purchaseDate !== undefined) {
+          requestBody.purchase_date = nextPurchaseDate
+        }
+        if (changes.quantity !== undefined) {
+          requestBody.quantity = nextQuantity
+        }
+        if (changes.neededQuantity !== undefined) {
+          requestBody.needed_quantity = nextNeededQuantity
         }
 
         const response = await fetch('/api/wishlist', {


### PR DESCRIPTION
## Summary
- Adds wishlist owned tracking with a checkbox and purchase details modal.
- Adds price paid, editable qty, and editable needs columns to the wishlist table.
- Persists owned/purchase/qty/needs metadata through the wishlist API and SQLite schema.
- Adds missing OpenAPI Photo schema so Redocly resolves the existing photo rotate reference.

## Validation
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts -Browser electron`
- `go test ./internal/app -run TestWishlistEndpointPersistsManualWatchStatusForActiveProfile -count=1`
- `npx --yes @redocly/cli@latest lint docs/api/openapi.yaml --max-problems 1`
- `git diff --check`
- pre-push OpenSpec + fast API docs smoke test

Closes #729
Refs #730