### PR TITLE
#811 fix(integrations): accept Bonza object attribute terms

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7996,13 +7996,47 @@ type bonzaProductName struct {
 }
 
 type bonzaProductAttribute struct {
-	Name    string   `json:"name"`
-	Terms   []string `json:"terms"`
-	Options []string `json:"options"`
+	Name    string                      `json:"name"`
+	Terms   bonzaProductAttributeValues `json:"terms"`
+	Options bonzaProductAttributeValues `json:"options"`
 }
 
 type bonzaProductImage struct {
 	Src string `json:"src"`
+}
+
+type bonzaProductAttributeValues []string
+
+func (values *bonzaProductAttributeValues) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*values = nil
+		return nil
+	}
+	var stringsOnly []string
+	if err := json.Unmarshal(data, &stringsOnly); err == nil {
+		*values = compactBonzaAttributeValues(stringsOnly)
+		return nil
+	}
+	var namedValues []bonzaProductName
+	if err := json.Unmarshal(data, &namedValues); err != nil {
+		return err
+	}
+	out := make([]string, 0, len(namedValues))
+	for _, value := range namedValues {
+		out = append(out, value.Name)
+	}
+	*values = compactBonzaAttributeValues(out)
+	return nil
+}
+
+func compactBonzaAttributeValues(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, value := range in {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 type providerProductURLRoute struct {

--- a/internal/app/bonza_product_url_ingest_api_test.go
+++ b/internal/app/bonza_product_url_ingest_api_test.go
@@ -119,7 +119,8 @@ func TestProviderProductURLIngestReturnsDuplicateCandidates(t *testing.T) {
 			"slug":"bonza-mug-white",
 			"permalink":"https://bonzaslotcars.com.au/product/bonza-mug-white/",
 			"prices":{"currency_code":"AUD","price":"995"},
-			"is_in_stock":true
+			"is_in_stock":true,
+			"attributes":[{"name":"Brand","terms":[{"name":"AFX","slug":"afx"}]}]
 		}]`))
 	}))
 	defer bonza.Close()
@@ -205,7 +206,8 @@ func TestProviderProductURLIngestSolvesBonzaSucuriChallenge(t *testing.T) {
 			"slug":"bonza-mug-white",
 			"permalink":"https://bonzaslotcars.com.au/product/bonza-mug-white/",
 			"prices":{"currency_code":"AUD","price":"995"},
-			"is_in_stock":true
+			"is_in_stock":true,
+			"attributes":[{"name":"Brand","terms":[{"name":"AFX","slug":"afx"}]}]
 		}]`))
 	}))
 	defer bonza.Close()
@@ -259,7 +261,8 @@ func TestProviderProductURLIngestSolvesChainedBonzaSucuriChallenges(t *testing.T
 			"slug":"bonza-mug-white",
 			"permalink":"https://bonzaslotcars.com.au/product/bonza-mug-white/",
 			"prices":{"currency_code":"AUD","price":"995"},
-			"is_in_stock":true
+			"is_in_stock":true,
+			"attributes":[{"name":"Brand","terms":[{"name":"AFX","slug":"afx"}]}]
 		}]`))
 	}))
 	defer bonza.Close()
@@ -283,6 +286,9 @@ func TestProviderProductURLIngestSolvesChainedBonzaSucuriChallenges(t *testing.T
 	}
 	if !strings.Contains(ingest.Body.String(), `"provider_product_id":"19603"`) {
 		t.Fatalf("expected Bonza product payload after chained challenge retries, got %s", ingest.Body.String())
+	}
+	if !strings.Contains(ingest.Body.String(), `"Brand":"AFX"`) {
+		t.Fatalf("expected object-shaped Bonza attribute terms to normalize, got %s", ingest.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- accepts Bonza WooCommerce Store API attribute `terms`/`options` when they arrive as named objects as well as strings
- trims empty attribute values during normalization
- extends #811 Bonza product URL ingest coverage with object-shaped attribute terms from the live Store API response

## Validation
- `go test ./internal/app -run 'TestProviderProductURLIngest' -count=1`
- `openspec validate ingest-bonza-product-urls --type change --strict --no-interactive`
- `git diff --check`
- `git push origin issue-811-bonza-attribute-term-objects` pre-push OpenSpec all-items validation and fast API docs smoke test

Logs: `.work-agent/logs/issue-811-bonza-attribute-term-objects-20260530-0500/`

## Live evidence
Live demo2 on merged develop `f05e977a9a1146e040be23fe110046e16b7e78e9` still returned HTTP 400. A temporary live debug test isolated the failure to JSON decoding: `json: cannot unmarshal object into Go struct field bonzaProductAttribute.attributes.terms of type string`. This PR fixes that decode contract.