### PR TITLE
#669 feat(console): add shared output style

### DIFF
--- a/docs/CONSOLE-OUTPUT-STANDARD.md
+++ b/docs/CONSOLE-OUTPUT-STANDARD.md
@@ -1,0 +1,52 @@
+# Cabinet Console Output Standard
+
+Cabinet command output should feel like part of the product: recognizable,
+calm, structured, and actionable. Scripts should avoid bare one-off
+`Write-Host` lines when a shared Cabinet formatter can provide consistent
+sections, status states, key/value facts, and hints.
+
+## Status states
+
+Use the shared PowerShell helper at `scripts/lib/cabinet-console.ps1` for
+high-traffic scripts:
+
+- `Write-CabinetBanner` identifies the command and purpose once at startup.
+- `Write-CabinetSection` separates phases such as build, validation, and launch.
+- `Write-CabinetStatus` reports `run`, `ok`, `warn`, `error`, or `info`.
+- `Write-CabinetKeyValue` lists important runtime facts in aligned rows.
+- `Write-CabinetHint` gives the next useful command or remediation step.
+
+## Style rules
+
+- Start with a banner for user-run commands.
+- Group related work into short sections.
+- Prefer clear verbs: `Building`, `Validating`, `Starting`, `Ready`.
+- Include paths, ports, URLs, process IDs, and output locations as key/value rows.
+- End successful flows with an `ok` status and one concrete verification hint.
+- On failure, show the failed phase and the next action before surfacing raw tool
+  output where practical.
+
+## Color and CI
+
+The helper uses PowerShell host colors when available and plain text when
+`NO_COLOR` is set. It also emits a CI-compatible mode line when `CI` is present
+so captured logs remain readable. Do not rely on color alone; every status must
+also be visible in text.
+
+## Example
+
+```text
+CABINET
+Command: start-demo2
+Purpose: Build and start the demo2 review runtime.
+
+== Build ==
+[RUN  ] Rebuilding Cabinet before launch.
+
+== Runtime ==
+  URL:         http://127.0.0.1:17882
+  Mode:        restart
+  Guard:       singleton endpoint guard enabled
+[OK   ] Started in background.
+  hint: Verify with: Invoke-WebRequest -UseBasicParsing http://127.0.0.1:17882/
+```

--- a/scripts/build-cabinet.ps1
+++ b/scripts/build-cabinet.ps1
@@ -7,23 +7,30 @@ param(
 $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
+. (Join-Path $repoRoot "scripts\lib\cabinet-console.ps1")
+
 $targetDir = Join-Path $repoRoot $OutputDir
 $targetPath = Join-Path $targetDir $BinaryName
+
+Write-CabinetBanner -Command "build-cabinet" -Summary "Build static UI assets and the Cabinet runtime binary."
 
 if (-not (Test-Path $targetDir)) {
   New-Item -ItemType Directory -Path $targetDir | Out-Null
 }
 
-Write-Host "[build-cabinet] Building ui.web static bundle first"
+Write-CabinetSection "Static UI"
+Write-CabinetStatus -State "run" -Message "Building ui.web static bundle first."
 & (Join-Path $repoRoot "scripts\build-ui-static.ps1") -InstallDeps:$InstallUIDeps
 if ($LASTEXITCODE -ne 0) {
   throw "ui.web build failed with exit code $LASTEXITCODE"
 }
 
-Write-Host "[build-cabinet] Building to $targetPath"
+Write-CabinetSection "Runtime"
+Write-CabinetKeyValue -Key "Output" -Value $targetPath
+Write-CabinetStatus -State "run" -Message "Building Cabinet executable."
 go build -o $targetPath ./cmd/cabinet
 if ($LASTEXITCODE -ne 0) {
   throw "go build failed with exit code $LASTEXITCODE"
 }
 
-Write-Host "[build-cabinet] Done"
+Write-CabinetStatus -State "ok" -Message "Cabinet build complete."

--- a/scripts/build-ui-static.ps1
+++ b/scripts/build-ui-static.ps1
@@ -5,7 +5,11 @@ param(
 $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
+. (Join-Path $repoRoot "scripts\lib\cabinet-console.ps1")
+
 $uiRoot = Join-Path $repoRoot "ui.web"
+
+Write-CabinetBanner -Command "build-ui-static" -Summary "Compile the web app into internal/ui/static."
 
 if (-not (Test-Path $uiRoot)) {
   throw "ui.web directory not found at $uiRoot"
@@ -17,14 +21,18 @@ $installRequired = $InstallDeps -or -not (Test-Path $nodeModules)
 Push-Location $uiRoot
 try {
   if ($installRequired) {
-    Write-Host "[build-ui-static] Installing ui.web dependencies (npm ci)"
+    Write-CabinetSection "Dependencies"
+    Write-CabinetStatus -State "run" -Message "Installing ui.web dependencies with npm ci."
     npm ci
     if ($LASTEXITCODE -ne 0) {
       throw "npm ci failed with exit code $LASTEXITCODE"
     }
   }
 
-  Write-Host "[build-ui-static] Building ui.web into internal/ui/static"
+  Write-CabinetSection "Build"
+  Write-CabinetKeyValue -Key "Source" -Value $uiRoot
+  Write-CabinetKeyValue -Key "Output" -Value (Join-Path $repoRoot "internal\ui\static")
+  Write-CabinetStatus -State "run" -Message "Running npm build."
   npm run build
   if ($LASTEXITCODE -ne 0) {
     throw "npm run build failed with exit code $LASTEXITCODE"
@@ -34,4 +42,4 @@ finally {
   Pop-Location
 }
 
-Write-Host "[build-ui-static] Done"
+Write-CabinetStatus -State "ok" -Message "Static UI build complete."

--- a/scripts/console-style.test.mjs
+++ b/scripts/console-style.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+
+function readRepoFile(path) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+describe("Cabinet console output standard", () => {
+  it("provides a shared PowerShell console helper", () => {
+    const helper = readRepoFile("scripts/lib/cabinet-console.ps1");
+
+    for (const functionName of [
+      "Write-CabinetBanner",
+      "Write-CabinetSection",
+      "Write-CabinetStatus",
+      "Write-CabinetKeyValue",
+      "Write-CabinetHint",
+    ]) {
+      assert.match(helper, new RegExp(`function\\s+${functionName}\\b`));
+    }
+
+    assert.match(helper, /NO_COLOR/);
+    assert.match(helper, /CI/);
+  });
+
+  it("documents the terminal output style guide", () => {
+    const docs = readRepoFile("docs/CONSOLE-OUTPUT-STANDARD.md");
+
+    assert.match(docs, /Cabinet Console Output Standard/);
+    assert.match(docs, /Status states/);
+    assert.match(docs, /NO_COLOR/);
+    assert.match(docs, /CI/);
+  });
+
+  it("uses the shared helper in high-traffic PowerShell scripts", () => {
+    for (const script of [
+      "scripts/build-cabinet.ps1",
+      "scripts/build-ui-static.ps1",
+      "scripts/validate-openapi.ps1",
+      "scripts/runtime/start-demo2.ps1",
+    ]) {
+      const contents = readRepoFile(script);
+
+      assert.match(
+        contents,
+        /\. .+cabinet-console\.ps1/,
+        `${script} should dot-source the shared helper`
+      );
+      assert.match(
+        contents,
+        /Write-Cabinet(Banner|Section|Status|KeyValue|Hint)/,
+        `${script} should use shared console output functions`
+      );
+    }
+  });
+});

--- a/scripts/lib/cabinet-console.ps1
+++ b/scripts/lib/cabinet-console.ps1
@@ -1,0 +1,84 @@
+$script:CabinetConsoleColorEnabled = -not [bool]$env:NO_COLOR
+
+function Write-CabinetHost {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message,
+    [ConsoleColor]$Color = [ConsoleColor]::Gray
+  )
+
+  if ($script:CabinetConsoleColorEnabled) {
+    Write-Host $Message -ForegroundColor $Color
+    return
+  }
+
+  Write-Host $Message
+}
+
+function Write-CabinetBanner {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Command,
+    [string]$Summary = ''
+  )
+
+  Write-Host ''
+  Write-CabinetHost 'CABINET' -Color Cyan
+  Write-CabinetHost ("Command: {0}" -f $Command) -Color White
+  if ($Summary.Trim() -ne '') {
+    Write-CabinetHost ("Purpose: {0}" -f $Summary.Trim()) -Color DarkGray
+  }
+  if ($env:CI) {
+    Write-CabinetHost 'Mode: CI log compatible' -Color DarkGray
+  }
+}
+
+function Write-CabinetSection {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Title
+  )
+
+  Write-Host ''
+  Write-CabinetHost ("== {0} ==" -f $Title) -Color Cyan
+}
+
+function Write-CabinetStatus {
+  param(
+    [ValidateSet('info', 'run', 'ok', 'warn', 'error')]
+    [string]$State = 'info',
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  $label = $State.ToUpperInvariant().PadRight(5)
+  $color = switch ($State) {
+    'ok' { [ConsoleColor]::Green }
+    'warn' { [ConsoleColor]::Yellow }
+    'error' { [ConsoleColor]::Red }
+    'run' { [ConsoleColor]::Cyan }
+    default { [ConsoleColor]::Gray }
+  }
+
+  Write-CabinetHost ("[{0}] {1}" -f $label, $Message) -Color $color
+}
+
+function Write-CabinetKeyValue {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Key,
+    [AllowEmptyString()]
+    [string]$Value = ''
+  )
+
+  Write-CabinetHost ("  {0,-12} {1}" -f ($Key + ':'), $Value) -Color Gray
+}
+
+function Write-CabinetHint {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  Write-CabinetHost ("  hint: {0}" -f $Message) -Color DarkGray
+}

--- a/scripts/runtime/start-demo2.ps1
+++ b/scripts/runtime/start-demo2.ps1
@@ -10,6 +10,8 @@ $ErrorActionPreference = 'Stop'
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent (Split-Path -Parent $scriptDir)
+. (Join-Path $repoRoot 'scripts\lib\cabinet-console.ps1')
+
 $exePath = Join-Path $repoRoot 'bin\cabinet.exe'
 $dataDir = Join-Path $repoRoot 'tmp\demo2\data'
 $profile = 'demo2-helper'
@@ -17,8 +19,11 @@ $instanceName = 'demo2-helper'
 $port = 17882
 $url = "http://127.0.0.1:$port"
 
+Write-CabinetBanner -Command "start-demo2" -Summary "Build and start the demo2 review runtime."
+
 if ($Rebuild) {
-  Write-Host '[start-demo2] Rebuilding Cabinet first...'
+  Write-CabinetSection "Build"
+  Write-CabinetStatus -State "run" -Message "Rebuilding Cabinet before launch."
   & (Join-Path $repoRoot 'scripts\build-cabinet.ps1')
 }
 
@@ -27,7 +32,9 @@ if (-not (Test-Path $exePath)) {
 }
 
 if ($FreshData -and (Test-Path $dataDir)) {
-  Write-Host "[start-demo2] Removing existing demo2 data dir: $dataDir"
+  Write-CabinetSection "Data"
+  Write-CabinetStatus -State "warn" -Message "Removing existing demo2 data directory."
+  Write-CabinetKeyValue -Key "Data dir" -Value $dataDir
   Remove-Item -Recurse -Force $dataDir
 }
 
@@ -63,19 +70,23 @@ if ($AllowParallel) {
   $args += '--allow-parallel'
 }
 
-Write-Host "[start-demo2] Executable: $exePath"
-Write-Host "[start-demo2] Data dir:   $dataDir"
-Write-Host "[start-demo2] Port:       $port"
-Write-Host "[start-demo2] URL:        $url"
-Write-Host "[start-demo2] Mode:       $mode"
-Write-Host "[start-demo2] Guard:      $parallelNote"
+Write-CabinetSection "Runtime"
+Write-CabinetKeyValue -Key "Executable" -Value $exePath
+Write-CabinetKeyValue -Key "Data dir" -Value $dataDir
+Write-CabinetKeyValue -Key "Port" -Value ([string]$port)
+Write-CabinetKeyValue -Key "URL" -Value $url
+Write-CabinetKeyValue -Key "Mode" -Value $mode
+Write-CabinetKeyValue -Key "Guard" -Value $parallelNote
 
 if ($Background) {
+  Write-CabinetStatus -State "run" -Message "Starting Cabinet in the background."
   $proc = Start-Process -FilePath $exePath -ArgumentList $args -WorkingDirectory $repoRoot -PassThru
   Start-Sleep -Seconds 2
-  Write-Host "[start-demo2] Started in background. PID: $($proc.Id)"
-  Write-Host "[start-demo2] Verify with: Invoke-WebRequest -UseBasicParsing $url/"
+  Write-CabinetStatus -State "ok" -Message "Started in background."
+  Write-CabinetKeyValue -Key "PID" -Value ([string]$proc.Id)
+  Write-CabinetHint -Message "Verify with: Invoke-WebRequest -UseBasicParsing $url/"
   exit 0
 }
 
+Write-CabinetStatus -State "run" -Message "Starting Cabinet in the foreground."
 & $exePath @args

--- a/scripts/validate-openapi.ps1
+++ b/scripts/validate-openapi.ps1
@@ -1,4 +1,11 @@
 $ErrorActionPreference = "Stop"
 
+$repoRoot = Split-Path -Parent $PSScriptRoot
+. (Join-Path $repoRoot "scripts\lib\cabinet-console.ps1")
+
+Write-CabinetBanner -Command "validate-openapi" -Summary "Lint the generated OpenAPI contract."
+Write-CabinetSection "OpenAPI"
+Write-CabinetKeyValue -Key "Spec" -Value (Join-Path $repoRoot "docs\api\openapi.yaml")
+Write-CabinetStatus -State "run" -Message "Running Redocly lint."
 npx --yes @redocly/cli@latest lint docs/api/openapi.yaml
-Write-Host "OpenAPI lint passed."
+Write-CabinetStatus -State "ok" -Message "OpenAPI lint passed."


### PR DESCRIPTION
## Summary
- Add a shared PowerShell console helper for Cabinet banners, sections, statuses, key/value rows, and hints.
- Document the Cabinet console output standard, including status states, CI behavior, and `NO_COLOR` fallback.
- Move high-traffic scripts onto the shared helper: build Cabinet, build UI static, validate OpenAPI, and start demo2.
- Add a Node test to keep the helper/docs/script adoption from regressing.

## Validation
- `node --test scripts/console-style.test.mjs`
- `./scripts/build-cabinet.ps1`
- `./scripts/validate-openapi.ps1` (passes with existing Redocly warnings)
- pre-push: OpenSpec validation
- pre-push: fast API docs smoke test
