### PR TITLE
#745 split inventory details sidebar and edit modal

### DIFF
--- a/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts
@@ -123,9 +123,10 @@ describe("inventory item editor modal", () => {
 
     cy.get('[data-testid="inventory-item-row-item-alpha"] [data-testid="task-row-actions-trigger"]').click();
     cy.contains('[role="menuitem"]', "Edit").click();
-    cy.get('[data-testid="inventory-item-editor-panel"]')
+    cy.get('[data-testid="inventory-item-editor-dialog"]')
       .should("be.visible")
       .and("contain", "Edit Item");
+    cy.get('[data-testid="inventory-item-editor-panel"]').should("not.exist");
     cy.get('[data-testid="inventory-item-title"]').should("have.value", "Alpha Item");
 
     cy.get('[data-testid="inventory-item-editor-next"]').click();
@@ -140,7 +141,7 @@ describe("inventory item editor modal", () => {
 
     cy.wait("@updateBravo");
     cy.wait("@itemsList");
-    cy.get('[data-testid="inventory-item-editor-panel"]').should("not.exist");
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
     cy.contains("Bravo Item Updated").should("be.visible");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-BRAVO");
   });

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -1429,12 +1429,12 @@ export function Collection({
   }, [startCreateItem])
 
   const openInventoryItemEditor = useCallback(
-    (item: InventoryItem | null) => {
+    (item: InventoryItem | null, surface: 'dialog' | 'panel' = 'panel') => {
       if (!item) {
         return
       }
       setItemEditorMode('edit')
-      setItemEditorSurface('panel')
+      setItemEditorSurface(surface)
       setItemDraft(inventoryItemToDraft(item))
       setItemSaveError(null)
       setItemSaveSuccess(null)
@@ -2614,9 +2614,10 @@ export function Collection({
         inventoryItems.find((item) => item.id === nextID) ??
         inventoryItems.find((item) => item.part_number === nextRow.id) ??
         null
-      openInventoryItemEditor(nextItem)
+      openInventoryItemEditor(nextItem, itemEditorSurface)
     },
     [
+      itemEditorSurface,
       inventoryItems,
       openInventoryItemEditor,
       selectedVisibleInventoryIndex,
@@ -4144,9 +4145,13 @@ export function Collection({
                   setItemSaveSuccess(null)
                   selectInventoryItem(matchedItem)
                 }}
+                onOpenDetailsRow={(task) => {
+                  const matchedItem = resolveInventoryItemFromTask(task)
+                  openInventoryItemEditor(matchedItem, 'panel')
+                }}
                 onEditRow={(task) => {
                   const matchedItem = resolveInventoryItemFromTask(task)
-                  openInventoryItemEditor(matchedItem)
+                  openInventoryItemEditor(matchedItem, 'dialog')
                 }}
                 onPhotoRow={(task) => {
                   const matchedItem = resolveInventoryItemFromTask(task)
@@ -4612,6 +4617,72 @@ export function Collection({
                             }
                           />
                         </div>
+                        {itemEditorMode === 'edit' ? (
+                          <>
+                            <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+                              <div className='space-y-2'>
+                                <label
+                                  className='text-sm font-medium'
+                                  htmlFor='inventory-item-tags'
+                                >
+                                  Tags
+                                </label>
+                                <Input
+                                  id='inventory-item-tags'
+                                  data-testid='inventory-item-tags'
+                                  placeholder='sealed, rare, boxed'
+                                  value={itemDraft.tags}
+                                  onChange={(event) =>
+                                    setItemDraft((current) => ({
+                                      ...current,
+                                      tags: event.target.value,
+                                    }))
+                                  }
+                                />
+                              </div>
+                              <div className='space-y-2'>
+                                <label
+                                  className='text-sm font-medium'
+                                  htmlFor='inventory-item-source-urls'
+                                >
+                                  URLs
+                                </label>
+                                <Textarea
+                                  id='inventory-item-source-urls'
+                                  data-testid='inventory-item-source-urls'
+                                  placeholder='One source URL per line'
+                                  value={itemDraft.source_urls}
+                                  onChange={(event) =>
+                                    setItemDraft((current) => ({
+                                      ...current,
+                                      source_urls: event.target.value,
+                                    }))
+                                  }
+                                />
+                              </div>
+                            </div>
+                            <div className='space-y-2'>
+                              <label
+                                className='text-sm font-medium'
+                                htmlFor='inventory-item-notes'
+                              >
+                                Notes
+                              </label>
+                              <Textarea
+                                id='inventory-item-notes'
+                                data-testid='inventory-item-notes'
+                                placeholder='Private item notes'
+                                value={itemDraft.notes}
+                                onChange={(event) =>
+                                  setItemDraft((current) => ({
+                                    ...current,
+                                    notes: event.target.value,
+                                  }))
+                                }
+                              />
+                            </div>
+                          </>
+                        ) : null}
                         {itemSaveError ? (
                           <div
                             className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm'

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -56,6 +56,7 @@ type DataTableProps = {
   routePath: TasksRoutePath
   currentRecordID?: string
   onRecordFocus?: (itemID: string, recordID: string, title: string) => void
+  onOpenDetailsRow?: (task: Task, navigationRows?: Task[]) => void
   onEditRow?: (task: Task, navigationRows?: Task[]) => void
   onPhotoRow?: (task: Task) => void
   onBarcodeRow?: (task: Task) => void
@@ -229,6 +230,7 @@ export function TasksTable({
   routePath,
   currentRecordID,
   onRecordFocus,
+  onOpenDetailsRow,
   onEditRow,
   onPhotoRow,
   onBarcodeRow,
@@ -483,6 +485,13 @@ export function TasksTable({
     if (clickTimerRef.current !== null) {
       window.clearTimeout(clickTimerRef.current)
       clickTimerRef.current = null
+    }
+    if (record && onOpenDetailsRow) {
+      onOpenDetailsRow(
+        record,
+        table.getRowModel().rows.map((row) => row.original)
+      )
+      return
     }
     if (record && onEditRow) {
       onEditRow(


### PR DESCRIPTION
## Summary
- separates shared table double-click details handling from row action edit handling
- keeps inventory double-click opening the right-side details sidebar
- makes inventory row action Edit open the edit modal with previous/next navigation
- adds tags, URLs, and notes fields to the edit modal so it is a fuller edit form
- updates Cypress coverage for the split behavior

## Validation
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/inventory-item-editor-modal/spec.cy.ts -Browser electron
- git diff --check