### PR TITLE
#757 fix(wishlist): restyle owned tick

### DIFF
--- a/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
@@ -212,22 +212,23 @@ describe("wishlist-pricing-columns", () => {
     expectHeaderVisible("Qty");
     expectHeaderVisible("Needs");
 
-    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').then(
-      ($checkbox) => {
-        expect($checkbox.prop("checked")).to.eq(false);
-      }
-    );
+    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]')
+      .should("have.attr", "role", "checkbox")
+      .and("have.attr", "aria-checked", "false")
+      .and("have.attr", "data-state", "unchecked");
     cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').click({
       force: true,
     });
     cy.wait("@updateWishlistEntry")
       .its("request.body")
       .should("include", { id: "wish-price-1", owned: true });
-    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').then(
-      ($checkbox) => {
-        expect($checkbox.prop("checked")).to.eq(true);
-      }
-    );
+    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]')
+      .should("have.attr", "aria-checked", "true")
+      .and("have.attr", "data-state", "checked");
+    cy.get('[data-testid="wishlist-owned-tick-item-price-1"]')
+      .should("have.class", "opacity-100")
+      .find("polyline")
+      .should("have.attr", "stroke", "rgb(73 103 255)");
 
     cy.get('[data-testid="wishlist-purchase-open-item-price-1"]')
       .click({ force: true });
@@ -294,9 +295,9 @@ describe("wishlist-pricing-columns", () => {
     cy.reload();
     cy.wait("@wishlistItems");
     cy.wait("@catalogItems");
-    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]').should(
-      "be.checked"
-    );
+    cy.get('[data-testid="wishlist-owned-checkbox-item-price-1"]')
+      .should("have.attr", "aria-checked", "true")
+      .and("have.attr", "data-state", "checked");
     cy.get('[data-testid="wishlist-price-paid-value-item-price-1"]').should(
       "contain.text",
       "$18.25"

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -9,6 +9,7 @@ import {
   TrendingDownIcon,
   TrendingUpIcon,
 } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -265,22 +266,51 @@ function WishlistOwnedCell({
   ) => Promise<void>
   onWishlistPurchaseRow?: (task: Task) => void
 }) {
+  const owned = Boolean(task.owned)
+
   return (
     <div
       className='flex min-w-[5rem] items-center gap-1'
       onClick={(event) => event.stopPropagation()}
       onDoubleClick={(event) => event.stopPropagation()}
     >
-      <input
-        type='checkbox'
-        checked={Boolean(task.owned)}
+      <button
+        type='button'
+        role='checkbox'
+        aria-checked={owned}
+        data-state={owned ? 'checked' : 'unchecked'}
         data-testid={`wishlist-owned-checkbox-${task.id}`}
         aria-label={`Owned status for ${task.title}`}
-        className='h-4 w-4 rounded border'
-        onChange={(event) => {
-          void onWishlistInlineUpdate?.(task, { owned: event.target.checked })
+        className={cn(
+          'relative flex h-7 w-12 items-center justify-center rounded-md border transition-colors',
+          owned
+            ? 'border-slate-700 bg-slate-950 shadow-inner'
+            : 'border-border bg-background hover:bg-accent/40'
+        )}
+        onClick={() => {
+          void onWishlistInlineUpdate?.(task, { owned: !owned })
         }}
-      />
+      >
+        <svg
+          viewBox='0 0 34 18'
+          aria-hidden='true'
+          className={cn(
+            'h-4 w-9 transition-opacity',
+            owned ? 'opacity-100' : 'opacity-0'
+          )}
+          data-testid={`wishlist-owned-tick-${task.id}`}
+          preserveAspectRatio='none'
+        >
+          <polyline
+            points='1,11 7,14 13,11 19,11 25,12 33,3'
+            fill='none'
+            stroke='rgb(73 103 255)'
+            strokeWidth='3'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      </button>
       <Button
         type='button'
         variant='outline'


### PR DESCRIPTION
## Summary
- replace the Wishlist Owned native checkbox with an accessible custom checkbox button
- render the checked state as a dark chip with an electric-blue tick stroke matching the provided visual language
- update Wishlist pricing-column Cypress coverage for the custom checkbox state and stroke

## Validation
- npm run build
- .\\scripts\\build-cabinet.ps1
- .\\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts -Browser electron -RequireE2EHooks
- pre-push OpenSpec validation
- pre-push fast API docs smoke test