### PR TITLE
#821 docs: add Market Watch saved search help

### DIFF
--- a/docs/help-center/sections/integrations.md
+++ b/docs/help-center/sections/integrations.md
@@ -4,8 +4,25 @@
 - Connecting providers
 - Validating tokens
 - Running sync and status checks
+- Reviewing Market Watch saved searches
 
 ## Common actions
 - Connect/disconnect provider
 - Validate token
 - Run provider sync
+
+## Market Watch saved searches
+Use Market Watch when you want Cabinet to watch provider listings without re-entering the same search each time.
+
+Saved searches keep the provider scope, keywords, filters, schedule, and rate-limit settings together. You can create, edit, delete, run now, or run scheduled refreshes from the Market Watch screen.
+
+## Reviewing run output
+Run results show provider attribution, latest run status, last run time, and candidate counts. Table view is useful when you have several saved searches and need to compare recent output quickly.
+
+Open output details before handing results off. The detail view keeps enough source context for follow-up actions to remain traceable.
+
+## Failures and retries
+Provider failures stay visible instead of silently dropping candidates. Use the retry action after checking the guidance shown on the failed run. When the retry recovers, Market Watch reloads the saved-search state and clears stale failure entries.
+
+## Discoveries and Wishlist handoff
+Send useful saved-search output to Discoveries for review, or add a candidate to Wishlist when it is worth tracking. Cabinet preserves saved-search provenance such as provider, query set, query name, and provider scope so the Wishlist entry can still be understood after reload.


### PR DESCRIPTION
## Summary
- adds Help Center guidance for Market Watch saved searches, run review, failures/retry, and Discoveries/Wishlist handoff
- closes the remaining documentation acceptance gap from #821

## Validation
- PASS git diff --check
- PASS npx openspec validate --all --strict --no-interactive
- PASS npm run build --prefix ui.web

Closes #821