### PR TITLE
#753 feat(wishlist): show price sparkline

### DIFF
--- a/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
@@ -97,6 +97,11 @@ describe("wishlist-pricing-columns", () => {
       .scrollIntoView()
       .should("have.attr", "aria-label", "Price trending down")
       .and("be.visible");
+    cy.get('[data-testid="wishlist-price-sparkline-item-price-1"]')
+      .should("be.visible")
+      .find("polyline")
+      .should("have.attr", "points")
+      .and("not.be.empty");
 
     cy.get('[data-testid="wishlist-cost-input-item-price-1"]')
       .scrollIntoView()

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -65,6 +65,62 @@ function formatCostDraft(value: number | undefined) {
   return Number.isInteger(value) ? String(value) : value.toFixed(2)
 }
 
+function buildSparklinePoints(values: number[]) {
+  const width = 88
+  const height = 28
+  const padding = 3
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const step =
+    values.length > 1 ? (width - padding * 2) / (values.length - 1) : 0
+
+  return values
+    .map((value, index) => {
+      const x = padding + index * step
+      const y =
+        height - padding - ((value - min) / range) * (height - padding * 2)
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+}
+
+function WishlistPriceSparkline({
+  task,
+  label,
+}: {
+  task: Task
+  label: string
+}) {
+  const values = (task.priceHistory ?? []).filter(
+    (value) => typeof value === 'number' && Number.isFinite(value)
+  )
+
+  if (values.length < 2) {
+    return null
+  }
+
+  return (
+    <svg
+      viewBox='0 0 88 28'
+      role='img'
+      aria-label={`${label} chart`}
+      className='h-7 w-[88px] rounded bg-slate-950/60'
+      data-testid={`wishlist-price-sparkline-${task.id}`}
+      preserveAspectRatio='none'
+    >
+      <polyline
+        points={buildSparklinePoints(values)}
+        fill='none'
+        stroke='rgb(73 103 255)'
+        strokeWidth='2.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  )
+}
+
 function WishlistPriceTrendCell({ task }: { task: Task }) {
   const trend = task.priceTrend ?? 'unknown'
   const trendConfig = {
@@ -92,14 +148,15 @@ function WishlistPriceTrendCell({ task }: { task: Task }) {
   const Icon = trendConfig.icon
 
   return (
-    <span
-      className='flex min-w-[44px] items-center justify-center'
+    <div
+      className='flex min-w-[8.5rem] items-center gap-2'
       data-testid={`wishlist-price-trend-${task.id}`}
       aria-label={trendConfig.label}
       title={trendConfig.label}
     >
       <Icon className={`size-4 ${trendConfig.className}`} />
-    </span>
+      <WishlistPriceSparkline task={task} label={trendConfig.label} />
+    </div>
   )
 }
 

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -16,6 +16,7 @@ export const taskSchema = z.object({
   targetPrice: z.number().optional(),
   marketPrice: z.number().optional(),
   priceTrend: z.enum(['up', 'steady', 'down', 'unknown']).optional(),
+  priceHistory: z.array(z.number()).optional(),
   highlightHit: z.boolean().optional(),
   owned: z.boolean().optional(),
   pricePaid: z.number().optional(),

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -106,6 +106,7 @@ type WishlistPriceTrend = 'up' | 'steady' | 'down' | 'unknown'
 type WishlistPricingSummary = {
   marketPrice?: number
   priceTrend: WishlistPriceTrend
+  priceHistory: number[]
 }
 
 type WishlistEntryPayload = {
@@ -192,16 +193,20 @@ async function loadWishlistPricingSummary(
     }
 
     let priceTrend: WishlistPriceTrend = 'unknown'
+    let priceHistory: number[] = []
     if (trendResponse.ok) {
       const trendPayload = (await trendResponse.json()) as {
         points?: Array<{ latest?: number }>
       }
+      priceHistory = (trendPayload.points ?? [])
+        .map((point) => point.latest)
+        .filter((value): value is number => typeof value === 'number')
       priceTrend = inferWishlistPriceTrend(trendPayload.points)
     }
 
-    return { marketPrice, priceTrend }
+    return { marketPrice, priceTrend, priceHistory }
   } catch {
-    return { priceTrend: 'unknown' }
+    return { priceTrend: 'unknown', priceHistory: [] }
   }
 }
 
@@ -370,6 +375,7 @@ export function Tasks({
               : undefined,
           marketPrice: pricingSummary.marketPrice,
           priceTrend: pricingSummary.priceTrend,
+          priceHistory: pricingSummary.priceHistory,
           highlightHit: Boolean(wishlistEntry?.highlight_hit),
           owned: Boolean(wishlistEntry?.owned),
           pricePaid:


### PR DESCRIPTION
## Summary
- Capture wishlist pricing trend points from the pricing trend API.
- Render a compact inline SVG sparkline in the Wishlist Price Graph column.
- Keep the existing accessible trend label and icon semantics.

## Validation
- npm run build
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts -Browser electron -StartupTimeoutSec 90
- pre-push OpenSpec validation
- pre-push fast API docs smoke test

Closes #753