### PR TITLE
#804 fix(release): align gate contracts with current UI

### DIFF
--- a/internal/app/openspec_docs_migration_test.go
+++ b/internal/app/openspec_docs_migration_test.go
@@ -11,6 +11,13 @@ import (
 func TestDocsFolderContainsNoMarkdownAfterMigration(t *testing.T) {
 	t.Parallel()
 
+	allowedMarkdownFiles := map[string]struct{}{
+		"../../docs/CONSOLE-OUTPUT-STANDARD.md":     {},
+		"../../docs/PRODUCT-OVERVIEW.md":            {},
+		"../../docs/PRODUCT_OVERVIEW_PLAN.md":       {},
+		"../../docs/auth/exploration-auth-setup.md": {},
+	}
+
 	var markdownFiles []string
 	err := filepath.WalkDir("../../docs", func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -21,7 +28,10 @@ func TestDocsFolderContainsNoMarkdownAfterMigration(t *testing.T) {
 		}
 		if strings.EqualFold(filepath.Ext(path), ".md") {
 			normalized := filepath.ToSlash(path)
-			if strings.HasPrefix(normalized, "../../docs/help-center/") || normalized == "../../docs/auth/exploration-auth-setup.md" {
+			if strings.HasPrefix(normalized, "../../docs/help-center/") {
+				return nil
+			}
+			if _, ok := allowedMarkdownFiles[normalized]; ok {
 				return nil
 			}
 			markdownFiles = append(markdownFiles, filepath.ToSlash(path))
@@ -50,6 +60,7 @@ func TestOpenSpecDocumentationGovernanceContract(t *testing.T) {
 		"### Requirement DOCUMENTATION-GOVERNANCE-001: OpenSpec Is The Normative Documentation Source",
 		"### Requirement DOCUMENTATION-GOVERNANCE-002: Legacy Docs Directory Contains No Markdown Sources",
 		"### Requirement DOCUMENTATION-GOVERNANCE-003: OpenAPI Contract Remains in docs/api/openapi.yaml",
+		"docs/PRODUCT-OVERVIEW.md",
 	}
 	for _, token := range required {
 		if !strings.Contains(src, token) {

--- a/internal/app/ui_template_contract_test.go
+++ b/internal/app/ui_template_contract_test.go
@@ -295,7 +295,8 @@ func TestCollectionWorkspaceSemanticContract(t *testing.T) {
 		"Folders",
 		"Active Brand",
 		"Active Category",
-		"Collection Browser",
+		"inventory-table-card",
+		"collection-summary-line",
 	})
 }
 
@@ -338,7 +339,7 @@ func TestInventoryFolderTreePersistenceAndDragContract(t *testing.T) {
 	required := []string{
 		"inventoryTreeStorageKey",
 		"inventoryWorkspaceSettingsStorageKeyPrefix",
-		"inventory.folder-tree.v1",
+		"inventory.folder-tree.v2",
 		"loadPersistedWorkspaceSnapshot",
 		"loadProfileWorkspaceSnapshot",
 		"savePersistedWorkspaceSnapshot",

--- a/openspec/specs/general/documentation-governance/spec.md
+++ b/openspec/specs/general/documentation-governance/spec.md
@@ -65,6 +65,9 @@ Cabinet SHALL maintain a strict per-file migration audit at `openspec/migrations
 - `docs/auth/CLERK_BILLING_SETUP.md` -> `openspec/specs/general/cloud-auth-billing/spec.md`
 
 ## Allowed Published Markdown Exceptions
+- `docs/CONSOLE-OUTPUT-STANDARD.md`
+- `docs/PRODUCT-OVERVIEW.md`
+- `docs/PRODUCT_OVERVIEW_PLAN.md`
 - `docs/help-center/**/*.md`
 - `docs/auth/exploration-auth-setup.md`
 


### PR DESCRIPTION
## Summary
- allow current published docs markdown exceptions in documentation governance
- update release gate UI contract for the removed Collection Browser heading
- update folder tree contract to the current v2 storage key

## Validation
- openspec validate --all --strict --no-interactive
- go test ./internal/app
- go test ./...
- .\\scripts\\build-cabinet.ps1
- CABINET_E2E_MODE=1 npm run e2e:ci-smoke
