### PR TITLE
#888 test(app): harden canceled runtime fast-exit gate

### DIFF
--- a/internal/app/runtime_fast_exit_test.go
+++ b/internal/app/runtime_fast_exit_test.go
@@ -28,11 +28,17 @@ func TestRunReturnsQuicklyWhenContextAlreadyCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	start := time.Now()
-	if err := a.Run(ctx); err != nil {
-		t.Fatalf("Run() error = %v", err)
-	}
-	if took := time.Since(start); took > 500*time.Millisecond {
-		t.Fatalf("expected pre-canceled Run to exit quickly, took %s", took)
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return for a pre-canceled context")
 	}
 }


### PR DESCRIPTION
## Summary\n- Replace the 500ms wall-clock assertion in the pre-canceled runtime fast-exit test with a blocked-call guard.\n- Preserve the canceled-context behavior check while avoiding full-suite load sensitivity.\n\n## Verification\n- go test ./internal/app -run TestRunReturnsQuicklyWhenContextAlreadyCanceled -count=1\n- go test ./internal/app -count=1\n- go test ./... -count=1\n- git diff --check\n\nFixes collectors-tech/cabinet#888