### PR TITLE
#507 fix(integrations): reconcile validate health state

### DIFF
--- a/internal/app/ui_template_contract_test.go
+++ b/internal/app/ui_template_contract_test.go
@@ -590,6 +590,30 @@ func TestIntegrationsProviderConfigInputsHaveLabels(t *testing.T) {
 	}
 }
 
+func TestIntegrationsValidateHealthReconcilesVisibleStateContract(t *testing.T) {
+	t.Parallel()
+
+	b, err := os.ReadFile("../../ui.web/src/features/apps/index.tsx")
+	if err != nil {
+		t.Fatalf("read integrations feature: %v", err)
+	}
+	src := string(b)
+	required := []string{
+		"/api/provider/health?provider=",
+		"const checkedAt = payload.updated_at ?? new Date().toISOString()",
+		"health: nextProvider.health",
+		"last_run: nextProvider.last_run",
+		"{actionMessage ? <p>{actionMessage}</p> : null}",
+		"Validated ${editingProvider.display_name} health: ${healthStatus}.",
+		"Validating...",
+	}
+	for _, token := range required {
+		if !strings.Contains(src, token) {
+			t.Fatalf("integrations validate health reconciliation missing token: %s", token)
+		}
+	}
+}
+
 func TestGeneralErrorChunkRecoveryContract(t *testing.T) {
 	t.Parallel()
 

--- a/openspec/specs/integrations/ui-screen-integrations/spec.md
+++ b/openspec/specs/integrations/ui-screen-integrations/spec.md
@@ -77,6 +77,17 @@ Integrations screen SHALL derive provider cards exclusively from `GET /api/provi
 ### Requirement UI-SCREEN-INTEGRATIONS-007: Provider detail panel SHALL expose health and action controls
 Integrations screen SHALL expose provider health and actionable controls from detail panel.
 
+### Requirement UI-SCREEN-INTEGRATIONS-008: Provider validation SHALL reconcile visible health state
+Integrations screen SHALL keep validation completion feedback and visible provider health metadata consistent.
+
+#### Scenario: Successful validation updates visible provider health metadata
+- **GIVEN** a provider detail panel is open and currently shows stale or unknown health metadata
+- **WHEN** the user triggers `Validate` and the health endpoint returns successfully
+- **THEN** the UI MUST expose an in-progress validating state while the request is active
+- **AND** the completion message MUST include the resulting health status
+- **AND** the provider detail panel MUST update health, last-run, and last-checked metadata from the validation result
+- **AND** the provider card MUST use the same reconciled health state after the result is applied
+
 ### Requirement UI-SCREEN-INTEGRATIONS-009: Integrations UI SHALL display provider API family support mapping
 Integrations screen SHALL show API support mapping per provider (Woo/Boost/Algolia/custom) in cards and detail panel.
 
@@ -113,6 +124,7 @@ Integrations provider configuration dialogs MUST render stable visible labels as
 ## Acceptance Criteria
 - Provider cards are sourced from runtime registry, not static seed list.
 - Provider detail panel shows instructions, health, and last-run data.
+- Provider validation feedback and visible health metadata reconcile after successful validation.
 - Token handling is write-only with replace-token flow.
 
 ## Use-Case IDs and E2E Mapping
@@ -130,3 +142,4 @@ Integrations provider configuration dialogs MUST render stable visible labels as
 | UC-INT-UI-10 | Provider API family badge display | Cards show API family labels from registry mapping | `ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-009 + UC-INT-UI-10: cards show provider API family badges from registry mapping` |
 | UC-INT-UI-11 | Provider API support detail display | Detail panel shows API family + support profile metadata | `ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-009 + UC-INT-UI-11 + INTEGRATION-024: detail panel shows API family + support profile metadata from registry` |
 | UC-INT-UI-12 | Provider edit fields are labeled | Dialog config fields have visible labels associated by `htmlFor`/`id` | `internal/app/ui_template_contract_test.go` `TestIntegrationsProviderConfigInputsHaveLabels` |
+| UC-INT-UI-13 | Validate provider health | Validation shows progress, reconciles health/last-run/last-checked, and reports resulting status | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-003 + UI-SCREEN-INTEGRATIONS-004 + UI-SCREEN-INTEGRATIONS-008: persists settings and reconciles validation health state` |

--- a/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
@@ -146,7 +146,7 @@ describe('ui-screen-integrations', () => {
     cy.contains('Last run: success').should('be.visible')
   })
 
-  it('UI-SCREEN-INTEGRATIONS-003 + UI-SCREEN-INTEGRATIONS-004: persists settings with write-only replace-token flow', () => {
+  it('UI-SCREEN-INTEGRATIONS-003 + UI-SCREEN-INTEGRATIONS-004 + UI-SCREEN-INTEGRATIONS-008: persists settings and reconciles validation health state', () => {
     cy.intercept('GET', '/api/profiles/active', {
       statusCode: 200,
       body: { id: 'profile-e2e-001', name: 'E2E Local' },
@@ -170,8 +170,8 @@ describe('ui-screen-integrations', () => {
               pricing: true,
               health: true,
             },
-            health: { status: 'ok', last_checked_at: '2026-03-01T00:00:00Z' },
-            last_run: { status: 'success', finished_at: '2026-03-01T00:00:00Z' },
+            health: { status: 'unknown', last_checked_at: null },
+            last_run: { status: 'never', finished_at: null },
           },
         ],
       },
@@ -188,6 +188,7 @@ describe('ui-screen-integrations', () => {
     })
     cy.intercept('GET', '/api/provider/health?provider=ebay', {
       statusCode: 200,
+      delayMs: 250,
       body: {
         provider: 'ebay',
         status: 'ok',
@@ -217,9 +218,22 @@ describe('ui-screen-integrations', () => {
     cy.contains('input[placeholder="New token / API key"]').should('not.exist')
     cy.get('[data-testid="replace-token"]').click()
     cy.get('[data-testid="provider-token-input"]').type('new-secret-token')
+    cy.contains('Health: unknown').should('be.visible')
+    cy.contains('Last run: never').should('be.visible')
+    cy.contains('Last checked: n/a').should('be.visible')
     cy.contains('button', 'Validate').click()
+    cy.contains('button', 'Validating...').should('be.visible')
     cy.wait('@validate')
-    cy.contains('Validated eBay health.').should('be.visible')
+    cy.contains('Validated eBay health: ok.').should('be.visible')
+    cy.contains('Health: ok').should('be.visible')
+    cy.contains('Last run: success').should('be.visible')
+    cy.contains('Last checked: 2026-03-01T00:01:00Z').should('be.visible')
+    cy.contains('button', 'Cancel').click()
+    cy.contains('[data-testid="provider-card-ebay"]', 'Health: ok').should('be.visible')
+    cy.contains('[data-testid="provider-card-ebay"]', 'Last run: success').should('be.visible')
+    cy.get('[data-testid="provider-open-ebay"]').click()
+    cy.get('[data-testid="replace-token"]').click()
+    cy.get('[data-testid="provider-token-input"]').type('new-secret-token')
     cy.contains('button', 'Save Integration').click()
     cy.wait('@saveSettings')
     cy.contains('Provider configuration saved.').should('be.visible')

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -606,30 +606,34 @@ export function Apps({
         message?: string
         updated_at?: string
       }
+      const checkedAt = payload.updated_at ?? new Date().toISOString()
+      const healthStatus = payload.status ?? 'unknown'
+      const nextProvider: ProviderRecord = {
+        ...editingProvider,
+        health: {
+          status: healthStatus,
+          message: payload.message,
+          last_checked_at: checkedAt,
+        },
+        last_run: {
+          status: healthStatus === 'ok' ? 'success' : 'failed',
+          finished_at: checkedAt,
+        },
+      }
       setProviders((prev) =>
         prev.map((provider) =>
           provider.provider_id === editingProvider.provider_id
             ? {
                 ...provider,
-                health: {
-                  status: payload.status ?? 'unknown',
-                  message: payload.message,
-                  last_checked_at: payload.updated_at ?? null,
-                },
-                last_run: {
-                  status:
-                    payload.status === 'ok'
-                      ? 'success'
-                      : payload.status === 'unknown'
-                        ? 'never'
-                        : 'failed',
-                  finished_at: payload.updated_at ?? null,
-                },
+                health: nextProvider.health,
+                last_run: nextProvider.last_run,
               }
             : provider
         )
       )
-      setActionMessage(`Validated ${editingProvider.display_name} health.`)
+      setActionMessage(
+        `Validated ${editingProvider.display_name} health: ${healthStatus}.`
+      )
     } catch (error) {
       setSaveError(error instanceof Error ? error.message : 'validate_failed')
     } finally {
@@ -988,6 +992,7 @@ export function Apps({
                     editingProvider.last_run?.finished_at ??
                     'n/a'}
                 </p>
+                {actionMessage ? <p>{actionMessage}</p> : null}
               </div>
 
               <div className='rounded-md border p-3 text-xs text-muted-foreground'>
@@ -1070,6 +1075,9 @@ export function Apps({
 
               {saveError ? (
                 <p className='text-sm text-destructive'>{saveError}</p>
+              ) : null}
+              {actionMessage ? (
+                <p className='text-sm text-muted-foreground'>{actionMessage}</p>
               ) : null}
 
               <div className='flex flex-wrap justify-end gap-2'>


### PR DESCRIPTION
## Summary
- reconcile provider Validate success with visible health, last-run, and last-checked metadata
- show validate progress/completion feedback in the provider detail dialog
- bind the behavior to UI-SCREEN-INTEGRATIONS-008 and focused Cypress/Go contract proof

## Validation
- openspec validate --all --strict --no-interactive
- go test ./internal/app -run Integrations -count=1
- cd ui.web; npm run build
- pwsh -NoLogo -NoProfile -File .\\scripts\\build-cabinet.ps1
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts -Browser chrome -RequireE2EHooks

Closes #507