### PR TITLE
#823 test(profiles): preserve showcase label after recovery

### DIFF
--- a/openspec/specs/users/profiles/spec.md
+++ b/openspec/specs/users/profiles/spec.md
@@ -26,7 +26,7 @@ The authenticated shell SHALL show actionable guidance when active profile/datab
 - **GIVEN** the authenticated shell cannot load the active profile/database context
 - **WHEN** the user opens the database switcher
 - **THEN** the shell SHALL show profile-unavailable guidance with a retry action
-- **AND** retrying after the active profile endpoint recovers SHALL restore the active database label
+- **AND** retrying after the active profile endpoint recovers SHALL restore the active profile name and database/sample classification label
 
 ### Requirement PROFILES-004: Cabinet SHALL create and activate database profiles from the shell switcher
 The authenticated database/profile switcher SHALL let users create a new database profile and SHALL make that profile the active app-wide data context immediately after creation.

--- a/ui.web/cypress/e2e/general/profile-context-recovery/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/profile-context-recovery/spec.cy.ts
@@ -59,6 +59,6 @@ describe('profile-context-recovery', () => {
     cy.wait('@activeProfile')
 
     visibleByTestId('active-profile-name').should('contain', 'Showcase DB')
-    visibleByTestId('active-profile-status').should('have.text', 'Database')
+    visibleByTestId('active-profile-status').should('have.text', 'Showcase sample data')
   })
 })


### PR DESCRIPTION
## Summary
- Aligns the #823 active-profile recovery Cypress assertion with the merged Showcase/sample-data profile classification behavior.
- Updates PROFILES-003 wording so retry recovery restores both profile name and database/sample classification label.

## Validation
- PASS: `openspec validate --all --strict --no-interactive`
- PASS: `go test ./internal/app -run TestOpenSpecScenariosRequireGivenWhenThen -count=1`
- PASS: `git diff --check`
- PASS: `pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/general/profile-context-recovery/spec.cy.ts -Browser chrome -RequireE2EHooks -StartupTimeoutSec 90`

Logs: `.work-agent/logs/issue-823-20260524-1000`
