### PR TITLE
#840 feat(costing): add landed cost allocation contract

### DIFF
--- a/internal/costing/landed_cost.go
+++ b/internal/costing/landed_cost.go
@@ -1,0 +1,283 @@
+package costing
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type AllocationMethod string
+
+const (
+	AllocationEqual  AllocationMethod = "equal"
+	AllocationValue  AllocationMethod = "value"
+	AllocationWeight AllocationMethod = "weight"
+	AllocationManual AllocationMethod = "manual"
+)
+
+type ItemInput struct {
+	ID                    string
+	PurchaseCents         int64
+	DomesticShippingCents int64
+	TaxCents              int64
+	WeightGrams           int64
+	Quantity              int
+}
+
+type CostComponentInput struct {
+	ID               string
+	Label            string
+	AmountCents      int64
+	AllocationMethod AllocationMethod
+	ManualShares     map[string]int64
+	Provenance       string
+}
+
+type AllocationRequest struct {
+	Items      []ItemInput
+	Components []CostComponentInput
+}
+
+type ItemLandedCost struct {
+	ItemID                 string
+	DirectCostCents        int64
+	AllocatedCostCents     int64
+	LandedCostCents        int64
+	ComponentAllocations   []ComponentAllocation
+	AllocationProvenanceID []string
+}
+
+type ComponentAllocation struct {
+	ComponentID      string
+	Label            string
+	Method           AllocationMethod
+	AmountCents      int64
+	Provenance       string
+	AllocationBasis  int64
+	AllocationWeight int64
+}
+
+type AllocationResult struct {
+	Items             []ItemLandedCost
+	TotalDirectCents  int64
+	TotalSharedCents  int64
+	TotalLandedCents  int64
+	AllocationSummary []ComponentAllocationSummary
+}
+
+type ComponentAllocationSummary struct {
+	ComponentID string
+	Label       string
+	Method      AllocationMethod
+	AmountCents int64
+	Provenance  string
+}
+
+type ConsolidationRequest struct {
+	Items                 []ItemLandedCost
+	ShipmentFeeCents      int64
+	DestinationLimitCents int64
+	WarningBufferCents    int64
+}
+
+type ConsolidationPlan struct {
+	ItemIDs             []string
+	EstimatedValueCents int64
+	EstimatedFeeCents   int64
+	EstimatedTotalCents int64
+	ThresholdState      string
+	Warnings            []string
+	Mutable             bool
+}
+
+func AllocateLandedCosts(req AllocationRequest) (AllocationResult, error) {
+	if len(req.Items) == 0 {
+		return AllocationResult{}, errors.New("at least one item is required")
+	}
+
+	items := make([]ItemLandedCost, len(req.Items))
+	itemByID := make(map[string]int, len(req.Items))
+	for i, item := range req.Items {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			return AllocationResult{}, fmt.Errorf("item at index %d requires id", i)
+		}
+		if _, exists := itemByID[id]; exists {
+			return AllocationResult{}, fmt.Errorf("duplicate item id %q", id)
+		}
+		if item.PurchaseCents < 0 || item.DomesticShippingCents < 0 || item.TaxCents < 0 || item.WeightGrams < 0 {
+			return AllocationResult{}, fmt.Errorf("item %q has negative cost input", id)
+		}
+		direct := item.PurchaseCents + item.DomesticShippingCents + item.TaxCents
+		items[i] = ItemLandedCost{
+			ItemID:          id,
+			DirectCostCents: direct,
+			LandedCostCents: direct,
+		}
+		itemByID[id] = i
+	}
+
+	var result AllocationResult
+	result.Items = items
+	for _, item := range items {
+		result.TotalDirectCents += item.DirectCostCents
+	}
+
+	for _, component := range req.Components {
+		if component.AmountCents < 0 {
+			return AllocationResult{}, fmt.Errorf("component %q has negative amount", component.ID)
+		}
+		if strings.TrimSpace(component.ID) == "" {
+			return AllocationResult{}, errors.New("component requires id")
+		}
+		method := component.AllocationMethod
+		if method == "" {
+			method = AllocationEqual
+		}
+		allocations, bases, err := allocateComponent(req.Items, component, method)
+		if err != nil {
+			return AllocationResult{}, err
+		}
+		for i, amount := range allocations {
+			allocation := ComponentAllocation{
+				ComponentID:      component.ID,
+				Label:            component.Label,
+				Method:           method,
+				AmountCents:      amount,
+				Provenance:       component.Provenance,
+				AllocationBasis:  bases[i],
+				AllocationWeight: amount,
+			}
+			result.Items[i].AllocatedCostCents += amount
+			result.Items[i].LandedCostCents += amount
+			result.Items[i].ComponentAllocations = append(result.Items[i].ComponentAllocations, allocation)
+			if component.Provenance != "" {
+				result.Items[i].AllocationProvenanceID = append(result.Items[i].AllocationProvenanceID, component.Provenance)
+			}
+		}
+		result.TotalSharedCents += component.AmountCents
+		result.AllocationSummary = append(result.AllocationSummary, ComponentAllocationSummary{
+			ComponentID: component.ID,
+			Label:       component.Label,
+			Method:      method,
+			AmountCents: component.AmountCents,
+			Provenance:  component.Provenance,
+		})
+	}
+	result.TotalLandedCents = result.TotalDirectCents + result.TotalSharedCents
+	return result, nil
+}
+
+func PlanConsolidation(req ConsolidationRequest) (ConsolidationPlan, error) {
+	if len(req.Items) == 0 {
+		return ConsolidationPlan{}, errors.New("at least one landed-cost item is required")
+	}
+	if req.ShipmentFeeCents < 0 || req.DestinationLimitCents < 0 || req.WarningBufferCents < 0 {
+		return ConsolidationPlan{}, errors.New("consolidation thresholds and fees cannot be negative")
+	}
+	plan := ConsolidationPlan{
+		EstimatedFeeCents: req.ShipmentFeeCents,
+		ThresholdState:    "under_limit",
+		Mutable:           false,
+	}
+	for _, item := range req.Items {
+		if strings.TrimSpace(item.ItemID) == "" {
+			return ConsolidationPlan{}, errors.New("landed-cost item requires id")
+		}
+		if item.LandedCostCents < 0 {
+			return ConsolidationPlan{}, fmt.Errorf("item %q has negative landed cost", item.ItemID)
+		}
+		plan.ItemIDs = append(plan.ItemIDs, item.ItemID)
+		plan.EstimatedValueCents += item.LandedCostCents
+	}
+	sort.Strings(plan.ItemIDs)
+	plan.EstimatedTotalCents = plan.EstimatedValueCents + plan.EstimatedFeeCents
+	if req.DestinationLimitCents > 0 {
+		switch {
+		case plan.EstimatedTotalCents > req.DestinationLimitCents:
+			plan.ThresholdState = "over_limit"
+			plan.Warnings = append(plan.Warnings, "estimated total exceeds destination value limit")
+		case req.WarningBufferCents > 0 && plan.EstimatedTotalCents+req.WarningBufferCents > req.DestinationLimitCents:
+			plan.ThresholdState = "near_limit"
+			plan.Warnings = append(plan.Warnings, "estimated total is within warning buffer of destination value limit")
+		}
+	}
+	return plan, nil
+}
+
+func allocateComponent(items []ItemInput, component CostComponentInput, method AllocationMethod) ([]int64, []int64, error) {
+	bases := make([]int64, len(items))
+	switch method {
+	case AllocationEqual:
+		for i := range bases {
+			bases[i] = 1
+		}
+	case AllocationValue:
+		for i, item := range items {
+			bases[i] = item.PurchaseCents + item.DomesticShippingCents + item.TaxCents
+		}
+	case AllocationWeight:
+		for i, item := range items {
+			bases[i] = item.WeightGrams
+		}
+	case AllocationManual:
+		for i, item := range items {
+			bases[i] = component.ManualShares[item.ID]
+		}
+	default:
+		return nil, nil, fmt.Errorf("unsupported allocation method %q", method)
+	}
+	if method == AllocationManual {
+		for itemID := range component.ManualShares {
+			found := false
+			for _, item := range items {
+				if item.ID == itemID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, nil, fmt.Errorf("manual share references unknown item %q", itemID)
+			}
+		}
+	}
+	return allocateByBasis(component.AmountCents, bases)
+}
+
+func allocateByBasis(amount int64, bases []int64) ([]int64, []int64, error) {
+	var totalBasis int64
+	for _, basis := range bases {
+		if basis < 0 {
+			return nil, nil, errors.New("allocation basis cannot be negative")
+		}
+		totalBasis += basis
+	}
+	if totalBasis <= 0 {
+		return nil, nil, errors.New("allocation basis must be positive")
+	}
+	allocations := make([]int64, len(bases))
+	type remainder struct {
+		index int
+		value int64
+	}
+	remainders := make([]remainder, len(bases))
+	var allocated int64
+	for i, basis := range bases {
+		numerator := amount * basis
+		allocations[i] = numerator / totalBasis
+		allocated += allocations[i]
+		remainders[i] = remainder{index: i, value: numerator % totalBasis}
+	}
+	sort.SliceStable(remainders, func(i, j int) bool {
+		if remainders[i].value == remainders[j].value {
+			return remainders[i].index < remainders[j].index
+		}
+		return remainders[i].value > remainders[j].value
+	})
+	for remaining := amount - allocated; remaining > 0; remaining-- {
+		allocations[remainders[0].index]++
+		remainders = append(remainders[1:], remainders[0])
+	}
+	return allocations, bases, nil
+}

--- a/internal/costing/landed_cost_test.go
+++ b/internal/costing/landed_cost_test.go
@@ -1,0 +1,78 @@
+package costing
+
+import "testing"
+
+func TestAllocateLandedCostsByValueWeightAndManualAdjustments(t *testing.T) {
+	result, err := AllocateLandedCosts(AllocationRequest{
+		Items: []ItemInput{
+			{ID: "card-a", PurchaseCents: 10000, DomesticShippingCents: 500, TaxCents: 1000, WeightGrams: 100},
+			{ID: "card-b", PurchaseCents: 30000, DomesticShippingCents: 1500, TaxCents: 3000, WeightGrams: 300},
+		},
+		Components: []CostComponentInput{
+			{ID: "intl", Label: "International shipping", AmountCents: 8000, AllocationMethod: AllocationWeight, Provenance: "forwarder-shipment:SHIP-1"},
+			{ID: "handling", Label: "Handling", AmountCents: 1200, AllocationMethod: AllocationEqual, Provenance: "forwarder-invoice:INV-1"},
+			{ID: "insurance", Label: "Insurance", AmountCents: 2000, AllocationMethod: AllocationValue, Provenance: "manual-adjustment:ADJ-1"},
+			{ID: "review", Label: "Manual review adjustment", AmountCents: 300, AllocationMethod: AllocationManual, ManualShares: map[string]int64{"card-a": 2, "card-b": 1}, Provenance: "manual-adjustment:ADJ-2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AllocateLandedCosts returned error: %v", err)
+	}
+	if result.TotalDirectCents != 46000 || result.TotalSharedCents != 11500 || result.TotalLandedCents != 57500 {
+		t.Fatalf("unexpected totals: %+v", result)
+	}
+	assertItem := func(index int, id string, direct, allocated, landed int64) {
+		t.Helper()
+		item := result.Items[index]
+		if item.ItemID != id || item.DirectCostCents != direct || item.AllocatedCostCents != allocated || item.LandedCostCents != landed {
+			t.Fatalf("unexpected item[%d]: %+v", index, item)
+		}
+		if len(item.ComponentAllocations) != 4 {
+			t.Fatalf("expected 4 component allocations for %s, got %d", id, len(item.ComponentAllocations))
+		}
+	}
+	assertItem(0, "card-a", 11500, 3300, 14800)
+	assertItem(1, "card-b", 34500, 8200, 42700)
+}
+
+func TestAllocateLandedCostsRejectsInvalidManualAllocation(t *testing.T) {
+	_, err := AllocateLandedCosts(AllocationRequest{
+		Items: []ItemInput{{ID: "card-a", PurchaseCents: 1000}},
+		Components: []CostComponentInput{{
+			ID:               "manual",
+			AmountCents:      100,
+			AllocationMethod: AllocationManual,
+			ManualShares:     map[string]int64{"missing": 1},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected unknown manual item error")
+	}
+}
+
+func TestPlanConsolidationThresholdWarnings(t *testing.T) {
+	plan, err := PlanConsolidation(ConsolidationRequest{
+		Items: []ItemLandedCost{
+			{ItemID: "card-b", LandedCostCents: 42000},
+			{ItemID: "card-a", LandedCostCents: 14500},
+		},
+		ShipmentFeeCents:      2500,
+		DestinationLimitCents: 60000,
+		WarningBufferCents:    1500,
+	})
+	if err != nil {
+		t.Fatalf("PlanConsolidation returned error: %v", err)
+	}
+	if plan.EstimatedValueCents != 56500 || plan.EstimatedFeeCents != 2500 || plan.EstimatedTotalCents != 59000 {
+		t.Fatalf("unexpected plan totals: %+v", plan)
+	}
+	if plan.ThresholdState != "near_limit" || len(plan.Warnings) != 1 {
+		t.Fatalf("expected near-limit warning, got %+v", plan)
+	}
+	if plan.Mutable {
+		t.Fatal("planner result should be non-mutating until explicitly executed")
+	}
+	if got := plan.ItemIDs; len(got) != 2 || got[0] != "card-a" || got[1] != "card-b" {
+		t.Fatalf("expected deterministic sorted item ids, got %#v", got)
+	}
+}

--- a/openspec/specs/commerce/landed-cost/spec.md
+++ b/openspec/specs/commerce/landed-cost/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+Define the first deliverable slice for landed-cost allocation and consolidation planning.
+
+## Requirements
+### Requirement COMMERCE-LANDED-COST-001: Landed cost allocation SHALL produce explainable item cost basis
+Cabinet SHALL calculate item landed cost from purchase price, domestic shipping, taxes, forwarder fees, international shipping, handling, consolidation fees, and manual adjustments.
+
+#### Scenario: Allocate shared costs deterministically
+- **GIVEN** a set of purchased items with direct costs and shared forwarding cost components
+- **WHEN** Cabinet allocates landed costs by equal, value, weight, or manual allocation rules
+- **THEN** Cabinet MUST return per-item direct cost, allocated cost, landed cost, allocation method, and provenance for each allocated component without mutating inventory state.
+
+### Requirement COMMERCE-LANDED-COST-002: Manual adjustments SHALL preserve audit provenance
+Cabinet SHALL require manual landed-cost adjustments to preserve source/provenance metadata and deterministic allocation shares.
+
+#### Scenario: Reject invalid manual allocation
+- **GIVEN** a manual allocation references an item outside the allocation request
+- **WHEN** Cabinet validates the landed-cost request
+- **THEN** Cabinet MUST reject the request instead of silently reallocating or dropping the manual adjustment.
+
+### Requirement COMMERCE-LANDED-COST-003: Consolidation planning SHALL warn near or over destination thresholds
+Cabinet SHALL produce non-mutating consolidation recommendations with threshold states for destination value limits.
+
+#### Scenario: Warn when consolidation plan nears destination limit
+- **GIVEN** landed-cost items, a shipment fee estimate, a destination value limit, and a warning buffer
+- **WHEN** Cabinet estimates the consolidation plan total
+- **THEN** Cabinet MUST return sorted item IDs, estimated value, estimated fee, estimated total, threshold state, and warnings while leaving execution state unchanged.

--- a/openspec/traceability.md
+++ b/openspec/traceability.md
@@ -6,6 +6,9 @@
 
 | Requirement ID | Spec Path | Route/Component Scope | Validating Tests | Status |
 | --- | --- | --- | --- | --- |
+| COMMERCE-LANDED-COST-001 | openspec/specs/commerce/landed-cost/spec.md | deterministic landed-cost allocation engine with equal/value/weight/manual shared component allocation and non-mutating output | TestAllocateLandedCostsByValueWeightAndManualAdjustments (internal/costing/landed_cost_test.go) | implemented |
+| COMMERCE-LANDED-COST-002 | openspec/specs/commerce/landed-cost/spec.md | manual adjustment validation rejects unknown item shares and preserves provenance on successful allocations | TestAllocateLandedCostsRejectsInvalidManualAllocation, TestAllocateLandedCostsByValueWeightAndManualAdjustments (internal/costing/landed_cost_test.go) | implemented |
+| COMMERCE-LANDED-COST-003 | openspec/specs/commerce/landed-cost/spec.md | non-mutating consolidation planner threshold states and deterministic item ordering | TestPlanConsolidationThresholdWarnings (internal/costing/landed_cost_test.go) | implemented |
 | `AI-ASSIST-001` | `openspec/specs/chats/ai-assist/spec.md` | `openspec/specs/chats/ai-assist/spec.md` | TestWave7AIContractsMissingKeySuggestAndToggle (internal/app/traceability_wave7_ai_settings_lookup_test.go) | implemented |
 | `AI-ASSIST-002` | `openspec/specs/chats/ai-assist/spec.md` | `openspec/specs/chats/ai-assist/spec.md` | TestWave7AIContractsMissingKeySuggestAndToggle (internal/app/traceability_wave7_ai_settings_lookup_test.go) | implemented |
 | `AI-ASSIST-003` | `openspec/specs/chats/ai-assist/spec.md` | `internal/app/ai_api_test.go` (`TestAIAssistApplyRequiresExplicitConfirmation`) | implemented |


### PR DESCRIPTION
## Summary
- Adds the first #840 landed-cost allocation contract under internal/costing.
- Adds deterministic equal/value/weight/manual shared-cost allocation with provenance in the result.
- Adds non-mutating consolidation threshold planning with near/over-limit warnings.
- Adds OpenSpec requirement coverage and traceability for COMMERCE-LANDED-COST-001 through COMMERCE-LANDED-COST-003.

## Validation
- PASS go test ./internal/costing -count=1
- PASS openspec validate --all --strict --no-interactive
- PASS git diff --check

## Notes
- Branch was initially created from local master because origin/master is absent in this checkout; PR targets develop per Cabinet discipline.
- An attempted pre-PR merge from origin/develop was aborted because the repo hook rejected the default merge commit message before completion. The branch is clean aside from pre-existing untracked ui.web/cypress/downloads/.
