### PR TITLE
#747 make page header actions icon-only

### DIFF
--- a/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/workspace-header-actions/spec.cy.ts
@@ -182,10 +182,15 @@ describe('workspace header action lanes', () => {
       .should('be.visible')
       .within(() => {
         cy.contains('Planning list').should('not.exist')
-        cy.get('[data-testid="wishlist-new-action"]').should('be.visible')
-        cy.get('[data-testid="wishlist-create-menu-trigger"]').should(
-          'be.visible'
-        )
+        cy.get('[data-testid="wishlist-new-action"]')
+          .should('be.visible')
+          .and('not.contain.text', 'New')
+        cy.get('[data-testid="wishlist-create-collection-action"]')
+          .should('be.visible')
+          .and('not.contain.text', 'Create')
+        cy.get('[data-testid="wishlist-import-action"]')
+          .should('be.visible')
+          .and('not.contain.text', 'Import')
       })
     cy.get('[data-testid="wishlist-header-action-separator"]').should('be.visible')
     cy.contains(
@@ -220,7 +225,11 @@ describe('workspace header action lanes', () => {
       .should('be.visible')
       .within(() => {
         cy.get('[data-testid="collections-page-icon"]').should('not.exist')
-        cy.get('[data-testid="collections-new-action"]').should('be.visible')
+        cy.get('[data-testid="collections-new-action"]')
+          .should('be.visible')
+          .and('have.attr', 'aria-label', 'New collection')
+          .and('have.attr', 'title', 'New collection')
+          .and('not.contain.text', 'New collection')
       })
     cy.get('[data-testid="collections-header-action-separator"]').should('be.visible')
     cy.contains(

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -431,10 +431,12 @@ export function Collections() {
           >
             <Button
               data-testid='collections-new-action'
+              size='icon'
+              aria-label='New collection'
+              title='New collection'
               onClick={() => setCreateOpen(true)}
             >
-              <Plus className='mr-2 h-4 w-4' />
-              New collection
+              <Plus className='h-4 w-4' aria-hidden='true' />
             </Button>
           </div>
           <Separator


### PR DESCRIPTION
## Summary
- makes the Collections page header action icon-only with aria-label/title preserved
- tightens header action Cypress coverage so Inventory, Wishlist, and Collections reject visible action labels

## Validation
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/inventory/workspace-header-actions/spec.cy.ts -Browser electron
- git diff --check