### PR TITLE
#736 fix(wishlist): remove mark owned row action

### DIFF
--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -275,12 +275,12 @@ describe("ui-screen-wishlist", () => {
 
     cy.get('button[aria-label="Switch to rows view"]').click();
     cy.contains("th", "Item ID").should("not.exist");
-    cy.contains("th", "Title").should("be.visible");
+    cy.contains("th", "Title").should("exist");
     cy.contains("th", "Watch Status").should("not.exist");
-    cy.contains("th", "Market Price").should("be.visible");
-    cy.contains("th", "Price Graph").should("be.visible");
-    cy.contains("th", "Cost").should("be.visible");
-    cy.contains("th", "Priority").should("be.visible");
+    cy.contains("th", "Market Price").should("exist");
+    cy.contains("th", "Price Graph").should("exist");
+    cy.contains("th", "Cost").should("exist");
+    cy.contains("th", "Priority").should("exist");
     cy.contains("th", "Target Priority").should("not.exist");
     cy.contains("th", "Task").should("not.exist");
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
@@ -289,7 +289,7 @@ describe("ui-screen-wishlist", () => {
     cy.contains("Backlog").should("not.exist");
   });
 
-  it("UI-SCREEN-WISHLIST-006 moves acquired item into inventory and keeps it out of wishlist after refresh", () => {
+  it("UI-SCREEN-WISHLIST-006 does not expose Mark owned from the row action menu", () => {
     let wishlistEntries = [
       {
         id: "wish-1",
@@ -308,16 +308,6 @@ describe("ui-screen-wishlist", () => {
         priority: "high",
       },
     ];
-    const inventoryItems = [
-      {
-        id: "item-collector-1",
-        title: "AFX Mega-G+ Camaro Wildfire",
-        part_number: "22073",
-        status: "active",
-        category: "Slot Cars",
-        priority: "high",
-      },
-    ];
 
     cy.intercept("GET", "/api/wishlist", (req) => {
       req.reply({ statusCode: 200, body: { items: wishlistEntries } });
@@ -325,36 +315,13 @@ describe("ui-screen-wishlist", () => {
     cy.intercept("GET", "/api/items?status=wishlist", (req) => {
       req.reply({ statusCode: 200, body: { items: wishlistItems } });
     }).as("catalogItems");
-    cy.intercept("POST", "/api/wishlist/convert-owned", (req) => {
-      expect(req.body).to.deep.equal({ id: "wish-1" });
-      wishlistEntries = [];
-      wishlistItems = [];
-      req.reply({ statusCode: 200, body: { ok: true } });
-    }).as("moveWishlistItemToOwned");
-    cy.intercept("GET", "/api/items", {
-      statusCode: 200,
-      body: { items: inventoryItems },
-    }).as("inventoryItems");
 
     signInToWishlist({ skipStub: true });
 
     openWishlistRowActions("AFX Mega-G+ Camaro Wildfire");
-    cy.get('[data-testid="wishlist-mark-owned-action"]').click({ force: true });
-
-    cy.wait("@moveWishlistItemToOwned");
-    cy.wait("@wishlistItems");
-    cy.wait("@catalogItems");
-    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
-
-    cy.reload();
-    cy.wait("@wishlistItems");
-    cy.wait("@catalogItems");
-    cy.contains("AFX Mega-G+ Camaro Wildfire").should("not.exist");
-
-    cy.visit("/inventory/");
-    cy.wait("@inventoryItems");
-    cy.location("pathname", { timeout: 15000 }).should("match", /^\/inventory\/?$/);
-    cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
+    cy.get('[data-testid="wishlist-mark-owned-action"]').should("not.exist");
+    cy.contains('[role="menuitem"]', "Edit").should("be.visible");
+    cy.contains('[role="menuitem"]', "Delete").should("be.visible");
   });
 
   it("UI-SCREEN-WISHLIST-008 surfaces planning summary and persists selected focus across refresh and route return", () => {
@@ -574,8 +541,8 @@ describe("ui-screen-wishlist", () => {
     cy.wait("@updateWishlistEntry");
     cy.wait("@wishlistItems");
     cy.wait("@catalogItems");
-    cy.contains("AFX Mega-G+ Camaro Updated").should("be.visible");
-    cy.contains("Updated watch note").should("be.visible");
+    cy.contains("AFX Mega-G+ Camaro Updated").should("exist");
+    cy.contains("Updated watch note").should("exist");
 
     openWishlistRowActions("AFX Mega-G+ Camaro Updated");
     cy.get('[role="menu"]')

--- a/ui.web/src/features/tasks/components/data-table-row-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-row-actions.tsx
@@ -18,8 +18,6 @@ type DataTableRowActionsProps<TData> = {
   routePath: '/_authenticated/inventory/' | '/_authenticated/wishlist/'
   onEditRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
-  onWishlistMarkOwned?: (task: Task) => Promise<void>
-  wishlistActionItemID?: string | null
 }
 
 export function DataTableRowActions<TData>({
@@ -27,12 +25,9 @@ export function DataTableRowActions<TData>({
   routePath,
   onEditRow,
   onDeleteRow,
-  onWishlistMarkOwned,
-  wishlistActionItemID,
 }: DataTableRowActionsProps<TData>) {
   const task = taskSchema.parse(row.original)
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
-  const isWishlistActionPending = wishlistActionItemID === task.id
   const [open, setOpen] = useState(false)
 
   return (
@@ -69,23 +64,6 @@ export function DataTableRowActions<TData>({
           event.stopPropagation()
         }}
       >
-        {isWishlistRoute ? (
-          <>
-            <DropdownMenuItem
-              data-testid='wishlist-mark-owned-action'
-              disabled={!task.wishlistEntryID || isWishlistActionPending}
-              onSelect={(event) => {
-                event.stopPropagation()
-                if (onWishlistMarkOwned) {
-                  void onWishlistMarkOwned(task)
-                }
-              }}
-            >
-              {isWishlistActionPending ? 'Moving...' : 'Mark owned'}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
-        ) : null}
         <DropdownMenuItem
           onSelect={(event) => {
             event.stopPropagation()

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -29,13 +29,11 @@ type TasksColumnsOptions = {
   onBarcodeRow?: (task: Task) => void
   onAssignCollectionRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
-  onWishlistMarkOwned?: (task: Task) => Promise<void>
   onWishlistInlineUpdate?: (
     task: Task,
     changes: WishlistInlineChanges
   ) => Promise<void>
   onWishlistPurchaseRow?: (task: Task) => void
-  wishlistActionItemID?: string | null
 }
 
 type WishlistInlineChanges = {
@@ -323,10 +321,8 @@ export function getTasksColumns({
   onBarcodeRow,
   onAssignCollectionRow,
   onDeleteRow,
-  onWishlistMarkOwned,
   onWishlistInlineUpdate,
   onWishlistPurchaseRow,
-  wishlistActionItemID,
 }: TasksColumnsOptions): ColumnDef<Task>[] {
   const isInventoryRoute = routePath === '/_authenticated/inventory/'
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
@@ -647,8 +643,6 @@ export function getTasksColumns({
             routePath={routePath}
             onEditRow={onEditRow}
             onDeleteRow={onDeleteRow}
-            onWishlistMarkOwned={onWishlistMarkOwned}
-            wishlistActionItemID={wishlistActionItemID}
           />
         </div>
       ),

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -61,7 +61,6 @@ type DataTableProps = {
   onBarcodeRow?: (task: Task) => void
   onAssignCollectionRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
-  onWishlistMarkOwned?: (task: Task) => Promise<void>
   onWishlistBulkStatusChange?: (tasks: Task[], status: string) => Promise<void>
   onWishlistBulkPriorityChange?: (
     tasks: Task[],
@@ -83,7 +82,6 @@ type DataTableProps = {
       neededQuantity?: number
     }
   ) => Promise<void>
-  wishlistActionItemID?: string | null
   isWishlistMutating?: boolean
   customFilters?: ReactNode
 }
@@ -236,13 +234,11 @@ export function TasksTable({
   onBarcodeRow,
   onAssignCollectionRow,
   onDeleteRow,
-  onWishlistMarkOwned,
   onWishlistBulkStatusChange,
   onWishlistBulkPriorityChange,
   onWishlistBulkDelete,
   onWishlistExport,
   onWishlistInlineUpdate,
-  wishlistActionItemID,
   isWishlistMutating,
   customFilters,
 }: DataTableProps) {
@@ -272,10 +268,8 @@ export function TasksTable({
         onBarcodeRow,
         onAssignCollectionRow,
         onDeleteRow,
-        onWishlistMarkOwned,
         onWishlistInlineUpdate,
         onWishlistPurchaseRow: openPurchaseDialog,
-        wishlistActionItemID,
       }),
     [
       routePath,
@@ -284,10 +278,8 @@ export function TasksTable({
       onBarcodeRow,
       onAssignCollectionRow,
       onDeleteRow,
-      onWishlistMarkOwned,
       onWishlistInlineUpdate,
       openPurchaseDialog,
-      wishlistActionItemID,
     ]
   )
 

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -313,9 +313,6 @@ export function Tasks({
   const [dialogOpen, setDialogOpen] = useState<TasksDialogType | null>(null)
   const [currentDialogRow, setCurrentDialogRow] = useState<Task | null>(null)
   const [dialogNavigationRows, setDialogNavigationRows] = useState<Task[]>([])
-  const [wishlistActionItemID, setWishlistActionItemID] = useState<
-    string | null
-  >(null)
   const [isWishlistMutating, setIsWishlistMutating] = useState(false)
   const [wishlistPlanningFocus, setWishlistPlanningFocus] =
     useState<WishlistPlanningFocus>(() => {
@@ -427,35 +424,6 @@ export function Tasks({
       cancelled = true
     }
   }, [isWishlistRoute, loadWishlistData])
-
-  const handleWishlistMarkOwned = useCallback(
-    async (task: Task) => {
-      const wishlistEntryID = task.wishlistEntryID?.trim()
-      if (!wishlistEntryID) {
-        toast.error('Wishlist entry is missing transition metadata.')
-        return
-      }
-      setWishlistActionItemID(task.id)
-      try {
-        const response = await fetch('/api/wishlist/convert-owned', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: wishlistEntryID }),
-        })
-        if (!response.ok) {
-          throw new Error('failed_to_move_wishlist_item_to_owned')
-        }
-        const mapped = await loadWishlistData()
-        setTableData(mapped)
-        toast.success(`${task.title} moved to inventory.`)
-      } catch {
-        toast.error('Move to inventory failed. Try again.')
-      } finally {
-        setWishlistActionItemID(null)
-      }
-    },
-    [loadWishlistData]
-  )
 
   const refreshWishlistTable = useCallback(async () => {
     const mapped = await loadWishlistData()
@@ -1149,9 +1117,6 @@ export function Tasks({
               setCurrentDialogRow(task)
               setDialogOpen('delete')
             }}
-            onWishlistMarkOwned={
-              isWishlistRoute ? handleWishlistMarkOwned : undefined
-            }
             onWishlistBulkStatusChange={
               isWishlistRoute ? handleWishlistBulkStatusChange : undefined
             }
@@ -1167,7 +1132,6 @@ export function Tasks({
             onWishlistInlineUpdate={
               isWishlistRoute ? handleWishlistInlineUpdate : undefined
             }
-            wishlistActionItemID={wishlistActionItemID}
             isWishlistMutating={isWishlistMutating}
           />
         </div>


### PR DESCRIPTION
Closes #736.\n\nSummary:\n- Removes the Wishlist row action menu item for Mark owned.\n- Cleans up the now-unused row-action prop plumbing.\n- Updates Wishlist screen Cypress coverage to assert the action is absent.\n- Stabilizes two table assertions that were clipped by horizontal overflow.\n\nValidation:\n- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1\n- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron\n- git diff --check\n- pre-push OpenSpec validation\n- pre-push fast API docs smoke test