### PR TITLE
#846 fix(telegram): preserve direct capture lookup evidence

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1228,6 +1228,12 @@ paths:
                       type: string
                     category:
                       type: string
+                    lookup_source:
+                      type: string
+                    lookup_url:
+                      type: string
+                    lookup_confidence:
+                      type: string
                 media:
                   type: array
                   items:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3582,10 +3582,13 @@ func New(cfg config.Config) (*App, error) {
 			GroupingHint:   req.GroupingHint,
 			SourceMetadata: req.SourceMetadata,
 			Draft: telegramcapture.Draft{
-				PartNumber: req.Draft.PartNumber,
-				Title:      req.Draft.Title,
-				Brand:      req.Draft.Brand,
-				Category:   req.Draft.Category,
+				PartNumber:       req.Draft.PartNumber,
+				Title:            req.Draft.Title,
+				Brand:            req.Draft.Brand,
+				Category:         req.Draft.Category,
+				LookupSource:     req.Draft.LookupSource,
+				LookupURL:        req.Draft.LookupURL,
+				LookupConfidence: req.Draft.LookupConfidence,
 			},
 			Media: media,
 		})
@@ -8108,10 +8111,13 @@ type telegramCatalogCaptureRequest struct {
 	Barcode      string `json:"barcode"`
 	GroupingHint string `json:"grouping_hint"`
 	Draft        struct {
-		PartNumber string `json:"part_number"`
-		Title      string `json:"title"`
-		Brand      string `json:"brand"`
-		Category   string `json:"category"`
+		PartNumber       string `json:"part_number"`
+		Title            string `json:"title"`
+		Brand            string `json:"brand"`
+		Category         string `json:"category"`
+		LookupSource     string `json:"lookup_source"`
+		LookupURL        string `json:"lookup_url"`
+		LookupConfidence string `json:"lookup_confidence"`
 	} `json:"draft"`
 	Media          []telegramCatalogCaptureMediaRequest `json:"media"`
 	SourceMetadata map[string]any                       `json:"source_metadata"`

--- a/internal/app/telegram_capture_api_test.go
+++ b/internal/app/telegram_capture_api_test.go
@@ -84,6 +84,56 @@ func TestTelegramCatalogCaptureAPIRequiresPersistedSenderAuthorization(t *testin
 	}
 }
 
+func TestTelegramCatalogCaptureAPIPreservesLookupEvidence(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	create := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"Telegram Lookup API"}`), map[string]string{"Content-Type": "application/json"})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", create.Code, create.Body.String())
+	}
+	var p struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(create.Body).Decode(&p); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	settings := doRequest(t, a, http.MethodPut, "/api/profiles/"+p.ID+"/settings", strings.NewReader(`{
+		"settings":{
+			"telegram.catalog_capture.sender_id":"sender-lookup",
+			"telegram.catalog_capture.chat_id":"chat-lookup"
+		}
+	}`), map[string]string{"Content-Type": "application/json"})
+	if settings.Code != http.StatusOK {
+		t.Fatalf("settings status=%d body=%s", settings.Code, settings.Body.String())
+	}
+
+	capture := doRequest(t, a, http.MethodPost, "/api/telegram/catalog-captures", strings.NewReader(`{
+		"profile_id":"`+p.ID+`",
+		"sender_id":"sender-lookup",
+		"chat_id":"chat-lookup",
+		"barcode":"4904810900019",
+		"draft":{
+			"part_number":"TOMY-001",
+			"title":"Lookup-backed Tomy release",
+			"brand":"Tomy",
+			"category":"Die-cast",
+			"lookup_source":"barcode_local",
+			"lookup_url":"/api/barcodes/4904810900019",
+			"lookup_confidence":"high"
+		}
+	}`), map[string]string{"Content-Type": "application/json"})
+	if capture.Code != http.StatusCreated {
+		t.Fatalf("capture status=%d body=%s", capture.Code, capture.Body.String())
+	}
+	body := capture.Body.String()
+	if !strings.Contains(body, `"lookup":{"confidence":"high","source":"barcode_local","url":"/api/barcodes/4904810900019"}`) ||
+		!strings.Contains(body, `"part_number":"TOMY-001"`) ||
+		!strings.Contains(body, `"title":"Lookup-backed Tomy release"`) {
+		t.Fatalf("expected direct API capture to preserve lookup evidence in preview and audit metadata, body=%s", body)
+	}
+}
+
 func TestTelegramCatalogCaptureCallbackAPIConfirmsAuthorizedPreview(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Preserves lookup-backed draft evidence through the direct Telegram catalog capture API.
- Adds focused API coverage proving `lookup_source`, `lookup_url`, and `lookup_confidence` survive into preview and Inbox audit metadata.
- Updates OpenAPI request schema for direct Telegram capture draft lookup fields.

## Validation
- `go test ./internal/app -run TestTelegramCatalogCaptureAPIPreservesLookupEvidence -count=1` passed.
- `go test ./internal/app -run TestTelegramCatalogCapture -count=1` passed.
- `go test ./internal/app -run TestOpenAPI -count=1` passed.
- `openspec validate --all --strict --no-interactive` passed.
- `git diff --check` passed.
- Push hook passed OpenSpec validation and fast API docs smoke test.

## Logs
- `.work-agent/logs/846-telegram-direct-lookup-evidence/go-test-app-lookup-api.log`
- `.work-agent/logs/846-telegram-direct-lookup-evidence/go-test-app-telegram-capture.log`
- `.work-agent/logs/846-telegram-direct-lookup-evidence/go-test-openapi.log`
- `.work-agent/logs/846-telegram-direct-lookup-evidence/openspec-validate.log`
- `.work-agent/logs/846-telegram-direct-lookup-evidence/git-diff-check.log`

## Demo deploy
Not run: this PR updates only the issue branch. Develop was not merged or materially updated in this worker turn.

Closes part of #846.
