### PR TITLE
#480 Tolerate missing E2E reset tables

### DIFF
--- a/internal/app/e2e_hooks.go
+++ b/internal/app/e2e_hooks.go
@@ -294,6 +294,13 @@ func resetE2EDatabase(ctx context.Context, conn *sql.DB) error {
 	}
 
 	for _, table := range tables {
+		exists, err := resetTableExists(ctx, tx, table)
+		if err != nil {
+			return fmt.Errorf("check table %s: %w", table, err)
+		}
+		if !exists {
+			continue
+		}
 		query := "DELETE FROM " + table
 		if _, err := tx.ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("clear table %s: %w", table, err)
@@ -307,6 +314,14 @@ func resetE2EDatabase(ctx context.Context, conn *sql.DB) error {
 		return fmt.Errorf("commit reset tx: %w", err)
 	}
 	return nil
+}
+
+func resetTableExists(ctx context.Context, tx *sql.Tx, table string) (bool, error) {
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?`, table).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func bootstrapE2EFixtures(ctx context.Context, conn *sql.DB, cfg config.Config, req e2eBootstrapRequest) (e2eBootstrapResponse, error) {

--- a/internal/app/e2e_hooks_reset_test.go
+++ b/internal/app/e2e_hooks_reset_test.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/collectors-tech/cabinet/internal/config"
+	"github.com/collectors-tech/cabinet/internal/update"
+)
+
+func TestResetE2EDatabaseSkipsMissingLegacyTables(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	seedLegacyResetState(t, a)
+
+	if err := resetE2EDatabase(context.Background(), a.db); err != nil {
+		t.Fatalf("reset with missing legacy table: %v", err)
+	}
+	assertLegacyResetCleared(t, a)
+}
+
+func TestE2EResetEndpointSkipsMissingLegacyTables(t *testing.T) {
+	t.Parallel()
+
+	a := newE2ETestApp(t)
+	seedLegacyResetState(t, a)
+
+	reset := doRequest(t, a, http.MethodPost, "/api/test/reset", nil, nil)
+	if reset.Code != http.StatusOK {
+		t.Fatalf("reset status=%d body=%s", reset.Code, reset.Body.String())
+	}
+	assertLegacyResetCleared(t, a)
+}
+
+func seedLegacyResetState(t *testing.T, a *App) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := a.db.ExecContext(ctx, `INSERT INTO activity_logs(id, level, action, details) VALUES ('legacy-reset-log', 'info', 'seed', '{}')`); err != nil {
+		t.Fatalf("seed activity log: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `DROP TABLE pokemon_graded_overrides`); err != nil {
+		t.Fatalf("drop legacy-missing table: %v", err)
+	}
+}
+
+func assertLegacyResetCleared(t *testing.T, a *App) {
+	t.Helper()
+	var remaining int
+	if err := a.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM activity_logs`).Scan(&remaining); err != nil {
+		t.Fatalf("count activity logs after reset: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("expected reset to clear present tables, got %d activity logs", remaining)
+	}
+}
+
+func newE2ETestApp(t *testing.T) *App {
+	t.Helper()
+	base := t.TempDir()
+	return newTestAppWithConfig(t, config.Config{
+		Addr:           "127.0.0.1:0",
+		DataDir:        base,
+		DBPath:         filepath.Join(base, "cabinet.db"),
+		UpdateChannel:  update.ChannelStable,
+		WebAuthnRPID:   "127.0.0.1",
+		WebAuthnOrigin: "http://127.0.0.1:8080",
+		WebAuthnName:   "Cabinet Test",
+		BackupInterval: 60,
+		EnableE2EHooks: true,
+	})
+}

--- a/openspec/specs/general/runtime-core/spec.md
+++ b/openspec/specs/general/runtime-core/spec.md
@@ -175,3 +175,12 @@ If the supplied runtime context is already canceled before run-loop startup begi
 - **WHEN** run-loop startup begins
 - **THEN** runtime MUST return quickly without binding a listener or writing startup lifecycle artifacts
 - **AND** local NFR/startup checks MUST observe the fast-exit behavior rather than an unnecessary shutdown timeout path
+
+### Requirement RUNTIME-CORE-017: E2E reset hooks SHALL tolerate legacy/shared schema drift
+E2E-only reset hooks MUST clear supported runtime data without failing solely because a known reset table is absent from a legacy or shared managed test database.
+
+#### Scenario: Reset with missing known table
+- **GIVEN** an E2E-enabled managed runtime uses a database where a known reset table is absent
+- **WHEN** `/api/test/reset` or the reset hook clears E2E state
+- **THEN** reset MUST skip the absent table and continue clearing present reset tables
+- **AND** reset MUST still fail on real delete/query errors for tables that exist


### PR DESCRIPTION
## Summary
- make E2E reset skip known reset tables that are absent from legacy/shared managed DB schemas
- add direct reset + `/api/test/reset` regression coverage for the missing `pokemon_graded_overrides` case
- document the reset schema-drift contract in runtime-core OpenSpec

## Validation
- `go test ./internal/app -run "TestResetE2EDatabaseSkipsMissingLegacyTables|TestE2EResetEndpointSkipsMissingLegacyTables|TestPokemonGradedOverride" -count=1` — PASS (`ok github.com/collectors-tech/cabinet/internal/app 1.372s`)
- pre-push `openspec validate --all --strict --no-interactive` — PASS (`10 passed, 0 failed`)
- pre-push fast API docs smoke test — PASS (`ok github.com/collectors-tech/cabinet/internal/app 1.059s`)

Closes #480