### PR TITLE
#734 feat(wishlist): add purchase qty and condition

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1997,6 +1997,7 @@ components:
         price_paid: { type: number }
         purchase_url: { type: string }
         purchase_date: { type: string, format: date }
+        purchase_condition: { type: string }
         quantity: { type: integer }
         needed_quantity: { type: integer }
     WishlistEntry:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2873,6 +2873,9 @@ func New(cfg config.Config) (*App, error) {
 					if _, ok := raw["purchase_date"]; !ok {
 						req.PurchaseDate = existing.PurchaseDate
 					}
+					if _, ok := raw["purchase_condition"]; !ok {
+						req.PurchaseCondition = existing.PurchaseCondition
+					}
 					if _, ok := raw["quantity"]; !ok {
 						req.Quantity = existing.Quantity
 					}

--- a/internal/app/wishlist_planning_metadata_api_test.go
+++ b/internal/app/wishlist_planning_metadata_api_test.go
@@ -45,7 +45,7 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 		t.Fatal("expected item id")
 	}
 
-	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"manual watch state","below_target_now":true,"highlight_hit":true,"owned":true,"price_paid":37.5,"purchase_url":"https://example.test/receipt","purchase_date":"2026-04-27","quantity":2,"needed_quantity":5}`), map[string]string{"Content-Type": "application/json"})
+	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"manual watch state","below_target_now":true,"highlight_hit":true,"owned":true,"price_paid":37.5,"purchase_url":"https://example.test/receipt","purchase_date":"2026-04-27","purchase_condition":"boxed","quantity":2,"needed_quantity":5}`), map[string]string{"Content-Type": "application/json"})
 	if createWish.Code != http.StatusCreated {
 		t.Fatalf("create wishlist status=%d body=%s", createWish.Code, createWish.Body.String())
 	}
@@ -71,7 +71,7 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 		t.Fatalf("expected created wishlist to persist owned=true, got %+v", created)
 	}
 
-	updateWish := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+created.ID+`","item_id":"`+item.ID+`","target_price":42,"priority":"medium","notes":"updated manual watch state","below_target_now":false,"highlight_hit":false,"owned":true,"price_paid":35.25,"purchase_url":"https://example.test/updated-receipt","purchase_date":"2026-04-28","quantity":3,"needed_quantity":4}`), map[string]string{"Content-Type": "application/json"})
+	updateWish := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+created.ID+`","item_id":"`+item.ID+`","target_price":42,"priority":"medium","notes":"updated manual watch state","below_target_now":false,"highlight_hit":false,"owned":true,"price_paid":35.25,"purchase_url":"https://example.test/updated-receipt","purchase_date":"2026-04-28","purchase_condition":"loose","quantity":3,"needed_quantity":4}`), map[string]string{"Content-Type": "application/json"})
 	if updateWish.Code != http.StatusOK {
 		t.Fatalf("update wishlist status=%d body=%s", updateWish.Code, updateWish.Body.String())
 	}
@@ -82,17 +82,18 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	}
 	var listPayload struct {
 		Items []struct {
-			ID             string  `json:"id"`
-			BelowTargetNow bool    `json:"below_target_now"`
-			HighlightHit   bool    `json:"highlight_hit"`
-			Priority       string  `json:"priority"`
-			Notes          string  `json:"notes"`
-			Owned          bool    `json:"owned"`
-			PricePaid      float64 `json:"price_paid"`
-			PurchaseURL    string  `json:"purchase_url"`
-			PurchaseDate   string  `json:"purchase_date"`
-			Quantity       int     `json:"quantity"`
-			NeededQuantity int     `json:"needed_quantity"`
+			ID                string  `json:"id"`
+			BelowTargetNow    bool    `json:"below_target_now"`
+			HighlightHit      bool    `json:"highlight_hit"`
+			Priority          string  `json:"priority"`
+			Notes             string  `json:"notes"`
+			Owned             bool    `json:"owned"`
+			PricePaid         float64 `json:"price_paid"`
+			PurchaseURL       string  `json:"purchase_url"`
+			PurchaseDate      string  `json:"purchase_date"`
+			PurchaseCondition string  `json:"purchase_condition"`
+			Quantity          int     `json:"quantity"`
+			NeededQuantity    int     `json:"needed_quantity"`
 		} `json:"items"`
 	}
 	if err := json.NewDecoder(listWish.Body).Decode(&listPayload); err != nil {
@@ -113,7 +114,7 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	if listPayload.Items[0].Notes != "updated manual watch state" {
 		t.Fatalf("expected updated wishlist notes to persist, got %+v", listPayload.Items[0])
 	}
-	if !listPayload.Items[0].Owned || listPayload.Items[0].PricePaid != 35.25 || listPayload.Items[0].PurchaseURL != "https://example.test/updated-receipt" || listPayload.Items[0].PurchaseDate != "2026-04-28" || listPayload.Items[0].Quantity != 3 || listPayload.Items[0].NeededQuantity != 4 {
+	if !listPayload.Items[0].Owned || listPayload.Items[0].PricePaid != 35.25 || listPayload.Items[0].PurchaseURL != "https://example.test/updated-receipt" || listPayload.Items[0].PurchaseDate != "2026-04-28" || listPayload.Items[0].PurchaseCondition != "loose" || listPayload.Items[0].Quantity != 3 || listPayload.Items[0].NeededQuantity != 4 {
 		t.Fatalf("expected ownership metadata round-trip after update, got %+v", listPayload.Items[0])
 	}
 
@@ -128,18 +129,19 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	}
 	var partialPayload struct {
 		Items []struct {
-			ID             string  `json:"id"`
-			TargetPrice    float64 `json:"target_price"`
-			BelowTargetNow bool    `json:"below_target_now"`
-			HighlightHit   bool    `json:"highlight_hit"`
-			Priority       string  `json:"priority"`
-			Notes          string  `json:"notes"`
-			Owned          bool    `json:"owned"`
-			PricePaid      float64 `json:"price_paid"`
-			PurchaseURL    string  `json:"purchase_url"`
-			PurchaseDate   string  `json:"purchase_date"`
-			Quantity       int     `json:"quantity"`
-			NeededQuantity int     `json:"needed_quantity"`
+			ID                string  `json:"id"`
+			TargetPrice       float64 `json:"target_price"`
+			BelowTargetNow    bool    `json:"below_target_now"`
+			HighlightHit      bool    `json:"highlight_hit"`
+			Priority          string  `json:"priority"`
+			Notes             string  `json:"notes"`
+			Owned             bool    `json:"owned"`
+			PricePaid         float64 `json:"price_paid"`
+			PurchaseURL       string  `json:"purchase_url"`
+			PurchaseDate      string  `json:"purchase_date"`
+			PurchaseCondition string  `json:"purchase_condition"`
+			Quantity          int     `json:"quantity"`
+			NeededQuantity    int     `json:"needed_quantity"`
 		} `json:"items"`
 	}
 	if err := json.NewDecoder(listAfterPartialUpdate.Body).Decode(&partialPayload); err != nil {
@@ -160,7 +162,7 @@ func TestWishlistEndpointPersistsManualWatchStatusForActiveProfile(t *testing.T)
 	if partialPayload.Items[0].BelowTargetNow || partialPayload.Items[0].HighlightHit {
 		t.Fatalf("expected partial update to preserve false watch flags, got %+v", partialPayload.Items[0])
 	}
-	if !partialPayload.Items[0].Owned || partialPayload.Items[0].PricePaid != 35.25 || partialPayload.Items[0].PurchaseURL != "https://example.test/updated-receipt" || partialPayload.Items[0].PurchaseDate != "2026-04-28" || partialPayload.Items[0].Quantity != 3 || partialPayload.Items[0].NeededQuantity != 4 {
+	if !partialPayload.Items[0].Owned || partialPayload.Items[0].PricePaid != 35.25 || partialPayload.Items[0].PurchaseURL != "https://example.test/updated-receipt" || partialPayload.Items[0].PurchaseDate != "2026-04-28" || partialPayload.Items[0].PurchaseCondition != "loose" || partialPayload.Items[0].Quantity != 3 || partialPayload.Items[0].NeededQuantity != 4 {
 		t.Fatalf("expected partial update to preserve ownership metadata, got %+v", partialPayload.Items[0])
 	}
 }

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -286,6 +286,7 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 			price_paid REAL NOT NULL DEFAULT 0,
 			purchase_url TEXT NOT NULL DEFAULT '',
 			purchase_date TEXT NOT NULL DEFAULT '',
+			purchase_condition TEXT NOT NULL DEFAULT '',
 			quantity INTEGER NOT NULL DEFAULT 0,
 			needed_quantity INTEGER NOT NULL DEFAULT 1,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -574,6 +575,10 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "purchase_date", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("ensure wishlist_entries.purchase_date: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "purchase_condition", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.purchase_condition: %w", err)
 	}
 	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "quantity", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		conn.Close()

--- a/internal/wishlist/service.go
+++ b/internal/wishlist/service.go
@@ -10,21 +10,22 @@ import (
 )
 
 type Entry struct {
-	ID             string  `json:"id"`
-	ItemID         string  `json:"item_id"`
-	TargetPrice    float64 `json:"target_price"`
-	Priority       string  `json:"priority"`
-	Notes          string  `json:"notes"`
-	HighlightHit   bool    `json:"highlight_hit"`
-	BelowTargetNow bool    `json:"below_target_now"`
-	Owned          bool    `json:"owned"`
-	PricePaid      float64 `json:"price_paid"`
-	PurchaseURL    string  `json:"purchase_url"`
-	PurchaseDate   string  `json:"purchase_date"`
-	Quantity       int     `json:"quantity"`
-	NeededQuantity int     `json:"needed_quantity"`
-	CreatedAt      string  `json:"created_at"`
-	UpdatedAt      string  `json:"updated_at"`
+	ID                string  `json:"id"`
+	ItemID            string  `json:"item_id"`
+	TargetPrice       float64 `json:"target_price"`
+	Priority          string  `json:"priority"`
+	Notes             string  `json:"notes"`
+	HighlightHit      bool    `json:"highlight_hit"`
+	BelowTargetNow    bool    `json:"below_target_now"`
+	Owned             bool    `json:"owned"`
+	PricePaid         float64 `json:"price_paid"`
+	PurchaseURL       string  `json:"purchase_url"`
+	PurchaseDate      string  `json:"purchase_date"`
+	PurchaseCondition string  `json:"purchase_condition"`
+	Quantity          int     `json:"quantity"`
+	NeededQuantity    int     `json:"needed_quantity"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
 }
 
 type Hit struct {
@@ -70,9 +71,9 @@ func (s *Service) CreateForProfile(ctx context.Context, profileID string, in Ent
 	in.Quantity = normalizeWishlistCount(in.Quantity)
 	in.NeededQuantity = normalizeWishlistCount(in.NeededQuantity)
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, price_paid, purchase_url, purchase_date, quantity, needed_quantity)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, in.ID, trimmedProfileID, in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, owned, in.PricePaid, strings.TrimSpace(in.PurchaseURL), strings.TrimSpace(in.PurchaseDate), in.Quantity, in.NeededQuantity)
+		INSERT INTO wishlist_entries(id, profile_id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, price_paid, purchase_url, purchase_date, purchase_condition, quantity, needed_quantity)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, in.ID, trimmedProfileID, in.ItemID, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, owned, in.PricePaid, strings.TrimSpace(in.PurchaseURL), strings.TrimSpace(in.PurchaseDate), strings.TrimSpace(in.PurchaseCondition), in.Quantity, in.NeededQuantity)
 	if err != nil {
 		return Entry{}, fmt.Errorf("create wishlist entry: %w", err)
 	}
@@ -112,9 +113,9 @@ func (s *Service) UpdateForProfile(ctx context.Context, profileID string, in Ent
 	in.NeededQuantity = normalizeWishlistCount(in.NeededQuantity)
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE wishlist_entries
-		SET target_price = ?, priority = ?, notes = ?, highlight_hit = ?, below_target_now = ?, owned = ?, price_paid = ?, purchase_url = ?, purchase_date = ?, quantity = ?, needed_quantity = ?, updated_at = CURRENT_TIMESTAMP
+		SET target_price = ?, priority = ?, notes = ?, highlight_hit = ?, below_target_now = ?, owned = ?, price_paid = ?, purchase_url = ?, purchase_date = ?, purchase_condition = ?, quantity = ?, needed_quantity = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, owned, in.PricePaid, strings.TrimSpace(in.PurchaseURL), strings.TrimSpace(in.PurchaseDate), in.Quantity, in.NeededQuantity, in.ID, trimmedProfileID, trimmedProfileID)
+	`, in.TargetPrice, in.Priority, in.Notes, highlight, belowTargetNow, owned, in.PricePaid, strings.TrimSpace(in.PurchaseURL), strings.TrimSpace(in.PurchaseDate), strings.TrimSpace(in.PurchaseCondition), in.Quantity, in.NeededQuantity, in.ID, trimmedProfileID, trimmedProfileID)
 	if err != nil {
 		return err
 	}
@@ -160,9 +161,9 @@ func (s *Service) GetByIDForProfile(ctx context.Context, profileID, id string) (
 	var belowTargetNow int
 	var owned int
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, price_paid, purchase_url, purchase_date, quantity, needed_quantity, created_at, updated_at
+		SELECT id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, price_paid, purchase_url, purchase_date, purchase_condition, quantity, needed_quantity, created_at, updated_at
 		FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &belowTargetNow, &owned, &e.PricePaid, &e.PurchaseURL, &e.PurchaseDate, &e.Quantity, &e.NeededQuantity, &e.CreatedAt, &e.UpdatedAt)
+	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &belowTargetNow, &owned, &e.PricePaid, &e.PurchaseURL, &e.PurchaseDate, &e.PurchaseCondition, &e.Quantity, &e.NeededQuantity, &e.CreatedAt, &e.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return Entry{}, fmt.Errorf("wishlist entry not found")

--- a/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
@@ -149,6 +149,7 @@ describe("wishlist-pricing-columns", () => {
         price_paid: 0,
         purchase_url: "",
         purchase_date: "",
+        purchase_condition: "",
         quantity: 0,
         needed_quantity: 1,
       },
@@ -234,10 +235,22 @@ describe("wishlist-pricing-columns", () => {
       "have.value",
       today
     );
+    cy.get('[data-testid="wishlist-purchase-quantity"]').should(
+      "have.value",
+      "0"
+    );
+    cy.get('[data-testid="wishlist-purchase-condition"]').should(
+      "have.value",
+      ""
+    );
     cy.get('[data-testid="wishlist-purchase-price-paid"]')
       .click()
       .should("have.value", "")
       .type("18.25");
+    cy.get('[data-testid="wishlist-purchase-quantity"]').type(
+      "{selectall}2"
+    );
+    cy.get('[data-testid="wishlist-purchase-condition"]').type("Used - boxed");
     cy.get('[data-testid="wishlist-purchase-url"]').type(
       "https://example.test/purchase"
     );
@@ -250,6 +263,8 @@ describe("wishlist-pricing-columns", () => {
         price_paid: 18.25,
         purchase_url: "https://example.test/purchase",
         purchase_date: today,
+        purchase_condition: "Used - boxed",
+        quantity: 2,
       });
     cy.get('[data-testid="wishlist-price-paid-value-item-price-1"]').should(
       "contain.text",
@@ -257,12 +272,12 @@ describe("wishlist-pricing-columns", () => {
     );
 
     cy.get('[data-testid="wishlist-qty-input-item-price-1"]').type(
-      "{selectall}2{enter}",
+      "{selectall}3{enter}",
       { force: true }
     );
     cy.wait("@updateWishlistEntry")
       .its("request.body")
-      .should("include", { id: "wish-price-1", quantity: 2 });
+      .should("include", { id: "wish-price-1", quantity: 3 });
     cy.get('[data-testid="wishlist-needs-input-item-price-1"]').type(
       "{selectall}5{enter}",
       { force: true }
@@ -283,11 +298,18 @@ describe("wishlist-pricing-columns", () => {
     );
     cy.get('[data-testid="wishlist-qty-input-item-price-1"]').should(
       "have.value",
-      "2"
+      "3"
     );
     cy.get('[data-testid="wishlist-needs-input-item-price-1"]').should(
       "have.value",
       "5"
+    );
+    cy.get('[data-testid="wishlist-purchase-open-item-price-1"]').click({
+      force: true,
+    });
+    cy.get('[data-testid="wishlist-purchase-condition"]').should(
+      "have.value",
+      "Used - boxed"
     );
   });
 });

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -45,6 +45,7 @@ type WishlistInlineChanges = {
   pricePaid?: number
   purchaseUrl?: string
   purchaseDate?: string
+  purchaseCondition?: string
   quantity?: number
   neededQuantity?: number
 }

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -78,6 +78,7 @@ type DataTableProps = {
       pricePaid?: number
       purchaseUrl?: string
       purchaseDate?: string
+      purchaseCondition?: string
       quantity?: number
       neededQuantity?: number
     }
@@ -250,12 +251,16 @@ export function TasksTable({
   const [purchasePricePaid, setPurchasePricePaid] = useState('')
   const [purchaseUrl, setPurchaseUrl] = useState('')
   const [purchaseDate, setPurchaseDate] = useState(todayISODate())
+  const [purchaseQuantity, setPurchaseQuantity] = useState('0')
+  const [purchaseCondition, setPurchaseCondition] = useState('')
   const priceClearedOnFocusRef = useRef(false)
   const openPurchaseDialog = useCallback((task: Task) => {
     setPurchaseTask(task)
     setPurchasePricePaid(formatMoneyDraft(task.pricePaid || task.marketPrice))
     setPurchaseUrl(task.purchaseUrl ?? '')
     setPurchaseDate(task.purchaseDate || todayISODate())
+    setPurchaseQuantity(String(task.quantity ?? 0))
+    setPurchaseCondition(task.purchaseCondition ?? '')
     priceClearedOnFocusRef.current = false
   }, [])
   const columns = useMemo(
@@ -702,18 +707,31 @@ export function TasksTable({
       )
       return
     }
+    const parsedQuantity = Number(purchaseQuantity.trim())
+    if (
+      !Number.isInteger(parsedQuantity) ||
+      Number.isNaN(parsedQuantity) ||
+      parsedQuantity < 0
+    ) {
+      setPurchaseQuantity(String(purchaseTask.quantity ?? 0))
+      return
+    }
 
     await onWishlistInlineUpdate?.(purchaseTask, {
       owned: true,
       pricePaid: parsedPrice,
       purchaseUrl: purchaseUrl.trim(),
       purchaseDate: purchaseDate || todayISODate(),
+      purchaseCondition: purchaseCondition.trim(),
+      quantity: parsedQuantity,
     })
     setPurchaseTask(null)
   }, [
     onWishlistInlineUpdate,
+    purchaseCondition,
     purchaseDate,
     purchasePricePaid,
+    purchaseQuantity,
     purchaseTask,
     purchaseUrl,
   ])
@@ -1091,6 +1109,27 @@ export function TasksTable({
                 value={purchaseDate}
                 data-testid='wishlist-purchase-date'
                 onChange={(event) => setPurchaseDate(event.target.value)}
+              />
+            </label>
+            <label className='space-y-2 text-sm font-medium'>
+              <span>Qty</span>
+              <Input
+                type='number'
+                min='0'
+                step='1'
+                inputMode='numeric'
+                value={purchaseQuantity}
+                data-testid='wishlist-purchase-quantity'
+                onChange={(event) => setPurchaseQuantity(event.target.value)}
+              />
+            </label>
+            <label className='space-y-2 text-sm font-medium'>
+              <span>Condition</span>
+              <Input
+                value={purchaseCondition}
+                data-testid='wishlist-purchase-condition'
+                placeholder='New, boxed, loose...'
+                onChange={(event) => setPurchaseCondition(event.target.value)}
               />
             </label>
             <label className='space-y-2 text-sm font-medium sm:col-span-2'>

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -21,6 +21,7 @@ export const taskSchema = z.object({
   pricePaid: z.number().optional(),
   purchaseUrl: z.string().optional(),
   purchaseDate: z.string().optional(),
+  purchaseCondition: z.string().optional(),
   quantity: z.number().optional(),
   neededQuantity: z.number().optional(),
 })

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -120,6 +120,7 @@ type WishlistEntryPayload = {
   price_paid?: number
   purchase_url?: string
   purchase_date?: string
+  purchase_condition?: string
   quantity?: number
   needed_quantity?: number
 }
@@ -131,6 +132,7 @@ type WishlistInlineChanges = {
   pricePaid?: number
   purchaseUrl?: string
   purchaseDate?: string
+  purchaseCondition?: string
   quantity?: number
   neededQuantity?: number
 }
@@ -383,6 +385,7 @@ export function Tasks({
               : undefined,
           purchaseUrl: wishlistEntry?.purchase_url?.trim(),
           purchaseDate: wishlistEntry?.purchase_date?.trim(),
+          purchaseCondition: wishlistEntry?.purchase_condition?.trim(),
           quantity:
             typeof wishlistEntry?.quantity === 'number'
               ? wishlistEntry.quantity
@@ -563,6 +566,8 @@ export function Tasks({
       const nextPurchaseUrl = changes.purchaseUrl ?? currentTask.purchaseUrl ?? ''
       const nextPurchaseDate =
         changes.purchaseDate ?? currentTask.purchaseDate ?? ''
+      const nextPurchaseCondition =
+        changes.purchaseCondition ?? currentTask.purchaseCondition ?? ''
       const nextQuantity = changes.quantity ?? currentTask.quantity ?? 0
       const nextNeededQuantity =
         changes.neededQuantity ?? currentTask.neededQuantity ?? 1
@@ -597,6 +602,7 @@ export function Tasks({
               pricePaid: nextPricePaid,
               purchaseUrl: nextPurchaseUrl,
               purchaseDate: nextPurchaseDate,
+              purchaseCondition: nextPurchaseCondition,
               quantity: nextQuantity,
               neededQuantity: nextNeededQuantity,
             }
@@ -614,6 +620,7 @@ export function Tasks({
                 pricePaid: nextPricePaid,
                 purchaseUrl: nextPurchaseUrl,
                 purchaseDate: nextPurchaseDate,
+                purchaseCondition: nextPurchaseCondition,
                 quantity: nextQuantity,
                 neededQuantity: nextNeededQuantity,
               }
@@ -641,6 +648,9 @@ export function Tasks({
         }
         if (changes.purchaseDate !== undefined) {
           requestBody.purchase_date = nextPurchaseDate
+        }
+        if (changes.purchaseCondition !== undefined) {
+          requestBody.purchase_condition = nextPurchaseCondition
         }
         if (changes.quantity !== undefined) {
           requestBody.quantity = nextQuantity


### PR DESCRIPTION
Closes #734.\n\nSummary:\n- Adds Qty and Condition fields to the Wishlist Add purchase details modal.\n- Persists purchase_condition through SQLite, wishlist API, OpenAPI, and UI mapping.\n- Extends Cypress coverage for purchase modal quantity and condition round-trip.\n\nValidation:\n- go test ./internal/app -run TestWishlistEndpointPersistsManualWatchStatusForActiveProfile -count=1\n- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1\n- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts -Browser electron\n- npx --yes @redocly/cli@latest lint docs/api/openapi.yaml --max-problems 1\n- git diff --check