### PR TITLE
#809 fix(inventory): truncate long row values

### DIFF
--- a/ui.web/cypress/e2e/inventory/table-overflow/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/table-overflow/spec.cy.ts
@@ -1,0 +1,56 @@
+describe("inventory table overflow", () => {
+  function signIn() {
+    cy.e2eReset();
+    cy.e2eSetSetupState("present");
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: "/inventory/",
+      });
+    });
+  }
+
+  it("UI-SCREEN-INVENTORY-ITEMS-008 truncates long row values instead of overlapping columns", () => {
+    cy.intercept("GET", "/api/items", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "item-long-row",
+            part_number:
+              "URL-BONZASLOTCARS-002-MATCHBOX-HOT-WHEELS-MOOISYRQ",
+            title:
+              "Bonza Matchbox Hot Wheels Mooi Syrq Long Showcase Title",
+            status: "active",
+            category: "Slot Cars",
+          },
+        ],
+      },
+    }).as("itemsLongRow");
+
+    signIn();
+    cy.wait("@itemsLongRow");
+
+    cy.get('[data-testid="inventory-item-row-item-long-row"]')
+      .should("exist")
+      .scrollIntoView()
+      .within(() => {
+        cy.get("td")
+          .eq(1)
+          .then(($cell) => {
+            expect($cell[0].scrollWidth, "part number cell overflow").to.be.at
+              .most($cell[0].clientWidth + 1);
+          });
+        cy.get("td")
+          .eq(2)
+          .then(($cell) => {
+            expect($cell[0].scrollWidth, "title cell overflow").to.be.at.most(
+              $cell[0].clientWidth + 1
+            );
+          });
+        cy.get("td")
+          .eq(1)
+          .find("[data-testid='inventory-row-part-number']")
+          .should("have.css", "text-overflow", "ellipsis");
+      });
+  });
+});

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -561,6 +561,7 @@ export function getTasksColumns({
           className='translate-y-[2px]'
         />
       ),
+      meta: { className: 'w-12' },
       enableSorting: false,
       enableHiding: false,
     },
@@ -575,8 +576,20 @@ export function getTasksColumns({
                 title={isInventoryRoute ? 'Part #' : 'Task'}
               />
             ),
+            meta: isInventoryRoute
+              ? {
+                  className: 'w-[14rem] max-w-[14rem]',
+                  tdClassName: 'max-w-0',
+                }
+              : undefined,
             cell: ({ row }) => (
-              <div className='w-[120px]'>{row.getValue('id')}</div>
+              <span
+                className='block max-w-full truncate'
+                data-testid='inventory-row-part-number'
+                title={String(row.getValue('id'))}
+              >
+                {row.getValue('id')}
+              </span>
             ),
             enableSorting: false,
             enableHiding: false,
@@ -601,8 +614,11 @@ export function getTasksColumns({
             {!isInventoryRoute && !isWishlistRoute && label ? (
               <Badge variant='outline'>{label.label}</Badge>
             ) : null}
-            <div className='flex space-x-2'>
-              <span className='truncate font-medium'>
+            <div className='flex min-w-0 space-x-2'>
+              <span
+                className='block min-w-0 max-w-full truncate font-medium'
+                title={String(row.getValue('title'))}
+              >
                 {row.getValue('title')}
               </span>
             </div>
@@ -640,8 +656,8 @@ export function getTasksColumns({
             cell: ({ row }) => {
               if (isInventoryRoute) {
                 return (
-                  <div className='flex min-w-[100px] items-center gap-2'>
-                    <span className='capitalize'>
+                  <div className='flex min-w-0 items-center gap-2'>
+                    <span className='block max-w-full truncate capitalize'>
                       {String(row.getValue('status'))}
                     </span>
                   </div>
@@ -797,7 +813,11 @@ export function getTasksColumns({
       meta: { className: 'ps-1', tdClassName: 'ps-3' },
       cell: ({ row }) => {
         if (isInventoryRoute) {
-          return <span>{row.original.label || 'Uncategorized'}</span>
+          return (
+            <span className='block max-w-full truncate'>
+              {row.original.label || 'Uncategorized'}
+            </span>
+          )
         }
 
         if (isWishlistRoute) {
@@ -839,6 +859,10 @@ export function getTasksColumns({
     },
     {
       id: 'actions',
+      meta: {
+        className: isInventoryRoute ? 'w-40' : undefined,
+        tdClassName: isInventoryRoute ? 'max-w-none' : undefined,
+      },
       cell: ({ row }) => (
         <div className='flex items-center justify-end gap-1'>
           {isInventoryRoute ? (

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -1026,6 +1026,7 @@ export function TasksTable({
           <Table
             className={cn(
               'min-w-[42rem]',
+              isInventoryRoute ? 'table-fixed' : '',
               routePath === '/_authenticated/wishlist/' ? 'min-w-[56rem]' : ''
             )}
           >
@@ -1093,6 +1094,9 @@ export function TasksTable({
                       <TableCell
                         key={cell.id}
                         className={cn(
+                          isInventoryRoute
+                            ? 'max-w-0 overflow-hidden text-ellipsis'
+                            : undefined,
                           cell.column.columnDef.meta?.className,
                           cell.column.columnDef.meta?.tdClassName
                         )}


### PR DESCRIPTION
## Summary
- Constrain Inventory table layout so long Part # values cannot bleed into adjacent columns.
- Add truncation/title treatment for long Inventory row values.
- Add focused Cypress regression coverage for the screenshot case.

## Verification
- `git diff --check`
- `.\cypress.ps1 -Spec cypress/e2e/inventory/table-overflow/spec.cy.ts -Browser chrome -RequireE2EHooks`
- `.\scripts\runtime\start-demo2.ps1 -Rebuild -Restart -Background`