### PR TITLE
#732 feat(wishlist): simplify header actions

### DIFF
--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -102,8 +102,19 @@ describe("ui-screen-wishlist", () => {
 
     cy.contains("Wishlist").should("be.visible");
     cy.get('[data-testid="wishlist-global-header-actions"]').within(() => {
-      cy.get('[data-testid="wishlist-new-action"]').should("be.visible");
-      cy.get('[data-testid="wishlist-create-menu-trigger"]').should("be.visible");
+      cy.get('[data-testid="wishlist-new-action"]')
+        .should("be.visible")
+        .and("have.attr", "aria-label", "New wishlist item")
+        .and("not.contain.text", "New");
+      cy.get('[data-testid="wishlist-create-collection-action"]')
+        .should("be.visible")
+        .and("have.attr", "aria-label", "Create collection")
+        .and("not.contain.text", "Create");
+      cy.get('[data-testid="wishlist-import-action"]')
+        .should("be.visible")
+        .and("have.attr", "aria-label", "Import wishlist entries")
+        .and("not.contain.text", "Import");
+      cy.get('[data-testid="wishlist-create-menu-trigger"]').should("not.exist");
     });
     cy.contains(
       "Track wanted items, target prices, and planning decisions before they become owned inventory."
@@ -156,23 +167,35 @@ describe("ui-screen-wishlist", () => {
     cy.get('button[aria-label="Delete selected wishlist entries"]').should("be.visible");
   });
 
-  it("UI-SCREEN-WISHLIST-002 opens create and import actions from Create menu", () => {
+  it("UI-SCREEN-WISHLIST-002 exposes direct compact header actions", () => {
     signInToWishlist();
 
-    cy.get('[data-testid="wishlist-create-menu-trigger"]').click();
-    cy.get('[data-testid="wishlist-create-menu-entry"]').should("be.visible");
-    cy.get('[data-testid="wishlist-create-menu-import"]').should("be.visible");
+    cy.get('[data-testid="wishlist-global-header-actions"]').within(() => {
+      cy.get('[data-testid="wishlist-new-action"]')
+        .should("be.visible")
+        .and("have.attr", "title", "New wishlist item");
+      cy.get('[data-testid="wishlist-create-collection-action"]')
+        .should("be.visible")
+        .and("have.attr", "title", "Create collection");
+      cy.get('[data-testid="wishlist-import-action"]')
+        .should("be.visible")
+        .and("have.attr", "title", "Import wishlist entries");
+      cy.get('[data-testid="wishlist-create-menu-trigger"]').should("not.exist");
+    });
   });
 
-  it("UI-SCREEN-WISHLIST-004 shows dedicated New action with adjacent Create menu", () => {
+  it("UI-SCREEN-WISHLIST-004 shows icon-only header actions", () => {
     signInToWishlist();
 
     cy.get('[data-testid="wishlist-new-action"]')
       .should("be.visible")
-      .and("contain", "New");
-    cy.get('[data-testid="wishlist-create-menu-trigger"]')
+      .and("not.contain", "New");
+    cy.get('[data-testid="wishlist-create-collection-action"]')
       .should("be.visible")
-      .and("contain", "Create");
+      .and("not.contain", "Create");
+    cy.get('[data-testid="wishlist-import-action"]')
+      .should("be.visible")
+      .and("not.contain", "Import");
   });
 
   it("UI-SCREEN-WISHLIST-005 supports inline collection create and auto-select", () => {
@@ -454,7 +477,7 @@ describe("ui-screen-wishlist", () => {
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
   });
 
-  it("UI-SCREEN-WISHLIST-009 wires New and Create actions into real wishlist dialogs", () => {
+  it("UI-SCREEN-WISHLIST-009 wires direct header actions into real wishlist dialogs", () => {
     signInToWishlist();
 
     cy.get('[data-testid="wishlist-new-action"]').click();
@@ -462,14 +485,12 @@ describe("ui-screen-wishlist", () => {
 
     cy.contains("button", "Close").click();
 
-    cy.get('[data-testid="wishlist-create-menu-trigger"]').click();
-    cy.get('[data-testid="wishlist-create-menu-entry"]').click();
-    cy.contains("Create Wishlist Entry").should("be.visible");
+    cy.get('[data-testid="wishlist-create-collection-action"]').click();
+    cy.get('[data-testid="wishlist-table-new-collection-name"]').should(
+      "be.visible"
+    );
 
-    cy.contains("button", "Close").click();
-
-    cy.get('[data-testid="wishlist-create-menu-trigger"]').click();
-    cy.get('[data-testid="wishlist-create-menu-import"]').click();
+    cy.get('[data-testid="wishlist-import-action"]').click();
     cy.contains("Import Wishlist Entries").should("be.visible");
   });
 

--- a/ui.web/cypress/e2e/wishlist/wishlist-header-actions/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-header-actions/spec.cy.ts
@@ -1,0 +1,84 @@
+describe("wishlist-header-actions", () => {
+  function openWishlist() {
+    cy.intercept("GET", "/api/wishlist", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "wish-header-1",
+            item_id: "item-header-1",
+            priority: "medium",
+            below_target_now: false,
+          },
+        ],
+      },
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "item-header-1",
+            title: "Header Action Wishlist Item",
+            part_number: "HDR-001",
+            status: "wishlist",
+            category: "Slot Cars",
+            priority: "medium",
+          },
+        ],
+      },
+    }).as("catalogItems");
+    cy.intercept("GET", "/api/profiles/*/settings").as("profileSettings");
+
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: "/wishlist/",
+      });
+    });
+
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.wait("@profileSettings");
+  }
+
+  it("shows direct compact wishlist header actions without create menu", () => {
+    openWishlist();
+
+    cy.get('[data-testid="wishlist-global-header-actions"]').within(() => {
+      cy.get('[data-testid="wishlist-new-action"]')
+        .should("be.visible")
+        .and("have.attr", "aria-label", "New wishlist item")
+        .and("have.attr", "title", "New wishlist item")
+        .and("not.contain.text", "New");
+      cy.get('[data-testid="wishlist-create-collection-action"]')
+        .should("be.visible")
+        .and("have.attr", "aria-label", "Create collection")
+        .and("have.attr", "title", "Create collection")
+        .and("not.contain.text", "Create");
+      cy.get('[data-testid="wishlist-import-action"]')
+        .should("be.visible")
+        .and("have.attr", "aria-label", "Import wishlist entries")
+        .and("have.attr", "title", "Import wishlist entries")
+        .and("not.contain.text", "Import");
+      cy.get('[data-testid="wishlist-create-menu-trigger"]').should("not.exist");
+    });
+  });
+
+  it("opens wishlist create, collection create, and import from direct buttons", () => {
+    openWishlist();
+
+    cy.get('[data-testid="wishlist-new-action"]').click();
+    cy.contains("Create Wishlist Entry").should("be.visible");
+    cy.contains("button", "Close").click();
+
+    cy.get('[data-testid="wishlist-create-collection-action"]').click();
+    cy.get('[data-testid="wishlist-table-new-collection-name"]').should(
+      "be.visible"
+    );
+
+    cy.get('[data-testid="wishlist-import-action"]').click();
+    cy.contains("Import Wishlist Entries").should("be.visible");
+  });
+});

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Heart } from 'lucide-react'
+import { FolderPlus, Heart, Plus, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { ConfigDrawer } from '@/components/config-drawer'
@@ -241,12 +235,10 @@ function buildWishlistCsv(tasksToExport: Task[]) {
 }
 
 function TasksHeaderActions({
-  isWishlistRoute,
   onOpenCollectionCreate,
   onCreate,
   onImport,
 }: {
-  isWishlistRoute: boolean
   onOpenCollectionCreate: () => void
   onCreate: () => void
   onImport: () => void
@@ -258,44 +250,36 @@ function TasksHeaderActions({
     >
       <Button
         type='button'
+        size='icon'
         data-testid='wishlist-new-action'
+        aria-label='New wishlist item'
+        title='New wishlist item'
         onClick={onCreate}
       >
-        New
+        <Plus className='h-4 w-4' aria-hidden='true' />
       </Button>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type='button'
-            variant='outline'
-            data-testid='wishlist-create-menu-trigger'
-          >
-            Create
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='end'>
-          <DropdownMenuItem
-            data-testid='wishlist-create-menu-entry'
-            onClick={onCreate}
-          >
-            New Wishlist Entry
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            data-testid='wishlist-create-menu-import'
-            onClick={onImport}
-          >
-            Import Wishlist
-          </DropdownMenuItem>
-          {isWishlistRoute ? (
-            <DropdownMenuItem
-              data-testid='wishlist-create-menu-collection'
-              onClick={onOpenCollectionCreate}
-            >
-              New Collection
-            </DropdownMenuItem>
-          ) : null}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <Button
+        type='button'
+        variant='outline'
+        size='icon'
+        data-testid='wishlist-create-collection-action'
+        aria-label='Create collection'
+        title='Create collection'
+        onClick={onOpenCollectionCreate}
+      >
+        <FolderPlus className='h-4 w-4' aria-hidden='true' />
+      </Button>
+      <Button
+        type='button'
+        variant='outline'
+        size='icon'
+        data-testid='wishlist-import-action'
+        aria-label='Import wishlist entries'
+        title='Import wishlist entries'
+        onClick={onImport}
+      >
+        <Upload className='h-4 w-4' aria-hidden='true' />
+      </Button>
     </div>
   )
 }
@@ -1073,7 +1057,6 @@ export function Tasks({
                 data-testid='wishlist-global-header-actions'
               >
                 <TasksHeaderActions
-                  isWishlistRoute={isWishlistRoute}
                   onOpenCollectionCreate={() => {
                     setInlineCollectionValidationMessage('')
                     setInlineCollectionInputOpen(true)


### PR DESCRIPTION
## Summary
- Replaces the Wishlist header `Create` submenu with three direct icon-only actions.
- `+` opens the new wishlist item flow.
- Collection-create icon opens inline collection creation.
- Import icon opens wishlist import.
- Updates wishlist screen coverage and adds a focused header-actions Cypress spec.

## Validation
- `pwsh -NoLogo -NoProfile -File .\scripts\build-cabinet.ps1`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-header-actions/spec.cy.ts -Browser electron`
- `git diff --check`
- pre-push OpenSpec + fast API docs smoke test

Note: the broader `ui-screen-wishlist` spec was attempted but this local runner timed out before returning output, so the new focused spec covers this change directly.

Closes #732