### PR TITLE
#811 fix(integrations): tolerate chained Bonza challenges

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9170,34 +9170,9 @@ func fetchBonzaProductURLProducts(ctx context.Context, client *http.Client, requ
 	requestClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	resp, err := fetchBonzaProductURLProductsResponse(ctx, &requestClient, requestURL)
 	if err != nil {
-		return nil, fmt.Errorf("build bonza product ingest request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "Cabinet/1.0 (+https://collectors.tech)")
-	resp, err := requestClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request bonza product ingest: %w", err)
-	}
-	challengeBody, readChallenge := readBonzaSucuriChallenge(resp)
-	if readChallenge {
-		cookie, cookieErr := bonzaSucuriChallengeCookie(challengeBody)
-		if cookieErr == nil && cookie != "" {
-			req, err = http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
-			if err != nil {
-				return nil, fmt.Errorf("build bonza product ingest retry request: %w", err)
-			}
-			req.Header.Set("Accept", "application/json")
-			req.Header.Set("User-Agent", "Cabinet/1.0 (+https://collectors.tech)")
-			req.Header.Set("Cookie", cookie)
-			resp, err = requestClient.Do(req)
-			if err != nil {
-				return nil, fmt.Errorf("retry bonza product ingest after challenge: %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("solve bonza product ingest challenge: %w", cookieErr)
-		}
+		return nil, err
 	}
 	if resp.StatusCode >= http.StatusBadRequest {
 		resp.Body.Close()
@@ -9210,6 +9185,66 @@ func fetchBonzaProductURLProducts(ctx context.Context, client *http.Client, requ
 		return nil, fmt.Errorf("decode bonza product ingest response: %w", decodeErr)
 	}
 	return products, nil
+}
+
+func fetchBonzaProductURLProductsResponse(ctx context.Context, client *http.Client, requestURL string) (*http.Response, error) {
+	const maxChallengeRetries = 5
+	cookies := map[string]string{}
+	var lastChallengeErr error
+
+	for attempt := 0; attempt <= maxChallengeRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build bonza product ingest request: %w", err)
+		}
+		applyBonzaProductURLRequestHeaders(req, cookies)
+		resp, err := client.Do(req)
+		if err != nil {
+			if attempt == 0 {
+				return nil, fmt.Errorf("request bonza product ingest: %w", err)
+			}
+			return nil, fmt.Errorf("retry bonza product ingest after challenge: %w", err)
+		}
+		challengeBody, readChallenge := readBonzaSucuriChallenge(resp)
+		if !readChallenge {
+			return resp, nil
+		}
+		cookie, cookieErr := bonzaSucuriChallengeCookie(challengeBody)
+		if cookieErr != nil || cookie == "" {
+			if cookieErr == nil {
+				cookieErr = fmt.Errorf("empty challenge cookie")
+			}
+			return nil, fmt.Errorf("solve bonza product ingest challenge: %w", cookieErr)
+		}
+		name, value, ok := strings.Cut(cookie, "=")
+		if !ok || strings.TrimSpace(name) == "" || strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("solve bonza product ingest challenge: invalid cookie")
+		}
+		cookies[strings.TrimSpace(name)] = strings.TrimSpace(value)
+		lastChallengeErr = fmt.Errorf("bonza product ingest challenge did not clear after %d attempt(s)", attempt+1)
+	}
+	return nil, lastChallengeErr
+}
+
+func applyBonzaProductURLRequestHeaders(req *http.Request, cookies map[string]string) {
+	req.Header.Set("Accept", "application/json, text/plain, */*")
+	req.Header.Set("Accept-Language", "en-AU,en;q=0.9")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36 Cabinet/1.0")
+	if req.URL != nil {
+		req.Header.Set("Referer", strings.TrimRight(req.URL.Scheme+"://"+req.URL.Host, "/")+"/")
+	}
+	if len(cookies) > 0 {
+		names := make([]string, 0, len(cookies))
+		for name := range cookies {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		parts := make([]string, 0, len(names))
+		for _, name := range names {
+			parts = append(parts, name+"="+cookies[name])
+		}
+		req.Header.Set("Cookie", strings.Join(parts, "; "))
+	}
 }
 
 func readBonzaSucuriChallenge(resp *http.Response) (string, bool) {

--- a/internal/app/bonza_product_url_ingest_api_test.go
+++ b/internal/app/bonza_product_url_ingest_api_test.go
@@ -229,6 +229,63 @@ func TestProviderProductURLIngestSolvesBonzaSucuriChallenge(t *testing.T) {
 	}
 }
 
+func TestProviderProductURLIngestSolvesChainedBonzaSucuriChallenges(t *testing.T) {
+	t.Parallel()
+
+	firstCookie := "sucuri_cloudproxy_uuid_first=first-cookie-value"
+	secondCookie := "sucuri_cloudproxy_uuid_second=second-cookie-value"
+	firstChallenge := bonzaSucuriChallengeBody(t, "sucuri_cloudproxy_uuid_first", "first-cookie-value")
+	secondChallenge := bonzaSucuriChallengeBody(t, "sucuri_cloudproxy_uuid_second", "second-cookie-value")
+	requests := 0
+	var cookies []string
+	bonza := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		cookie := r.Header.Get("Cookie")
+		cookies = append(cookies, cookie)
+		switch {
+		case !strings.Contains(cookie, firstCookie):
+			w.WriteHeader(http.StatusTemporaryRedirect)
+			_, _ = w.Write([]byte(firstChallenge))
+			return
+		case !strings.Contains(cookie, secondCookie):
+			w.WriteHeader(http.StatusTemporaryRedirect)
+			_, _ = w.Write([]byte(secondChallenge))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{
+			"id":19603,
+			"name":"BONZA MUG WHITE",
+			"slug":"bonza-mug-white",
+			"permalink":"https://bonzaslotcars.com.au/product/bonza-mug-white/",
+			"prices":{"currency_code":"AUD","price":"995"},
+			"is_in_stock":true
+		}]`))
+	}))
+	defer bonza.Close()
+
+	a, profileID := newBonzaIngestTestApp(t)
+	settingsBody := fmt.Sprintf(`{"settings":{"integration.bonzaslotcars.base_url":"%s"}}`, bonza.URL)
+	saveSettings := doRequest(t, a, http.MethodPut, "/api/profiles/"+profileID+"/settings", strings.NewReader(settingsBody), map[string]string{"Content-Type": "application/json"})
+	if saveSettings.Code != http.StatusOK {
+		t.Fatalf("save settings status=%d body=%s", saveSettings.Code, saveSettings.Body.String())
+	}
+
+	ingest := doRequest(t, a, http.MethodPost, "/api/providers/product-url/ingest", strings.NewReader(`{"url":"https://bonzaslotcars.com.au/product/bonza-mug-white/"}`), map[string]string{"Content-Type": "application/json"})
+	if ingest.Code != http.StatusOK {
+		t.Fatalf("ingest status=%d requests=%d cookies=%q body=%s", ingest.Code, requests, cookies, ingest.Body.String())
+	}
+	if requests != 3 {
+		t.Fatalf("expected first challenge, second challenge, and cookie retry, got %d requests", requests)
+	}
+	if !strings.Contains(cookies[2], firstCookie) || !strings.Contains(cookies[2], secondCookie) {
+		t.Fatalf("expected final retry to send both challenge cookies, got %q", cookies)
+	}
+	if !strings.Contains(ingest.Body.String(), `"provider_product_id":"19603"`) {
+		t.Fatalf("expected Bonza product payload after chained challenge retries, got %s", ingest.Body.String())
+	}
+}
+
 func TestProviderProductURLIngestRejectsKnownProviderNonProductURL(t *testing.T) {
 	t.Parallel()
 
@@ -261,6 +318,23 @@ func newBonzaIngestTestApp(t *testing.T) (*App, string) {
 		t.Fatalf("activate profile status=%d body=%s", activate.Code, activate.Body.String())
 	}
 	return a, profile.ID
+}
+
+func bonzaSucuriChallengeBody(t *testing.T, cookieName, cookieValue string) string {
+	t.Helper()
+
+	nameExpr := sucuriConcatExpression(cookieName)
+	valueExpr := sucuriConcatExpression(cookieValue)
+	challengeScript := "r=" + valueExpr + ";document.cookie=" + nameExpr + "+\"=\"+r+';path=/;max-age=86400'; location.reload();"
+	return "Javascript is required.<script>S='" + base64.StdEncoding.EncodeToString([]byte(challengeScript)) + "';sucuri_cloudproxy_js='';</script>"
+}
+
+func sucuriConcatExpression(value string) string {
+	parts := make([]string, 0, len(value))
+	for _, char := range value {
+		parts = append(parts, fmt.Sprintf("%q", string(char)))
+	}
+	return strings.Join(parts, "+")
 }
 
 func containsString(values []string, expected string) bool {


### PR DESCRIPTION
## Summary
- retries Bonza product URL Store API requests through chained Sucuri JavaScript challenges instead of stopping after the first decoded cookie
- carries decoded challenge cookies across retries with browser-like request headers
- adds targeted mocked coverage for a two-step rotating challenge before returning the Bonza product draft

## Validation
- `go test ./internal/app -run 'TestProviderProductURLIngest' -count=1`
- `openspec validate ingest-bonza-product-urls --type change --strict --no-interactive`
- `git diff --check`
- `git push origin issue-811-bonza-challenge-retry-followup` pre-push OpenSpec all-items validation and fast API docs smoke test

Logs: `.work-agent/logs/issue-811-bonza-challenge-retry-followup-20260530-0430/`

## Notes
This PR advances the live Bonza blocker from #811. Live demo verification still needs to be rerun after merge/deploy from develop before #811 can be closed.