### PR TITLE
#755 fix(wishlist): use shared collection filter

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -21,6 +21,25 @@ describe('ui-screen-collections', () => {
     cy.wait('@loadCollectionSettings')
   }
 
+  function collectionFilterOptionKey(value: string) {
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+  }
+
+  function selectWishlistCollection(collectionName: string) {
+    cy.get('[data-testid="wishlist-table-collection-trigger"]').click()
+    cy.get(
+      `[data-testid="wishlist-table-collection-option-${collectionFilterOptionKey(collectionName)}"]`
+    ).click()
+  }
+
+  function openWishlistCollectionFilter() {
+    cy.get('[data-testid="wishlist-table-collection-trigger"]').click()
+  }
+
   it('UI-SCREEN-COLLECTIONS-001 renders shared collections management table', () => {
     signInToCollections()
 
@@ -358,19 +377,17 @@ describe('ui-screen-collections', () => {
     cy.contains('Store 2 renamed to Store 2 Routed.').should('be.visible')
 
     cy.visit('/wishlist/')
-    cy.get('[data-testid="wishlist-table-collection-select"]').select('Store 2 Routed')
+    selectWishlistCollection('Store 2 Routed')
     cy.get('[data-testid="wishlist-table-collection-selected"]').should(
       'contain.text',
       'Store 2 Routed'
     )
-    cy.get('[data-testid="wishlist-table-collection-select"] option').then(
-      ($options) => {
-        const optionLabels = [...$options].map((option) =>
-          option.textContent?.trim()
-        )
-        expect(optionLabels).to.include('Store 2 Routed')
-        expect(optionLabels).not.to.include('Store 2')
-      }
+    openWishlistCollectionFilter()
+    cy.get('[data-testid="wishlist-table-collection-option-store-2-routed"]').should(
+      'exist'
+    )
+    cy.get('[data-testid="wishlist-table-collection-option-store-2"]').should(
+      'not.exist'
     )
   })
 
@@ -431,9 +448,9 @@ describe('ui-screen-collections', () => {
       'contain.text',
       'All Items'
     )
-    cy.get('[data-testid="wishlist-table-collection-select"] option').then(($options) => {
-      const optionLabels = [...$options].map((option) => option.textContent?.trim())
-      expect(optionLabels).not.to.include('Store 1')
-    })
+    openWishlistCollectionFilter()
+    cy.get('[data-testid="wishlist-table-collection-option-store-1"]').should(
+      'not.exist'
+    )
   })
 })

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -97,6 +97,21 @@ describe("ui-screen-wishlist", () => {
     cy.get('[role="menu"]').should("be.visible");
   }
 
+  function collectionFilterOptionKey(value: string) {
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+
+  function selectWishlistCollection(collectionName: string) {
+    cy.get('[data-testid="wishlist-table-collection-trigger"]').click();
+    cy.get(
+      `[data-testid="wishlist-table-collection-option-${collectionFilterOptionKey(collectionName)}"]`
+    ).click();
+  }
+
   it("UI-SCREEN-WISHLIST-001 filters list and persists row/card view mode", () => {
     signInToWishlist();
 
@@ -232,7 +247,7 @@ describe("ui-screen-wishlist", () => {
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
     cy.contains("F1 Silverline").should("be.visible");
 
-    cy.get('[data-testid="wishlist-table-collection-select"]').select("Overflow");
+    selectWishlistCollection("Overflow");
     cy.get('[data-testid="wishlist-table-collection-selected"]').should(
       "contain",
       "Overflow"
@@ -242,7 +257,7 @@ describe("ui-screen-wishlist", () => {
     cy.contains("F1 Silverline").should("not.exist");
     cy.contains("No results.").should("be.visible");
 
-    cy.get('[data-testid="wishlist-table-collection-select"]').select("All Items");
+    selectWishlistCollection("All Items");
     cy.contains("AFX Mega-G+ Camaro Wildfire").should("be.visible");
     cy.contains("F1 Silverline").should("be.visible");
   });
@@ -292,10 +307,15 @@ describe("ui-screen-wishlist", () => {
     cy.get('[data-testid="wishlist-table-add-collection"]').should(
       "be.visible"
     );
-
-    cy.get('[data-testid="wishlist-table-collection-select"]').select(
-      "Overflow"
+    cy.get('[data-testid="wishlist-table-collection-select"]').should(
+      "not.exist"
     );
+    cy.get('[data-testid="wishlist-table-collection-trigger"]')
+      .should("be.visible")
+      .and("contain.text", "Collection")
+      .and("contain.text", "All Items");
+
+    selectWishlistCollection("Overflow");
     cy.get('[data-testid="wishlist-table-collection-selected"]').should(
       "contain",
       "Overflow"

--- a/ui.web/src/components/data-table/faceted-filter.tsx
+++ b/ui.web/src/components/data-table/faceted-filter.tsx
@@ -28,20 +28,51 @@ type DataTableFacetedFilterProps<TData, TValue> = {
     value: string
     icon?: React.ComponentType<{ className?: string }>
   }[]
+  selectedValues?: Set<string>
+  onSelectedValuesChange?: (values: string[]) => void
+  singleSelect?: boolean
+  testIdPrefix?: string
+}
+
+function filterOptionTestID(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }
 
 export function DataTableFacetedFilter<TData, TValue>({
   column,
   title,
   options,
+  selectedValues: controlledSelectedValues,
+  onSelectedValuesChange,
+  singleSelect = false,
+  testIdPrefix,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const facets = column?.getFacetedUniqueValues()
-  const selectedValues = new Set(column?.getFilterValue() as string[])
+  const selectedValues =
+    controlledSelectedValues ?? new Set(column?.getFilterValue() as string[])
+
+  const commitSelectedValues = (nextSelectedValues: Set<string>) => {
+    const filterValues = Array.from(nextSelectedValues)
+    if (onSelectedValuesChange) {
+      onSelectedValuesChange(filterValues)
+      return
+    }
+    column?.setFilterValue(filterValues.length ? filterValues : undefined)
+  }
 
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant='outline' size='sm' className='h-8 border-dashed'>
+        <Button
+          variant='outline'
+          size='sm'
+          className='h-8 border-dashed'
+          data-testid={testIdPrefix ? `${testIdPrefix}-trigger` : undefined}
+        >
           <PlusCircledIcon className='size-4' />
           {title}
           {selectedValues?.size > 0 && (
@@ -90,16 +121,22 @@ export function DataTableFacetedFilter<TData, TValue>({
                 return (
                   <CommandItem
                     key={option.value}
+                    data-testid={
+                      testIdPrefix
+                        ? `${testIdPrefix}-option-${filterOptionTestID(option.value)}`
+                        : undefined
+                    }
                     onSelect={() => {
-                      if (isSelected) {
-                        selectedValues.delete(option.value)
+                      const nextSelectedValues = new Set(selectedValues)
+                      if (singleSelect) {
+                        nextSelectedValues.clear()
+                        nextSelectedValues.add(option.value)
+                      } else if (isSelected) {
+                        nextSelectedValues.delete(option.value)
                       } else {
-                        selectedValues.add(option.value)
+                        nextSelectedValues.add(option.value)
                       }
-                      const filterValues = Array.from(selectedValues)
-                      column?.setFilterValue(
-                        filterValues.length ? filterValues : undefined
-                      )
+                      commitSelectedValues(nextSelectedValues)
                     }}
                   >
                     <div
@@ -130,7 +167,10 @@ export function DataTableFacetedFilter<TData, TValue>({
                 <CommandSeparator />
                 <CommandGroup>
                   <CommandItem
-                    onSelect={() => column?.setFilterValue(undefined)}
+                    data-testid={
+                      testIdPrefix ? `${testIdPrefix}-clear` : undefined
+                    }
+                    onSelect={() => commitSelectedValues(new Set())}
                     className='justify-center text-center'
                   >
                     Clear filters

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -5,16 +5,14 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { ConfigDrawer } from '@/components/config-drawer'
+import { DataTableFacetedFilter } from '@/components/data-table'
 import { LanguageSwitch } from '@/components/language-switch'
 import { Header, HeaderTitle } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
-import {
-  collectionKey,
-  useWorkspaceCollections,
-} from '@/features/collections/use-workspace-collections'
+import { useWorkspaceCollections } from '@/features/collections/use-workspace-collections'
 import { TasksDialogs, type TasksDialogType } from './components/tasks-dialogs'
 import { type WishlistEntryDraft } from './components/tasks-mutate-drawer'
 import { TasksTable } from './components/tasks-table'
@@ -898,24 +896,19 @@ export function Tasks({
       className='flex flex-wrap items-center gap-2'
       data-testid='wishlist-table-collection-filter'
     >
-      <select
-        className='h-8 min-w-[10rem] rounded-md border bg-background px-2 text-sm'
-        data-testid='wishlist-table-collection-select'
-        value={wishlistActiveCollection}
-        onChange={(event) => {
-          setWishlistActiveCollection(event.target.value)
+      <DataTableFacetedFilter<Task, string>
+        title='Collection'
+        options={workspaceCollections.map((collection) => ({
+          label: collection,
+          value: collection,
+        }))}
+        selectedValues={new Set([wishlistActiveCollection])}
+        onSelectedValuesChange={(values) => {
+          setWishlistActiveCollection(values[0] ?? 'All Items')
         }}
-      >
-        {workspaceCollections.map((collection) => (
-          <option
-            key={collection}
-            value={collection}
-            data-testid={`wishlist-table-collection-option-${collectionKey(collection)}`}
-          >
-            {collection}
-          </option>
-        ))}
-      </select>
+        singleSelect
+        testIdPrefix='wishlist-table-collection'
+      />
       <span
         className='text-xs text-muted-foreground'
         data-testid='wishlist-table-collection-selected'


### PR DESCRIPTION
## Summary
- replace the Wishlist native collection dropdown with the shared faceted table filter component used by Priority
- add controlled/single-select support and stable test IDs to DataTableFacetedFilter
- update Wishlist and Collections Cypress coverage to exercise the shared filter trigger/options

## Validation
- npm run build
- .\\scripts\\build-cabinet.ps1
- .\\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron -RequireE2EHooks
- .\\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser electron -RequireE2EHooks