### PR TITLE
#811 docs(openspec): plan Bonza product URL ingestion

### DIFF
--- a/openspec/changes/ingest-bonza-product-urls/.openspec.yaml
+++ b/openspec/changes/ingest-bonza-product-urls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/ingest-bonza-product-urls/design.md
+++ b/openspec/changes/ingest-bonza-product-urls/design.md
@@ -1,0 +1,96 @@
+## Context
+
+Cabinet already has an AU webshop provider family and a Bonza provider path for query-based Market Watch ingestion. The missing path is user-directed product ingestion from a pasted URL inside Inventory. The example URL, `https://bonzaslotcars.com.au/product/bonza-mug-white/`, is a WooCommerce product page and the public Store API returns the product detail needed to prefill a Cabinet item.
+
+Current Inventory paste handling can keep raw pasted text and prefill simple local drafts, but it does not yet route known provider URLs to provider-specific extractors. Bonza detection can be deterministic because the provider registry already includes `bonzaslotcars.com.au`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect known provider product URLs without AI or guessing.
+- Route Bonza product URLs through the Bonza/WooCommerce provider path.
+- Use WooCommerce Store API first and page metadata/HTML only as fallback.
+- Return a normalized Cabinet item draft suitable for the Inventory create modal.
+- Preserve source provenance for later evidence/history review.
+- Prevent accidental duplicate item creation for the same provider product.
+- Add deterministic API and Cypress coverage.
+
+**Non-Goals:**
+- Build a generic scraper for all unknown websites in this slice.
+- Automatically create items without user confirmation.
+- Add privileged WooCommerce credentials or admin API usage.
+- Download and persist remote images in the first request unless the user confirms item creation.
+- Replace existing Market Watch query-set ingestion.
+
+## Decisions
+
+### 1. URL router before provider ingestion
+Cabinet will parse and normalize pasted URLs before attempting ingestion:
+
+```text
+raw URL -> normalized host/path -> provider registry match -> provider handler
+```
+
+For Bonza:
+
+```text
+host: bonzaslotcars.com.au or www.bonzaslotcars.com.au
+path: /product/<slug>/
+provider: bonzaslotcars
+family: woocommerce
+action: ingest_product_url
+```
+
+Alternative considered: send pasted URLs to AI or broad webpage scraping first. Rejected because known provider URLs are deterministic, faster, more testable, and safer.
+
+### 2. WooCommerce Store API is source of truth
+The Bonza handler will resolve product detail through the public Store API. For a product slug, it will query the Store API using a slug-derived search term, then select the product where `slug` or normalized `permalink` matches the pasted URL.
+
+Fallback parsing may read product page metadata such as Open Graph title/image, price HTML, and stock text only when Store API fields are missing.
+
+Alternative considered: scrape the product page directly. Rejected because the Store API returns structured title, price, currency, description, categories, attributes, images, and stock fields.
+
+### 3. Normalize into item draft, not immediate item mutation
+The backend response will return a normalized draft object. The Inventory modal will prefill the form and require the user to press Create/Save before mutation.
+
+Expected normalized fields include:
+- `provider_id`
+- `provider_family`
+- `provider_product_id`
+- `source_url`
+- `title`
+- `description`
+- `categories`
+- `item_type`
+- `attributes`
+- `price`
+- `currency`
+- `stock_state`
+- `stock_count`
+- `image_urls`
+- `evidence`
+
+Alternative considered: directly create the item from paste. Rejected because Cabinet workflows should remain confirm-before-apply when external data writes into user inventory.
+
+### 4. Provenance is first-class
+The created item should keep enough source evidence to explain where fields came from. At minimum this includes original pasted URL, normalized source URL, provider id, provider product id, ingestion timestamp, extraction method, and a compact raw payload/evidence summary.
+
+### 5. Duplicate check uses provider identity and URL
+Before create, Cabinet should check whether an existing item has the same provider/source identity. A match should return an actionable duplicate warning/open-existing option instead of silently creating another item.
+
+## Risks / Trade-offs
+
+- [Bonza Store API search returns multiple products] -> Match exact slug/permalink before accepting a product.
+- [Provider markup or API changes] -> Keep API-first tests mocked and live verification documented; fallback only covers safe metadata fields.
+- [Remote image persistence is slow or unsafe] -> Stage image URLs first and only persist media during confirmed create or later media import.
+- [Duplicate detection misses older items without provenance] -> Also compare normalized source URL where provider product id is absent.
+- [Unknown URLs create user confusion] -> Return explicit unsupported-provider or unsupported-page messages.
+
+## Migration Plan
+
+1. Add spec deltas and tests for URL detection, Bonza product ingestion, and Inventory paste prefill.
+2. Add backend URL router and Bonza ingest endpoint.
+3. Wire Inventory create modal paste processing to the endpoint.
+4. Preserve source/evidence fields in item create payloads.
+5. Validate with mocked API tests, Cypress paste flow, OpenSpec validation, and live manual verification against the example Bonza URL.
+6. Roll back by disabling the new paste-ingest call path; existing manual create and Market Watch ingestion remain unaffected.

--- a/openspec/changes/ingest-bonza-product-urls/proposal.md
+++ b/openspec/changes/ingest-bonza-product-urls/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Users need pasted product URLs to become actionable Cabinet item drafts instead of inert text. Bonza Slot Cars is already in the AU webshop provider family, and its product pages expose enough WooCommerce Store API data to reliably populate Cabinet item fields from a pasted URL.
+
+## What Changes
+
+- Add deterministic pasted URL routing for known provider product URLs.
+- Route `bonzaslotcars.com.au/product/<slug>/` to the Bonza provider and WooCommerce family ingestion path.
+- Add Bonza product URL ingestion that uses WooCommerce Store API first and page metadata/HTML only as fallback.
+- Normalize Bonza product data into a Cabinet item draft with source/evidence fields.
+- Wire Inventory create paste processing to call the provider ingestion path and prefill the create-item modal.
+- Preserve provenance so the original URL, provider, product id, and source payload summary remain attached to the created item.
+- Add duplicate detection for repeated provider product URLs/product ids before item creation.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `provider-api-families`: add deterministic product URL routing and WooCommerce product detail ingestion requirements.
+- `provider-au-webshops`: add Bonza product URL ingestion and normalized product detail extraction requirements.
+- `ui-screen-inventory-items`: require the Inventory create paste flow to process supported provider URLs into item drafts with confirm-before-create behavior.
+
+## Impact
+
+- Backend provider routing and Bonza/WooCommerce ingestion APIs.
+- Inventory create modal paste workflow and create-item draft mapping.
+- Item source URL, evidence/history, image staging, pricing, stock, and category/type field mapping.
+- API tests for mocked Bonza Store API responses.
+- Cypress coverage for pasted Bonza URL processing in Inventory.
+- Live/manual verification for `https://bonzaslotcars.com.au/product/bonza-mug-white/`.

--- a/openspec/changes/ingest-bonza-product-urls/specs/provider-api-families/spec.md
+++ b/openspec/changes/ingest-bonza-product-urls/specs/provider-api-families/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Provider URL router SHALL detect known product URLs deterministically
+Cabinet SHALL parse pasted URLs, normalize host/path values, and route known provider product URLs to the matching provider family without AI inference.
+
+#### Scenario: Bonza product URL routes to WooCommerce provider
+- **GIVEN** user input contains `https://bonzaslotcars.com.au/product/bonza-mug-white/`
+- **WHEN** Cabinet detects the pasted URL
+- **THEN** runtime MUST classify the provider as `bonzaslotcars`
+- **AND** runtime MUST classify the provider family as `woocommerce`
+- **AND** runtime MUST extract product slug `bonza-mug-white`
+- **AND** runtime MUST select product URL ingestion as the next action
+
+#### Scenario: Known provider non-product URL is rejected clearly
+- **GIVEN** user input contains a Bonza URL that is not under `/product/`
+- **WHEN** Cabinet detects the pasted URL
+- **THEN** runtime MUST return a supported-provider unsupported-page response
+- **AND** response MUST NOT create or mutate an inventory item
+
+### Requirement: WooCommerce product URL ingestion SHALL use Store API first
+WooCommerce-backed product URL ingestion SHALL resolve product detail from the public Store API before attempting page metadata or HTML fallback extraction.
+
+#### Scenario: Product detail resolved through Store API
+- **GIVEN** a WooCommerce product URL with slug `bonza-mug-white`
+- **WHEN** ingestion runs
+- **THEN** runtime MUST query the Store API product surface using a slug-derived search term or equivalent provider-supported lookup
+- **AND** runtime MUST match the returned product by exact slug or normalized permalink
+- **AND** runtime MUST return a normalized product draft only when a deterministic match is found
+
+#### Scenario: Store API fields are normalized consistently
+- **GIVEN** Store API returns product title, price, currency, description, categories, attributes, images, and stock values
+- **WHEN** ingestion normalizes the product
+- **THEN** output MUST include common fields for provider id, provider family, provider product id, source URL, title, description, price, currency, category values, attribute values, stock state, stock count, image URLs, and evidence metadata
+
+#### Scenario: Page fallback is limited to missing fields
+- **GIVEN** Store API lookup succeeds but selected optional fields are missing
+- **WHEN** fallback extraction runs
+- **THEN** runtime MAY use product page metadata or HTML to fill missing title, image, price, category, description, or stock fields
+- **AND** fallback evidence MUST identify the field source

--- a/openspec/changes/ingest-bonza-product-urls/specs/provider-au-webshops/spec.md
+++ b/openspec/changes/ingest-bonza-product-urls/specs/provider-au-webshops/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Bonza product URL ingestion SHALL populate Cabinet item draft data
+Bonza provider ingestion SHALL support direct product URL ingestion for `bonzaslotcars.com.au/product/<slug>/` and return a normalized Cabinet item draft.
+
+#### Scenario: Bonza mug URL extracts structured product data
+- **GIVEN** user submits `https://bonzaslotcars.com.au/product/bonza-mug-white/`
+- **WHEN** Bonza product ingestion runs
+- **THEN** normalized output MUST include title `BONZA MUG WHITE`
+- **AND** output MUST include provider product id `19603` when returned by the Store API
+- **AND** output MUST include source URL `https://bonzaslotcars.com.au/product/bonza-mug-white/`
+- **AND** output MUST include AUD price `9.95`
+- **AND** output MUST include stock count `3` and stock state `in_stock` when the provider reports `3 in stock`
+- **AND** output MUST include the product description text
+- **AND** output MUST include categories and attributes returned by the provider
+- **AND** output MUST include at least one product image URL when provider images are available
+
+#### Scenario: Bonza categories and attributes map to item metadata
+- **GIVEN** Bonza Store API returns categories and attributes for a product
+- **WHEN** product data is normalized for Cabinet
+- **THEN** categories MUST map to Cabinet category draft values
+- **AND** Brand, Scale, and Type attributes MUST map to item metadata or evidence fields
+- **AND** Type MAY map to Cabinet Item Type when a matching configured item type exists
+
+#### Scenario: Bonza evidence records extraction source
+- **GIVEN** Bonza product ingestion succeeds
+- **WHEN** normalized output is returned
+- **THEN** evidence MUST include provider `bonzaslotcars`, family `woocommerce`, extraction method `store_api`, product id, original pasted URL, normalized source URL, and observed timestamp
+
+### Requirement: Bonza product URL ingestion SHALL protect against duplicates
+Bonza product URL ingestion SHALL check existing item source evidence before allowing a duplicate provider product to be created silently.
+
+#### Scenario: Existing Bonza product source is detected
+- **GIVEN** an inventory item already has source evidence for Bonza product id `19603` or the normalized Bonza mug source URL
+- **WHEN** the same Bonza product URL is processed again
+- **THEN** runtime MUST return duplicate candidate information
+- **AND** Inventory UI MUST offer to open the existing item or continue only with explicit user confirmation

--- a/openspec/changes/ingest-bonza-product-urls/specs/ui-screen-inventory-items/spec.md
+++ b/openspec/changes/ingest-bonza-product-urls/specs/ui-screen-inventory-items/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Inventory create paste flow SHALL process supported provider URLs
+Inventory create paste flow SHALL call provider URL ingestion for supported product URLs and prefill the create-item modal from the normalized item draft.
+
+#### Scenario: Pasted Bonza URL prefills create item modal
+- **GIVEN** user opens Inventory and activates the paste create action
+- **WHEN** user submits `https://bonzaslotcars.com.au/product/bonza-mug-white/`
+- **THEN** the create item modal MUST remain in confirm-before-create mode
+- **AND** modal fields MUST be prefilled from Bonza normalized data
+- **AND** title MUST be populated with `BONZA MUG WHITE`
+- **AND** source URL MUST include the pasted Bonza product URL
+- **AND** price, category, item metadata, stock, description, and image URL evidence MUST be available for review before create
+
+#### Scenario: Unsupported pasted URL gives actionable feedback
+- **GIVEN** user opens the Inventory create paste flow
+- **WHEN** user submits a URL that does not match a supported provider product URL
+- **THEN** UI MUST show an actionable unsupported-provider or unsupported-page message
+- **AND** UI MUST keep the pasted value available for manual item creation
+- **AND** UI MUST NOT discard user input
+
+#### Scenario: Duplicate Bonza URL blocks silent create
+- **GIVEN** provider ingestion reports an existing item for the pasted Bonza product URL
+- **WHEN** the create modal renders the result
+- **THEN** UI MUST show duplicate information
+- **AND** UI MUST provide an action to open the existing item
+- **AND** UI MUST require explicit confirmation before creating another item from the same source
+
+### Requirement: Inventory create flow SHALL preserve provider provenance for pasted URLs
+Inventory item creation from provider-ingested pasted URLs SHALL save source provenance and user-visible evidence with the created item.
+
+#### Scenario: Created item stores Bonza source evidence
+- **GIVEN** user confirms creation from a Bonza-ingested product draft
+- **WHEN** Cabinet creates the inventory item
+- **THEN** the item MUST retain original pasted URL, normalized source URL, provider id, provider family, provider product id, observed timestamp, and extraction method
+- **AND** the item detail/editor evidence area MUST be able to display the source link and provider extraction summary

--- a/openspec/changes/ingest-bonza-product-urls/tasks.md
+++ b/openspec/changes/ingest-bonza-product-urls/tasks.md
@@ -1,0 +1,38 @@
+## 1. Tests First
+
+- [ ] 1.1 Add API test for pasted Bonza product URL detection and provider/family routing.
+- [ ] 1.2 Add API test with mocked Bonza Store API response proving product draft normalization for `bonza-mug-white`.
+- [ ] 1.3 Add API test for duplicate detection by provider product id and normalized source URL.
+- [ ] 1.4 Add Cypress test for Inventory paste action processing a Bonza URL and prefilling the create-item modal.
+- [ ] 1.5 Add Cypress test for unsupported pasted URL feedback preserving user input.
+
+## 2. Backend Provider Routing
+
+- [ ] 2.1 Add URL normalization helper for host, path, slug, and canonical source URL.
+- [ ] 2.2 Add provider registry/domain matching for `bonzaslotcars.com.au` and `www.bonzaslotcars.com.au`.
+- [ ] 2.3 Add product-page route classification for `/product/<slug>/`.
+- [ ] 2.4 Add clear unsupported-provider and unsupported-page response envelopes.
+
+## 3. Bonza WooCommerce Ingestion
+
+- [ ] 3.1 Add Bonza product ingest endpoint or generic provider ingest endpoint that dispatches to Bonza.
+- [ ] 3.2 Implement Store API-first lookup using slug-derived search and exact slug/permalink matching.
+- [ ] 3.3 Normalize title, source URL, provider product id, price/currency, stock state/count, description, categories, attributes, and image URLs.
+- [ ] 3.4 Add limited product page metadata/HTML fallback for missing Store API fields.
+- [ ] 3.5 Add provenance/evidence payload with provider id, family, extraction method, observed timestamp, original URL, normalized URL, and source summary.
+
+## 4. Inventory Create Flow
+
+- [ ] 4.1 Wire Inventory create paste process to call provider URL ingestion for URLs.
+- [ ] 4.2 Prefill create-item modal fields from normalized Bonza item draft while preserving confirm-before-create behavior.
+- [ ] 4.3 Stage provider image URLs as item evidence/media candidates without silently downloading unless create is confirmed.
+- [ ] 4.4 Persist source URL and provider evidence when user confirms item creation.
+- [ ] 4.5 Show duplicate warning with open-existing action and explicit continue option.
+
+## 5. Verification and Delivery
+
+- [ ] 5.1 Run OpenSpec validation for `ingest-bonza-product-urls`.
+- [ ] 5.2 Run targeted Go/API tests for provider routing and Bonza ingestion.
+- [ ] 5.3 Run targeted Cypress Inventory paste ingestion tests.
+- [ ] 5.4 Live/manual verify the example Bonza URL against demo after rebuild.
+- [ ] 5.5 Commit with `#811`, push, PR to `develop`, merge after validation, close issue, delete branch, and restart demo.


### PR DESCRIPTION
## Summary
- Adds OpenSpec proposal/design/tasks for Bonza pasted product URL ingestion.
- Adds provider-family, AU webshop, and Inventory UI spec deltas.
- Links implementation to issue #811 and the example Bonza mug URL.

## Verification
- `openspec validate ingest-bonza-product-urls --type change --strict`
- pre-commit OpenSpec validation
- pre-push OpenSpec validation
- pre-push fast API docs smoke test