### PR TITLE
#506 Label provider edit dialog fields

### DIFF
--- a/internal/app/ui_template_contract_test.go
+++ b/internal/app/ui_template_contract_test.go
@@ -565,6 +565,31 @@ func TestIntegrationsEditPersistenceContract(t *testing.T) {
 	}
 }
 
+func TestIntegrationsProviderConfigInputsHaveLabels(t *testing.T) {
+	t.Parallel()
+
+	b, err := os.ReadFile("../../ui.web/src/features/apps/index.tsx")
+	if err != nil {
+		t.Fatalf("read integrations feature: %v", err)
+	}
+	src := string(b)
+	required := []string{
+		"<Label htmlFor='provider-base-url'>Base URL</Label>",
+		"id='provider-base-url'",
+		"<Label htmlFor='provider-marketplace'>Marketplace / Region</Label>",
+		"id='provider-marketplace'",
+		"<Label htmlFor='provider-items-per-page'>Items per page</Label>",
+		"id='provider-items-per-page'",
+		"<Label htmlFor='provider-token'>New token / API key</Label>",
+		"id='provider-token'",
+	}
+	for _, token := range required {
+		if !strings.Contains(src, token) {
+			t.Fatalf("integrations provider input label contract missing token: %s", token)
+		}
+	}
+}
+
 func TestGeneralErrorChunkRecoveryContract(t *testing.T) {
 	t.Parallel()
 

--- a/openspec/specs/integrations/ui-screen-integrations/spec.md
+++ b/openspec/specs/integrations/ui-screen-integrations/spec.md
@@ -100,6 +100,16 @@ Integrations screen SHALL show API support mapping per provider (Woo/Boost/Algol
   - `Sync` action
   - `Save Integration` action
 
+### Requirement UI-SCREEN-INTEGRATIONS-010: Provider edit dialog inputs SHALL have visible and programmatic labels
+Integrations provider configuration dialogs MUST render stable visible labels associated with each editable field instead of relying on placeholder text alone.
+
+#### Scenario: Config fields remain labeled after values are populated
+- **GIVEN** provider detail/edit dialog opens for a configurable provider
+- **WHEN** base URL, marketplace/region, items-per-page, or token fields render
+- **THEN** each field MUST have a visible label
+- **AND** each label MUST be programmatically associated with its input by matching `htmlFor` and input `id`
+- **AND** placeholder text MUST NOT be the only source of field meaning
+
 ## Acceptance Criteria
 - Provider cards are sourced from runtime registry, not static seed list.
 - Provider detail panel shows instructions, health, and last-run data.
@@ -119,3 +129,4 @@ Integrations screen SHALL show API support mapping per provider (Woo/Boost/Algol
 | UC-INT-UI-09 | Toggle rows/cards view | Provider presentation switches deterministically | planned: `ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `integrations-rows-cards-toggle` |
 | UC-INT-UI-10 | Provider API family badge display | Cards show API family labels from registry mapping | `ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-009 + UC-INT-UI-10: cards show provider API family badges from registry mapping` |
 | UC-INT-UI-11 | Provider API support detail display | Detail panel shows API family + support profile metadata | `ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-009 + UC-INT-UI-11 + INTEGRATION-024: detail panel shows API family + support profile metadata from registry` |
+| UC-INT-UI-12 | Provider edit fields are labeled | Dialog config fields have visible labels associated by `htmlFor`/`id` | `internal/app/ui_template_contract_test.go` `TestIntegrationsProviderConfigInputsHaveLabels` |

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -24,6 +24,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -994,29 +995,41 @@ export function Apps({
                   'Enter provider details, validate health, and save configuration.'}
               </div>
 
-              <Input
-                placeholder='Base URL'
-                value={form.baseURL}
-                onChange={(e) =>
-                  setForm((prev) => ({ ...prev, baseURL: e.target.value }))
-                }
-              />
-              <Input
-                placeholder='Marketplace / Region'
-                value={form.marketplace}
-                onChange={(e) =>
-                  setForm((prev) => ({ ...prev, marketplace: e.target.value }))
-                }
-              />
-              <Input
-                type='number'
-                min='1'
-                placeholder='Items per page'
-                value={form.itemsPerPage}
-                onChange={(e) =>
-                  setForm((prev) => ({ ...prev, itemsPerPage: e.target.value }))
-                }
-              />
+              <div className='space-y-2'>
+                <Label htmlFor='provider-base-url'>Base URL</Label>
+                <Input
+                  id='provider-base-url'
+                  placeholder='Base URL'
+                  value={form.baseURL}
+                  onChange={(e) =>
+                    setForm((prev) => ({ ...prev, baseURL: e.target.value }))
+                  }
+                />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='provider-marketplace'>Marketplace / Region</Label>
+                <Input
+                  id='provider-marketplace'
+                  placeholder='Marketplace / Region'
+                  value={form.marketplace}
+                  onChange={(e) =>
+                    setForm((prev) => ({ ...prev, marketplace: e.target.value }))
+                  }
+                />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='provider-items-per-page'>Items per page</Label>
+                <Input
+                  id='provider-items-per-page'
+                  type='number'
+                  min='1'
+                  placeholder='Items per page'
+                  value={form.itemsPerPage}
+                  onChange={(e) =>
+                    setForm((prev) => ({ ...prev, itemsPerPage: e.target.value }))
+                  }
+                />
+              </div>
 
               {editingProvider.auth_mode !== 'none' ? (
                 <div className='space-y-2'>
@@ -1038,15 +1051,19 @@ export function Apps({
                       </Button>
                     </div>
                   ) : (
-                    <Input
-                      type='password'
-                      data-testid='provider-token-input'
-                      placeholder='New token / API key'
-                      value={form.token}
-                      onChange={(e) =>
-                        setForm((prev) => ({ ...prev, token: e.target.value }))
-                      }
-                    />
+                    <div className='space-y-2'>
+                      <Label htmlFor='provider-token'>New token / API key</Label>
+                      <Input
+                        id='provider-token'
+                        type='password'
+                        data-testid='provider-token-input'
+                        placeholder='New token / API key'
+                        value={form.token}
+                        onChange={(e) =>
+                          setForm((prev) => ({ ...prev, token: e.target.value }))
+                        }
+                      />
+                    </div>
                   )}
                 </div>
               ) : null}


### PR DESCRIPTION
## Summary
- add visible `Label` components for provider edit Base URL, Marketplace / Region, Items per page, and New token / API key fields
- associate every provider config label with its input by matching `htmlFor` / `id`
- add a focused Go template-contract regression for provider input labels
- bind the behavior in OpenSpec as `UI-SCREEN-INTEGRATIONS-010`

## Validation
- `go test ./internal/app -run "TestIntegrationsEditPersistenceContract|TestIntegrationsProviderConfigInputsHaveLabels" -count=1` — PASS (`ok github.com/collectors-tech/cabinet/internal/app 0.972s`)
- `openspec validate --all --strict --no-interactive` — PASS (`11 passed, 0 failed`)
- `npm run --prefix ui.web build` — PASS

Closes #506