### PR TITLE
#837 test(purchases): cover purchase inbox loading state

### DIFF
--- a/ui.web/cypress/e2e/purchases/purchase-inbox/spec.cy.ts
+++ b/ui.web/cypress/e2e/purchases/purchase-inbox/spec.cy.ts
@@ -111,4 +111,33 @@ describe('purchases/purchase-inbox', () => {
       .should('be.visible')
       .and('contain', 'Purchase Inbox could not load reviews.')
   })
+
+  it('EBAY-PURCHASE-CAPTURE-006 exposes loading state while reviews are prepared', () => {
+    cy.viewport(1400, 900)
+    cy.e2eReset()
+    cy.e2eBootstrap()
+    cy.e2eSetSetupState('present')
+    cy.intercept('POST', '/api/integrations/ebay/purchase-inbox/reviews', (req) => {
+      req.reply({
+        delay: 500,
+        statusCode: 200,
+        body: {
+          source: 'ebay_purchase_capture',
+          profile_id: 'e2e-profile-001',
+          reviews: [],
+        },
+      })
+    }).as('preparePurchaseReviews')
+
+    cy.useBootstrappedProfile('e2e-profile-001', 'E2E Local', {
+      path: '/inbox',
+    })
+    cy.get('[data-testid="purchase-inbox-load-reviews"]').click()
+    cy.get('[data-testid="purchase-inbox-loading-state"]')
+      .should('be.visible')
+      .and('contain', 'Preparing purchase review records...')
+    cy.wait('@preparePurchaseReviews')
+    cy.get('[data-testid="purchase-inbox-loading-state"]').should('not.exist')
+    cy.get('[data-testid="purchase-inbox-empty-state"]').should('be.visible')
+  })
 })


### PR DESCRIPTION
## Summary
- Adds focused Cypress coverage for the #837 Purchase Inbox loading state while the review API is still in flight.
- Verifies the loading panel clears and the empty state returns after an empty review response.
- Test-only change; no production behavior changed.

## Validation
- `.\\cypress.ps1 -Spec cypress/e2e/purchases/purchase-inbox/spec.cy.ts -Browser chrome -RequireE2EHooks` - PASS (3 tests, 3 passing)
- `openspec validate --all --strict --no-interactive` - PASS
- `git diff --check` - PASS

## Logs
- `.work-agent/logs/837-purchase-inbox-loading-state-20260523-0238/cypress-purchase-inbox-loading.log`
- `.work-agent/logs/837-purchase-inbox-loading-state-20260523-0238/openspec-validate.log`
- `.work-agent/logs/837-purchase-inbox-loading-state-20260523-0238/git-diff-check.log`
- `.work-agent/logs/837-purchase-inbox-loading-state-20260523-0238/git-commit.log`
- `.work-agent/logs/837-purchase-inbox-loading-state-20260523-0238/git-push.log`

Closes part of #837.
