### PR TITLE
#834 feat(integrations): add OpenAI config flow

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6042,6 +6042,44 @@ func providerRegistryPayload(ctx context.Context, conn *sql.DB, scannerSvc *scan
 	}
 	base := []map[string]any{
 		{
+			"provider_id":         "openai",
+			"display_name":        "OpenAI / ChatGPT",
+			"base_domain":         "platform.openai.com",
+			"api_family":          "ai_provider",
+			"api_support_profile": "browser_auth_or_api_key",
+			"active_mode":         strings.TrimSpace(settings["openai.active_auth_method"]),
+			"integration_mode":    "assistant_workflows",
+			"api_available":       true,
+			"auth_requirement":    "browser_auth_or_api_key",
+			"auth_mode":           "hybrid",
+			"active_auth_method":  strings.TrimSpace(settings["openai.active_auth_method"]),
+			"auth_methods": map[string]any{
+				"api_key": map[string]any{
+					"state":              map[bool]string{true: "connected", false: "setup_needed"}[strings.TrimSpace(settings["openai.active_auth_method"]) == "api_key"],
+					"connected":          strings.TrimSpace(settings["openai.active_auth_method"]) == "api_key",
+					"credential_present": strings.TrimSpace(settings["openai.active_auth_method"]) == "api_key",
+				},
+				"browser_auth": map[string]any{
+					"state":              map[bool]string{true: strings.TrimSpace(settings["openai.browser_auth_state"]), false: "setup_needed"}[strings.TrimSpace(settings["openai.browser_auth_state"]) != ""],
+					"connected":          strings.TrimSpace(settings["openai.active_auth_method"]) == "browser_auth" && strings.TrimSpace(settings["openai.browser_auth_state"]) == "connected" && strings.TrimSpace(settings["openai.browser_auth_artifact_present"]) == "true",
+					"credential_present": strings.TrimSpace(settings["openai.browser_auth_artifact_present"]) == "true",
+					"setup_message":      "Browser Auth requires a verifiable callback/artifact before Cabinet marks OpenAI connected.",
+				},
+			},
+			"model_options": []string{"gpt-4o-mini", "gpt-4.1-mini", "gpt-5.3-codex"},
+			"capabilities": map[string]bool{
+				"search":             false,
+				"stock_observation":  false,
+				"pricing":            false,
+				"health":             true,
+				"assistant":          true,
+				"image_help":         true,
+				"content_generation": true,
+			},
+			"state":              map[bool]string{true: "ready", false: "needs_config"}[strings.TrimSpace(settings["openai.active_auth_method"]) != ""],
+			"setup_instructions": "Configure OpenAI with Browser Auth or an API key. Browser Auth stays setup-needed until Cabinet verifies an auth artifact/callback; navigation alone is never connected proof.",
+		},
+		{
 			"provider_id":         "ebay",
 			"display_name":        "eBay",
 			"base_domain":         "ebay.com",

--- a/internal/app/provider_openai_config_api_test.go
+++ b/internal/app/provider_openai_config_api_test.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestOpenAIRegistryExposesMethodAwareSetupNeededState(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	createProfile := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"OpenAIRegistryProfile"}`), map[string]string{"Content-Type": "application/json"})
+	if createProfile.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", createProfile.Code, createProfile.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createProfile.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	activate := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profile.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if activate.Code != http.StatusOK {
+		t.Fatalf("activate profile status=%d body=%s", activate.Code, activate.Body.String())
+	}
+
+	registry := doRequest(t, a, http.MethodGet, "/api/providers/registry", nil, nil)
+	if registry.Code != http.StatusOK {
+		t.Fatalf("registry status=%d body=%s", registry.Code, registry.Body.String())
+	}
+	var payload struct {
+		Providers []map[string]any `json:"providers"`
+	}
+	if err := json.NewDecoder(registry.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode registry payload: %v", err)
+	}
+	openai := findRegistryProvider(payload.Providers, "openai")
+	if openai == nil {
+		t.Fatalf("expected openai provider in registry payload: %+v", payload.Providers)
+	}
+	if got := fmt.Sprintf("%v", openai["auth_mode"]); got != "hybrid" {
+		t.Fatalf("expected hybrid auth mode, got %q", got)
+	}
+	if got := fmt.Sprintf("%v", openai["state"]); got != "needs_config" {
+		t.Fatalf("expected setup-needed state before proof, got %q", got)
+	}
+	methods, ok := openai["auth_methods"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected auth_methods map, got %#v", openai["auth_methods"])
+	}
+	browser, ok := methods["browser_auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected browser_auth method, got %#v", methods["browser_auth"])
+	}
+	if got := fmt.Sprintf("%v", browser["state"]); got != "setup_needed" {
+		t.Fatalf("expected browser auth setup_needed until proof, got %q", got)
+	}
+	if connected, _ := browser["connected"].(bool); connected {
+		t.Fatalf("browser auth must not be connected without a verified artifact/callback")
+	}
+}
+
+func TestOpenAIRegistryUsesPersistedActiveMethodWithoutBrowserNavigationProof(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	createProfile := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"OpenAIConfiguredProfile"}`), map[string]string{"Content-Type": "application/json"})
+	if createProfile.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", createProfile.Code, createProfile.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createProfile.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	_ = doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profile.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	settings := doRequest(t, a, http.MethodPut, "/api/profiles/"+profile.ID+"/settings", strings.NewReader(`{"settings":{"openai.active_auth_method":"browser_auth","openai.browser_auth_state":"pending","openai.browser_auth_artifact_present":"false"}}`), map[string]string{"Content-Type": "application/json"})
+	if settings.Code != http.StatusOK {
+		t.Fatalf("settings status=%d body=%s", settings.Code, settings.Body.String())
+	}
+
+	registry := doRequest(t, a, http.MethodGet, "/api/providers/registry", nil, nil)
+	if registry.Code != http.StatusOK {
+		t.Fatalf("registry status=%d body=%s", registry.Code, registry.Body.String())
+	}
+	var payload struct {
+		Providers []map[string]any `json:"providers"`
+	}
+	if err := json.NewDecoder(registry.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode registry payload: %v", err)
+	}
+	openai := findRegistryProvider(payload.Providers, "openai")
+	methods := openai["auth_methods"].(map[string]any)
+	browser := methods["browser_auth"].(map[string]any)
+	if got := fmt.Sprintf("%v", browser["state"]); got != "pending" {
+		t.Fatalf("expected browser auth pending state, got %q", got)
+	}
+	if connected, _ := browser["connected"].(bool); connected {
+		t.Fatalf("browser auth must not be connected when active method is browser_auth but proof is pending")
+	}
+}
+
+func findRegistryProvider(providers []map[string]any, id string) map[string]any {
+	for _, provider := range providers {
+		if fmt.Sprintf("%v", provider["provider_id"]) == id {
+			return provider
+		}
+	}
+	return nil
+}

--- a/openspec/specs/integrations/provider-openai-chatgpt-ux/spec.md
+++ b/openspec/specs/integrations/provider-openai-chatgpt-ux/spec.md
@@ -34,3 +34,34 @@ Cabinet MUST define how integrations-level provider defaults interact with Assis
 - **WHEN** user opens Assistant workspace
 - **THEN** assistant selection UI MUST reflect those defaults deterministically
 - **AND** thread metadata MUST record the actual provider/model used for messages and executions
+
+### Requirement PROVIDER-OPENAI-UX-005: OpenAI config SHALL use a clean card and method-aware dialog
+Cabinet MUST adapt the SCHA OpenAI setup pattern into a compact provider card plus a dialog-owned configuration flow. The provider card MUST avoid setup clutter, while the dialog MUST separately present Browser Auth, API key, and Test OpenAI sections.
+
+#### Scenario: Clean OpenAI card with dialog-owned setup
+- **GIVEN** user opens `/integrations`
+- **WHEN** the OpenAI / ChatGPT provider card renders
+- **THEN** card-level setup controls MUST be limited to status and a primary connect/manage action
+- **AND** card-level Validate/Sync/Test/configuration clutter MUST be absent
+- **WHEN** user opens the OpenAI config dialog
+- **THEN** Browser Auth, API key, and Test OpenAI sections MUST be visible inside the dialog
+- **AND** duplicate method narration such as `OpenAI is using: Browser Auth` MUST NOT render
+
+### Requirement PROVIDER-OPENAI-UX-006: Browser Auth SHALL require verifiable proof before connected readiness
+Cabinet MUST NOT mark OpenAI Browser Auth connected from navigation, a user return, or a provider tab launch alone. Connected readiness requires a verifiable callback/artifact/proof recorded by Cabinet.
+
+#### Scenario: Browser Auth setup-needed until proof exists
+- **GIVEN** OpenAI Browser Auth has no verified callback/artifact/proof
+- **WHEN** the OpenAI dialog renders
+- **THEN** Browser Auth MUST show setup-needed or unavailable state
+- **AND** OpenAI MUST NOT be considered connected through Browser Auth
+- **AND** the UI MUST explain that navigation alone is not connected proof
+
+### Requirement PROVIDER-OPENAI-UX-007: API key setup SHALL save secrets separately from profile settings
+Cabinet MUST keep OpenAI API-key entry write-only and store the key through the profile secrets API while storing non-secret OpenAI defaults in profile settings.
+
+#### Scenario: API key connect writes secret and non-secret defaults
+- **GIVEN** user enters an OpenAI API key and default model in the OpenAI dialog
+- **WHEN** user connects or saves OpenAI
+- **THEN** Cabinet MUST write `openai_api_key` through `/api/profiles/:profileId/secrets`
+- **AND** Cabinet MUST write non-secret defaults such as `assistant_default_provider`, `assistant_default_model`, and active method through `/api/profiles/:profileId/settings`

--- a/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts
@@ -21,19 +21,35 @@ describe('integrations/provider-openai-chatgpt-ux', () => {
             provider_id: 'openai',
             display_name: 'OpenAI / ChatGPT',
             base_domain: 'platform.openai.com',
-            integration_mode: 'assistant_default',
-            auth_mode: 'api_key',
+            api_family: 'ai_provider',
+            api_support_profile: 'browser_auth_or_api_key',
+            integration_mode: 'assistant_workflows',
+            auth_mode: 'hybrid',
             state: 'needs_config',
             has_token: false,
+            active_auth_method: '',
+            auth_methods: {
+              api_key: { state: 'setup_needed', connected: false, credential_present: false },
+              browser_auth: {
+                state: 'setup_needed',
+                connected: false,
+                credential_present: false,
+                setup_message: 'Browser Auth requires a verifiable callback/artifact before Cabinet marks OpenAI connected.',
+              },
+            },
+            model_options: ['gpt-4o-mini', 'gpt-4.1-mini', 'gpt-5.3-codex'],
             capabilities: {
               search: false,
               stock_observation: false,
               pricing: false,
               health: true,
               assistant: true,
+              image_help: true,
+              content_generation: true,
             },
             health: { status: 'needs_config' },
             last_run: { status: 'not_run' },
+            setup_instructions: 'Configure OpenAI with Browser Auth or an API key.',
           },
         ],
       },
@@ -43,90 +59,79 @@ describe('integrations/provider-openai-chatgpt-ux', () => {
       statusCode: 200,
       body: {
         settings: {
-          openai_api_key: '',
           assistant_default_provider: 'openai',
           assistant_default_model: 'gpt-4o-mini',
+          'openai.browser_auth_state': 'setup_needed',
         },
       },
     }).as('profileSettings')
 
     cy.intercept('PUT', '/api/profiles/*/settings', (req) => {
-      req.reply({ statusCode: 200, body: req.body })
+      req.reply({ statusCode: 200, body: { settings: req.body.settings } })
     }).as('saveSettings')
+
+    cy.intercept('PUT', '/api/profiles/*/secrets', (req) => {
+      expect(req.body).to.deep.equal({ key: 'openai_api_key', value: 'sk-test-openai' })
+      req.reply({ statusCode: 200, body: { ok: true } })
+    }).as('saveSecret')
   })
 
-  it('PROVIDER-OPENAI-UX-001/002/003 renders visible provider, auth-mode guidance, and assistant capability narrative', () => {
+  it('PROVIDER-OPENAI-UX-001/005 renders a clean card and dialog-owned OpenAI setup sections', () => {
     cy.wait('@activeProfile')
     cy.wait('@providersRegistry')
     cy.wait('@profileSettings')
 
-    cy.contains('OpenAI / ChatGPT').should('be.visible')
-    cy.contains('platform.openai.com').should('be.visible')
-    cy.contains('assistant_default').should('be.visible')
-    cy.contains('api_key').should('be.visible')
-    cy.contains('needs_config').should('be.visible')
-    cy.contains('Assistant').should('be.visible')
+    cy.get('[data-testid="provider-card-openai"]').should('be.visible')
+    cy.get('[data-testid="provider-card-openai"]').should('contain', 'OpenAI / ChatGPT')
+    cy.get('[data-testid="provider-card-openai"]').should('contain', 'Assistant')
+    cy.get('[data-testid="provider-card-openai"]').should('not.contain', 'Validate')
+    cy.get('[data-testid="provider-card-openai"]').should('not.contain', 'Test OpenAI')
+    cy.get('[data-testid="provider-card-openai"]').should('not.contain', 'OpenAI is using:')
 
-    cy.contains('OpenAI / ChatGPT').click()
-    cy.contains('OpenAI / ChatGPT').should('be.visible')
-    cy.contains('api_key').should('be.visible')
-    cy.contains('platform.openai.com').should('be.visible')
-    cy.contains('Assistant').should('be.visible')
-    cy.contains('gpt-4o-mini').should('be.visible')
+    cy.get('[data-testid="provider-open-openai"]').click()
+    cy.get('[data-testid="openai-config-dialog"]').should('be.visible')
+    cy.get('[data-testid="openai-browser-auth-section"]').should('contain', 'Browser Auth')
+    cy.get('[data-testid="openai-api-key-section"]').should('contain', 'API key')
+    cy.get('[data-testid="openai-test-section"]').should('contain', 'Test OpenAI')
+    cy.contains('OpenAI is using:').should('not.exist')
   })
 
-  it('PROVIDER-OPENAI-UX-004 persists assistant default provider/model through integrations settings', () => {
+  it('PROVIDER-OPENAI-UX-006 keeps Browser Auth setup-needed until verifiable proof exists', () => {
     cy.wait('@activeProfile')
     cy.wait('@providersRegistry')
     cy.wait('@profileSettings')
 
-    cy.contains('OpenAI / ChatGPT').click()
-    cy.get('input').filter(':visible').first().type('sk-test-openai')
-    cy.contains('gpt-4o-mini').should('be.visible')
-    cy.contains('Save Integration').click()
+    cy.get('[data-testid="provider-open-openai"]').click()
+    cy.get('[data-testid="openai-browser-auth-status"]').should('contain', 'setup_needed')
+    cy.get('[data-testid="openai-browser-auth-connect"]').should('be.disabled')
+    cy.get('[data-testid="openai-browser-auth-setup-needed"]')
+      .should('contain', 'callback/artifact')
+      .and('contain', 'Navigation alone never marks OpenAI connected')
+    cy.get('[data-testid="openai-active-method"]').should('have.value', 'None connected')
+    cy.get('[data-testid="openai-test-run"]').should('be.disabled')
+  })
+
+  it('PROVIDER-OPENAI-UX-007 stores API key as a secret and non-secret defaults as settings', () => {
+    cy.wait('@activeProfile')
+    cy.wait('@providersRegistry')
+    cy.wait('@profileSettings')
+
+    cy.get('[data-testid="provider-open-openai"]').click()
+    cy.get('[data-testid="provider-token-input"]').type('sk-test-openai')
+    cy.get('[data-testid="openai-test-model"]').click()
+    cy.contains('[role="option"]', 'gpt-4.1-mini').click()
+    cy.get('[data-testid="openai-api-key-connect"]').click()
+
     cy.wait('@saveSettings').then(({ request }) => {
-      expect(request.body.assistant_default_provider).to.eq('openai')
-      expect(request.body.assistant_default_model).to.eq('gpt-4o-mini')
+      expect(request.body.settings).to.include({
+        openai_active_auth_method: 'api_key',
+        'openai.active_auth_method': 'api_key',
+        assistant_default_provider: 'openai',
+        assistant_default_model: 'gpt-4.1-mini',
+        'integration.openai.enabled': 'true',
+      })
     })
-  })
-
-  it('PROVIDER-OPENAI-UX-004 boots Assistant workspace from saved provider/model defaults', () => {
-    cy.wait('@activeProfile')
-    cy.wait('@providersRegistry')
-    cy.wait('@profileSettings')
-
-    cy.contains('OpenAI / ChatGPT').click()
-    cy.get('[data-testid="provider-openai-default-provider"]').clear().type('openai')
-    cy.get('[data-testid="provider-openai-default-model"]').select('gpt-4.1-mini')
-    cy.contains('Save Integration').click()
-    cy.wait('@saveSettings')
-
-    cy.visit('/inventory')
-    cy.get('[data-testid="shell-chat-toggle"]').click()
-    cy.get('[data-testid="shell-assistant-thread-provider"]').should('contain', 'openai')
-    cy.get('[data-testid="shell-assistant-thread-model"]').should('contain', 'gpt-4.1-mini')
-  })
-
-  it('PROVIDER-OPENAI-UX-004 syncs Assistant defaults immediately after integrations save without reload', () => {
-    cy.wait('@activeProfile')
-    cy.wait('@providersRegistry')
-    cy.wait('@profileSettings')
-
-    cy.visit('/inventory')
-    cy.get('[data-testid="shell-chat-toggle"]').click()
-    cy.get('[data-testid="shell-assistant-thread-provider"]').should('contain', 'openai')
-    cy.get('[data-testid="shell-assistant-thread-model"]').should('contain', 'gpt-4o-mini')
-
-    cy.visit('/integrations')
-    cy.contains('OpenAI / ChatGPT').click()
-    cy.get('[data-testid="provider-openai-default-provider"]').clear().type('openai')
-    cy.get('[data-testid="provider-openai-default-model"]').select('gpt-4.1-mini')
-    cy.contains('Save Integration').click()
-    cy.wait('@saveSettings')
-
-    cy.visit('/inventory')
-    cy.get('[data-testid="shell-chat-toggle"]').click()
-    cy.get('[data-testid="shell-assistant-thread-provider"]').should('contain', 'openai')
-    cy.get('[data-testid="shell-assistant-thread-model"]').should('contain', 'gpt-4.1-mini')
+    cy.wait('@saveSecret')
+    cy.contains('OpenAI configuration saved.').should('be.visible')
   })
 })

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -69,7 +69,25 @@ type ProviderRecord = {
     stock_observation: boolean
     pricing: boolean
     health: boolean
+    assistant?: boolean
+    image_help?: boolean
+    content_generation?: boolean
   }
+  active_auth_method?: 'api_key' | 'browser_auth' | string
+  auth_methods?: {
+    api_key?: {
+      state?: string
+      connected?: boolean
+      credential_present?: boolean
+    }
+    browser_auth?: {
+      state?: string
+      connected?: boolean
+      credential_present?: boolean
+      setup_message?: string
+    }
+  }
+  model_options?: string[]
   health?: {
     status: 'ok' | 'degraded' | 'down' | 'unknown' | string
     last_checked_at?: string | null
@@ -86,6 +104,8 @@ type IntegrationForm = {
   token: string
   marketplace: string
   itemsPerPage: string
+  openAiModel: string
+  openAiTestPrompt: string
 }
 
 type ProfileOption = {
@@ -128,6 +148,14 @@ function isConnected(
   provider: ProviderRecord,
   settings: Record<string, string>
 ) {
+  if (provider.provider_id === 'openai') {
+    return (
+      settings['openai.active_auth_method'] === 'api_key' ||
+      settings['openai.active_auth_method'] === 'browser_auth' ||
+      provider.active_auth_method === 'api_key' ||
+      provider.active_auth_method === 'browser_auth'
+    )
+  }
   if (provider.auth_mode === 'none') {
     return true
   }
@@ -223,6 +251,9 @@ export function Apps({
     token: '',
     marketplace: '',
     itemsPerPage: '',
+    openAiModel: 'gpt-4o-mini',
+    openAiTestPrompt:
+      'Write one sentence confirming OpenAI is connected to Cabinet.',
   })
 
   const loadBootstrap = useCallback(async () => {
@@ -434,6 +465,9 @@ export function Apps({
       token: '',
       marketplace: settings[keys.marketplaceKey] ?? 'AU',
       itemsPerPage: settings[keys.itemsPerPageKey] ?? '24',
+      openAiModel: settings['assistant_default_model'] ?? 'gpt-4o-mini',
+      openAiTestPrompt:
+        'Write one sentence confirming OpenAI is connected to Cabinet.',
     })
     setReplaceToken(!provider.has_token)
   }
@@ -509,6 +543,9 @@ export function Apps({
       token: '',
       marketplace: '',
       itemsPerPage: '',
+      openAiModel: 'gpt-4o-mini',
+      openAiTestPrompt:
+        'Write one sentence confirming OpenAI is connected to Cabinet.',
     })
   }
 
@@ -522,6 +559,76 @@ export function Apps({
     try {
       const keys = providerSettingsKeys(editingProvider.provider_id)
       const trimmedToken = form.token.trim()
+      if (editingProvider.provider_id === 'openai') {
+        const openAiSettings: Record<string, string> = {
+          openai_base_url: form.baseURL.trim(),
+          openai_active_auth_method:
+            trimmedToken !== ''
+              ? 'api_key'
+              : (settings['openai_active_auth_method'] ??
+                settings['openai.active_auth_method'] ??
+                ''),
+          'openai.active_auth_method':
+            trimmedToken !== ''
+              ? 'api_key'
+              : (settings['openai.active_auth_method'] ?? ''),
+          assistant_default_provider: 'openai',
+          assistant_default_model: form.openAiModel.trim() || 'gpt-4o-mini',
+          'integration.openai.enabled':
+            trimmedToken !== '' ||
+            settings['openai.active_auth_method'] === 'browser_auth'
+              ? 'true'
+              : 'false',
+        }
+        const settingsResponse = await fetch(
+          `/api/profiles/${activeProfileId}/settings`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ settings: openAiSettings }),
+          }
+        )
+        if (!settingsResponse.ok) {
+          throw new Error(`save_failed_${settingsResponse.status}`)
+        }
+        if (trimmedToken !== '') {
+          const secretResponse = await fetch(
+            `/api/profiles/${activeProfileId}/secrets`,
+            {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                key: 'openai_api_key',
+                value: trimmedToken,
+              }),
+            }
+          )
+          if (!secretResponse.ok) {
+            throw new Error(`secret_save_failed_${secretResponse.status}`)
+          }
+        }
+        const payload = (await settingsResponse.json()) as {
+          settings?: Record<string, string>
+        }
+        setSettings(payload.settings ?? {})
+        setProviders((prev) =>
+          prev.map((provider) =>
+            provider.provider_id === 'openai'
+              ? {
+                  ...provider,
+                  has_token: provider.has_token || trimmedToken !== '',
+                  active_auth_method:
+                    trimmedToken !== ''
+                      ? 'api_key'
+                      : provider.active_auth_method,
+                }
+              : provider
+          )
+        )
+        setActionMessage('OpenAI configuration saved.')
+        closeIntegration()
+        return
+      }
       if (
         editingProvider.auth_mode !== 'none' &&
         !editingProvider.has_token &&
@@ -944,6 +1051,16 @@ export function Apps({
                       Pricing
                     </span>
                   ) : null}
+                  {provider.capabilities.assistant ? (
+                    <span className='rounded bg-muted px-2 py-0.5'>
+                      Assistant
+                    </span>
+                  ) : null}
+                  {provider.capabilities.image_help ? (
+                    <span className='rounded bg-muted px-2 py-0.5'>
+                      Image help
+                    </span>
+                  ) : null}
                 </div>
               </li>
             ))}
@@ -994,85 +1111,325 @@ export function Apps({
                   'Enter provider details, validate health, and save configuration.'}
               </div>
 
-              <Input
-                placeholder='Base URL'
-                value={form.baseURL}
-                onChange={(e) =>
-                  setForm((prev) => ({ ...prev, baseURL: e.target.value }))
-                }
-              />
-              <Input
-                placeholder='Marketplace / Region'
-                value={form.marketplace}
-                onChange={(e) =>
-                  setForm((prev) => ({ ...prev, marketplace: e.target.value }))
-                }
-              />
-              <Input
-                type='number'
-                min='1'
-                placeholder='Items per page'
-                value={form.itemsPerPage}
-                onChange={(e) =>
-                  setForm((prev) => ({ ...prev, itemsPerPage: e.target.value }))
-                }
-              />
-
-              {editingProvider.auth_mode !== 'none' ? (
-                <div className='space-y-2'>
-                  {editingProvider.has_token && !replaceToken ? (
-                    <div className='rounded-md border bg-muted/20 p-3 text-xs'>
-                      <p>Token on file.</p>
-                      <p className='text-muted-foreground'>
-                        Existing token is hidden. Use replace-token to update
-                        it.
-                      </p>
+              {editingProvider.provider_id === 'openai' ? (
+                <div className='space-y-4' data-testid='openai-config-dialog'>
+                  <section
+                    className='rounded-md border p-3'
+                    data-testid='openai-browser-auth-section'
+                  >
+                    <div className='flex items-center justify-between gap-3'>
+                      <div>
+                        <p className='font-medium'>Browser Auth</p>
+                        <p className='text-xs text-muted-foreground'>
+                          Use a verified OpenAI/Codex browser-auth artifact when
+                          available.
+                        </p>
+                      </div>
+                      <span
+                        className='rounded bg-muted px-2 py-1 text-xs'
+                        data-testid='openai-browser-auth-status'
+                      >
+                        {settings['openai.browser_auth_state'] ??
+                          editingProvider.auth_methods?.browser_auth?.state ??
+                          'setup_needed'}
+                      </span>
+                    </div>
+                    <p
+                      className='mt-2 text-xs text-muted-foreground'
+                      data-testid='openai-browser-auth-setup-needed'
+                    >
+                      Browser Auth is setup-needed until Cabinet can verify an
+                      acquired callback/artifact. Navigation alone never marks
+                      OpenAI connected.
+                    </p>
+                    <div className='mt-3 flex flex-wrap gap-2'>
                       <Button
+                        type='button'
+                        size='sm'
+                        disabled
+                        data-testid='openai-browser-auth-connect'
+                      >
+                        Only available on this PC
+                      </Button>
+                      <Button
+                        type='button'
                         size='sm'
                         variant='outline'
-                        className='mt-2'
-                        data-testid='replace-token'
-                        onClick={() => setReplaceToken(true)}
+                        data-testid='openai-browser-auth-disconnect'
+                        onClick={() => {
+                          setSettings((prev) => ({
+                            ...prev,
+                            'openai.browser_auth_state': 'disconnected',
+                            'openai.active_auth_method':
+                              prev['openai.active_auth_method'] ===
+                              'browser_auth'
+                                ? ''
+                                : prev['openai.active_auth_method'],
+                          }))
+                        }}
                       >
-                        Replace Token
+                        Disconnect
                       </Button>
                     </div>
-                  ) : (
+                  </section>
+
+                  <section
+                    className='rounded-md border p-3'
+                    data-testid='openai-api-key-section'
+                  >
+                    <div className='flex items-center justify-between gap-3'>
+                      <div>
+                        <p className='font-medium'>API key</p>
+                        <p className='text-xs text-muted-foreground'>
+                          Validate and save an OpenAI API key for Cabinet
+                          assistant, image, and content workflows.
+                        </p>
+                      </div>
+                      <span
+                        className='rounded bg-muted px-2 py-1 text-xs'
+                        data-testid='openai-api-key-status'
+                      >
+                        {editingProvider.has_token ||
+                        settings['openai.active_auth_method'] === 'api_key'
+                          ? 'connected'
+                          : 'setup_needed'}
+                      </span>
+                    </div>
+                    {editingProvider.has_token && !replaceToken ? (
+                      <div className='mt-3 rounded-md border bg-muted/20 p-3 text-xs'>
+                        <p>API key on file.</p>
+                        <p className='text-muted-foreground'>
+                          Existing key is hidden. Replace it to update the
+                          active API-key method.
+                        </p>
+                        <Button
+                          size='sm'
+                          variant='outline'
+                          className='mt-2'
+                          data-testid='replace-token'
+                          onClick={() => setReplaceToken(true)}
+                        >
+                          Replace API key
+                        </Button>
+                      </div>
+                    ) : (
+                      <Input
+                        className='mt-3'
+                        type='password'
+                        data-testid='provider-token-input'
+                        placeholder='OpenAI API key'
+                        value={form.token}
+                        onChange={(e) =>
+                          setForm((prev) => ({
+                            ...prev,
+                            token: e.target.value,
+                          }))
+                        }
+                      />
+                    )}
+                    <div className='mt-3 flex flex-wrap gap-2'>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='outline'
+                        onClick={() => void validateProvider()}
+                        disabled={validating}
+                        data-testid='openai-api-key-validate'
+                      >
+                        {validating ? 'Validating...' : 'Validate'}
+                      </Button>
+                      <Button
+                        type='button'
+                        size='sm'
+                        data-testid='openai-api-key-connect'
+                        onClick={() => void saveIntegration()}
+                        disabled={saving}
+                      >
+                        Connect
+                      </Button>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='outline'
+                        data-testid='openai-api-key-disconnect'
+                        onClick={() => setReplaceToken(true)}
+                      >
+                        Disconnect
+                      </Button>
+                    </div>
+                  </section>
+
+                  <section
+                    className='rounded-md border p-3'
+                    data-testid='openai-test-section'
+                  >
+                    <p className='font-medium'>Test OpenAI</p>
+                    <p className='text-xs text-muted-foreground'>
+                      Uses the active connected method. If no method is
+                      verified, Cabinet shows setup-needed instead of pretending
+                      readiness.
+                    </p>
+                    <div className='mt-3 grid gap-2 sm:grid-cols-2'>
+                      <Select
+                        value={form.openAiModel}
+                        onValueChange={(value) =>
+                          setForm((prev) => ({ ...prev, openAiModel: value }))
+                        }
+                      >
+                        <SelectTrigger data-testid='openai-test-model'>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(
+                            editingProvider.model_options ?? [
+                              'gpt-4o-mini',
+                              'gpt-4.1-mini',
+                            ]
+                          ).map((model) => (
+                            <SelectItem key={model} value={model}>
+                              {model}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        data-testid='openai-active-method'
+                        readOnly
+                        value={
+                          settings['openai.active_auth_method'] ===
+                          'browser_auth'
+                            ? 'Browser Auth'
+                            : settings['openai.active_auth_method'] ===
+                                  'api_key' || editingProvider.has_token
+                              ? 'API key'
+                              : 'None connected'
+                        }
+                      />
+                    </div>
                     <Input
-                      type='password'
-                      data-testid='provider-token-input'
-                      placeholder='New token / API key'
-                      value={form.token}
+                      className='mt-2'
+                      data-testid='openai-test-prompt'
+                      value={form.openAiTestPrompt}
                       onChange={(e) =>
-                        setForm((prev) => ({ ...prev, token: e.target.value }))
+                        setForm((prev) => ({
+                          ...prev,
+                          openAiTestPrompt: e.target.value,
+                        }))
                       }
                     />
-                  )}
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='outline'
+                      className='mt-3'
+                      data-testid='openai-test-run'
+                      disabled={!isConnected(editingProvider, settings)}
+                      onClick={() =>
+                        setActionMessage(
+                          'OpenAI test requires a verified active method before Cabinet runs provider calls.'
+                        )
+                      }
+                    >
+                      Test
+                    </Button>
+                  </section>
                 </div>
-              ) : null}
+              ) : (
+                <>
+                  <Input
+                    placeholder='Base URL'
+                    value={form.baseURL}
+                    onChange={(e) =>
+                      setForm((prev) => ({ ...prev, baseURL: e.target.value }))
+                    }
+                  />
+                  <Input
+                    placeholder='Marketplace / Region'
+                    value={form.marketplace}
+                    onChange={(e) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        marketplace: e.target.value,
+                      }))
+                    }
+                  />
+                  <Input
+                    type='number'
+                    min='1'
+                    placeholder='Items per page'
+                    value={form.itemsPerPage}
+                    onChange={(e) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        itemsPerPage: e.target.value,
+                      }))
+                    }
+                  />
+
+                  {editingProvider.auth_mode !== 'none' ? (
+                    <div className='space-y-2'>
+                      {editingProvider.has_token && !replaceToken ? (
+                        <div className='rounded-md border bg-muted/20 p-3 text-xs'>
+                          <p>Token on file.</p>
+                          <p className='text-muted-foreground'>
+                            Existing token is hidden. Use replace-token to
+                            update it.
+                          </p>
+                          <Button
+                            size='sm'
+                            variant='outline'
+                            className='mt-2'
+                            data-testid='replace-token'
+                            onClick={() => setReplaceToken(true)}
+                          >
+                            Replace Token
+                          </Button>
+                        </div>
+                      ) : (
+                        <Input
+                          type='password'
+                          data-testid='provider-token-input'
+                          placeholder='New token / API key'
+                          value={form.token}
+                          onChange={(e) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              token: e.target.value,
+                            }))
+                          }
+                        />
+                      )}
+                    </div>
+                  ) : null}
+                </>
+              )}
 
               {saveError ? (
                 <p className='text-sm text-destructive'>{saveError}</p>
               ) : null}
 
               <div className='flex flex-wrap justify-end gap-2'>
-                <Button
-                  variant='outline'
-                  onClick={() => void validateProvider()}
-                  disabled={validating}
-                >
-                  {validating ? 'Validating...' : 'Validate'}
-                </Button>
-                <Button
-                  variant='outline'
-                  onClick={() => {
-                    setActionMessage(
-                      'Sync is initiated from Market Watch query sets. Open Market Watch to run provider discovery.'
-                    )
-                  }}
-                >
-                  Sync
-                </Button>
+                {editingProvider.provider_id !== 'openai' ? (
+                  <>
+                    <Button
+                      variant='outline'
+                      onClick={() => void validateProvider()}
+                      disabled={validating}
+                    >
+                      {validating ? 'Validating...' : 'Validate'}
+                    </Button>
+                    <Button
+                      variant='outline'
+                      onClick={() => {
+                        setActionMessage(
+                          'Sync is initiated from Market Watch query sets. Open Market Watch to run provider discovery.'
+                        )
+                      }}
+                    >
+                      Sync
+                    </Button>
+                  </>
+                ) : null}
                 <Button
                   variant='outline'
                   onClick={closeIntegration}
@@ -1084,7 +1441,11 @@ export function Apps({
                   onClick={() => void saveIntegration()}
                   disabled={saving}
                 >
-                  {saving ? 'Saving...' : 'Save Integration'}
+                  {saving
+                    ? 'Saving...'
+                    : editingProvider.provider_id === 'openai'
+                      ? 'Save OpenAI'
+                      : 'Save Integration'}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Adds OpenAI / ChatGPT as a first-class Cabinet integration registry provider with hybrid Browser Auth/API-key method metadata.
- Ports the SCHA-style clean card + dialog-owned setup flow into Cabinet Integrations.
- Adds Browser Auth setup-needed/unavailable copy that explicitly does not mark connected from navigation alone.
- Saves OpenAI API keys through profile secrets while storing non-secret defaults/settings separately.
- Extends OpenSpec and Cypress/API coverage for #834.

## Validation
- `go test ./internal/app -run "TestOpenAIRegistry" -count=1` ✅
- `openspec validate --all --strict --no-interactive` ✅
- `npm run build` from `ui.web` ✅
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/provider-openai-chatgpt-ux/spec.cy.ts -Browser chrome -RequireE2EHooks` ✅ (3 passing)
- `go test ./... -count=1` ✅

## Notes
- Branch was created in isolated worktree `C:\projects\collectors-tech\cabinet-worktrees\issue-834-openai-config` so the existing #833 regression-baseline worktree stayed untouched.
- Commit: a4f62d0dba4894687939647d0c2790f2a962d332