### PR TITLE
#759 fix(wishlist): default purchase details

### DIFF
--- a/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts
@@ -235,7 +235,7 @@ describe("wishlist-pricing-columns", () => {
     cy.get('[data-testid="wishlist-purchase-dialog"]').should("be.visible");
     cy.get('[data-testid="wishlist-purchase-price-paid"]').should(
       "have.value",
-      "22.50"
+      "25"
     );
     cy.get('[data-testid="wishlist-purchase-date"]').should(
       "have.value",
@@ -243,7 +243,7 @@ describe("wishlist-pricing-columns", () => {
     );
     cy.get('[data-testid="wishlist-purchase-quantity"]').should(
       "have.value",
-      "0"
+      "1"
     );
     cy.get('[data-testid="wishlist-purchase-condition"]').should(
       "have.value",
@@ -316,6 +316,95 @@ describe("wishlist-pricing-columns", () => {
     cy.get('[data-testid="wishlist-purchase-condition"]').should(
       "have.value",
       "Used - boxed"
+    );
+  });
+
+  it("saves default purchase values when fields are untouched", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    let wishlistEntries = [
+      {
+        id: "wish-default-1",
+        item_id: "item-default-1",
+        priority: "medium",
+        below_target_now: false,
+        target_price: 25,
+        owned: false,
+        price_paid: 0,
+        quantity: 0,
+        needed_quantity: 1,
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "item-default-1",
+            title: "Wishlist Default Purchase Candidate",
+            status: "wishlist",
+            category: "Cards",
+            priority: "medium",
+          },
+        ],
+      },
+    }).as("catalogItems");
+    cy.intercept("GET", "/api/pricing/stats?item_id=item-default-1", {
+      statusCode: 200,
+      body: { latest: 22.5 },
+    }).as("priceStats");
+    cy.intercept("GET", "/api/pricing/trend?item_id=item-default-1", {
+      statusCode: 200,
+      body: { points: [] },
+    }).as("priceTrend");
+    cy.intercept("PUT", "/api/wishlist", (req) => {
+      expect(req.body.id).to.eq("wish-default-1");
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === req.body.id ? { ...entry, ...req.body } : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("updateWishlistEntry");
+
+    openWishlist();
+
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.wait("@priceStats");
+    cy.wait("@priceTrend");
+
+    cy.get('button[aria-label="Switch to rows view"]').click();
+    cy.get('[data-testid="wishlist-purchase-open-item-default-1"]').click({
+      force: true,
+    });
+    cy.get('[data-testid="wishlist-purchase-price-paid"]').should(
+      "have.value",
+      "25"
+    );
+    cy.get('[data-testid="wishlist-purchase-quantity"]').should(
+      "have.value",
+      "1"
+    );
+    cy.get('[data-testid="wishlist-purchase-date"]').should(
+      "have.value",
+      today
+    );
+    cy.get('[data-testid="wishlist-purchase-save"]').click();
+
+    cy.wait("@updateWishlistEntry")
+      .its("request.body")
+      .should("include", {
+        id: "wish-default-1",
+        owned: true,
+        price_paid: 25,
+        purchase_date: today,
+        quantity: 1,
+      });
+    cy.get('[data-testid="wishlist-price-paid-value-item-default-1"]').should(
+      "contain.text",
+      "$25.00"
     );
   });
 });

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -221,6 +221,14 @@ function formatMoneyDraft(value: number | undefined) {
   return Number.isInteger(value) ? String(value) : value.toFixed(2)
 }
 
+function defaultPurchasePrice(task: Task) {
+  return task.pricePaid || task.targetPrice || task.marketPrice
+}
+
+function defaultPurchaseQuantity(task: Task) {
+  return task.quantity && task.quantity > 0 ? task.quantity : 1
+}
+
 function todayISODate() {
   return new Date().toISOString().slice(0, 10)
 }
@@ -254,10 +262,10 @@ export function TasksTable({
   const priceClearedOnFocusRef = useRef(false)
   const openPurchaseDialog = useCallback((task: Task) => {
     setPurchaseTask(task)
-    setPurchasePricePaid(formatMoneyDraft(task.pricePaid || task.marketPrice))
+    setPurchasePricePaid(formatMoneyDraft(defaultPurchasePrice(task)))
     setPurchaseUrl(task.purchaseUrl ?? '')
     setPurchaseDate(task.purchaseDate || todayISODate())
-    setPurchaseQuantity(String(task.quantity ?? 0))
+    setPurchaseQuantity(String(defaultPurchaseQuantity(task)))
     setPurchaseCondition(task.purchaseCondition ?? '')
     priceClearedOnFocusRef.current = false
   }, [])
@@ -703,9 +711,7 @@ export function TasksTable({
 
     const parsedPrice = Number(purchasePricePaid.trim())
     if (Number.isNaN(parsedPrice) || parsedPrice < 0) {
-      setPurchasePricePaid(
-        formatMoneyDraft(purchaseTask.pricePaid || purchaseTask.marketPrice)
-      )
+      setPurchasePricePaid(formatMoneyDraft(defaultPurchasePrice(purchaseTask)))
       return
     }
     const parsedQuantity = Number(purchaseQuantity.trim())
@@ -714,7 +720,7 @@ export function TasksTable({
       Number.isNaN(parsedQuantity) ||
       parsedQuantity < 0
     ) {
-      setPurchaseQuantity(String(purchaseTask.quantity ?? 0))
+      setPurchaseQuantity(String(defaultPurchaseQuantity(purchaseTask)))
       return
     }
 


### PR DESCRIPTION
## Summary
- Default Wishlist purchase quantity to `1` when adding purchase details.
- Default Price paid from the Wishlist cost/target price when no existing paid price is present.
- Keep the existing one-click clear behavior so focusing Price paid blanks the field for manual entry, while untouched fields still save defaults.

## Validation
- `./scripts/build-cabinet.ps1`
- `./cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-pricing-columns/spec.cy.ts -Browser electron -RequireE2EHooks`
- pre-push: OpenSpec validation
- pre-push: fast API docs smoke test
