### PR TITLE
#1042 fix(chats): restore original layout parity

### DIFF
--- a/openspec/specs/chats/chats-workspace/spec.md
+++ b/openspec/specs/chats/chats-workspace/spec.md
@@ -29,3 +29,14 @@ Cabinet MUST define the distinct responsibilities of shell Assistant workspace a
 - **THEN** Assistant MUST be documented as the AI helper workspace
 - **AND** `/chats` MUST be documented as the intentional conversation/thread workspace
 - **AND** overlap, if any, MUST be explicitly justified by product behavior
+
+### Requirement CHATS-WORKSPACE-004: `/chats` SHALL preserve the original/example two-pane conversation layout
+Chats workspace MUST render as a dark, sparse two-pane conversation surface with a compact conversation rail on the left and the active or empty conversation workspace on the right.
+
+#### Scenario: Render original/example chats layout parity
+- **GIVEN** user opens `/chats`
+- **WHEN** no conversation is selected
+- **THEN** the left rail MUST include a search input before the conversation list
+- **AND** conversation rows MUST preserve compact avatar, participant/title, and message preview structure
+- **AND** the right workspace MUST show a centered empty-state composition with icon, title, helper text, and primary action affordance
+- **AND** the rail and workspace MUST remain separate, readable, and unclipped at normal desktop widths

--- a/ui.web/cypress/e2e/chats/chats-workspace/spec.cy.ts
+++ b/ui.web/cypress/e2e/chats/chats-workspace/spec.cy.ts
@@ -52,4 +52,33 @@ describe('chats/chats-workspace', () => {
     cy.get('[data-testid="shell-chat-toggle"]').should('be.visible')
     cy.location('pathname').should('match', /^\/chats\/?$/)
   })
+
+  it('CHATS-WORKSPACE-004 renders original two-pane chats layout parity', () => {
+    openChats()
+
+    cy.get('[data-testid="chat-layout"]').should('be.visible')
+    cy.get('[data-testid="chat-conversation-rail"]').should('be.visible')
+    cy.get('[data-testid="chat-conversation-search"]')
+      .should('be.visible')
+      .and('have.attr', 'placeholder', 'Search messages')
+    cy.get('[data-testid="chat-empty-workspace-state"]')
+      .should('be.visible')
+      .and('contain.text', 'Select a conversation')
+      .and('contain.text', 'Choose an existing thread or create a new one to continue a durable Cabinet conversation.')
+    cy.get('[data-testid="chat-empty-workspace-action"]')
+      .should('be.visible')
+      .and('contain.text', 'Start a conversation')
+
+    createThread('E2E Visual Parity Thread')
+
+    cy.contains('[data-testid="chat-thread-item"]', 'E2E Visual Parity Thread')
+      .should('be.visible')
+      .within(() => {
+        cy.get('[data-testid="chat-thread-avatar"]').should('be.visible')
+        cy.get('[data-testid="chat-thread-preview"]').should(
+          'contain.text',
+          'No messages yet'
+        )
+      })
+  })
 })

--- a/ui.web/src/features/chats/index.tsx
+++ b/ui.web/src/features/chats/index.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { MessagesSquare, Send } from 'lucide-react'
+import {
+  MessageCircle,
+  MessagesSquare,
+  Plus,
+  Search as SearchIcon,
+  Send,
+} from 'lucide-react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -123,6 +129,10 @@ function prettyRole(role: ChatMessage['role']) {
   return 'You'
 }
 
+function threadInitial(title: string) {
+  return title.trim().charAt(0).toUpperCase() || 'C'
+}
+
 export function Chats() {
   const [activeProfileId, setActiveProfileId] = useState('')
   const [assistantDefaults, setAssistantDefaults] = useState<AssistantDefaults>(
@@ -133,6 +143,7 @@ export function Chats() {
   )
   const [threads, setThreads] = useState<ChatThread[]>([])
   const [selectedThreadId, setSelectedThreadId] = useState('')
+  const [threadSearch, setThreadSearch] = useState('')
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [threadTitle, setThreadTitle] = useState('')
   const [draft, setDraft] = useState('')
@@ -167,6 +178,13 @@ export function Chats() {
     () => actionPreviewStorageKey(activeProfileId, selectedThreadId),
     [activeProfileId, selectedThreadId]
   )
+  const filteredThreads = useMemo(() => {
+    const query = threadSearch.trim().toLowerCase()
+    if (!query) {
+      return threads
+    }
+    return threads.filter((thread) => thread.title.toLowerCase().includes(query))
+  }, [threadSearch, threads])
 
   const threadCreationDisabled = loading || Boolean(error) || !activeProfileId
 

--- a/ui.web/src/features/chats/index.tsx
+++ b/ui.web/src/features/chats/index.tsx
@@ -183,7 +183,9 @@ export function Chats() {
     if (!query) {
       return threads
     }
-    return threads.filter((thread) => thread.title.toLowerCase().includes(query))
+    return threads.filter((thread) =>
+      thread.title.toLowerCase().includes(query)
+    )
   }, [threadSearch, threads])
 
   const threadCreationDisabled = loading || Boolean(error) || !activeProfileId
@@ -299,7 +301,9 @@ export function Chats() {
     setApplyResult(null)
     setApplyNotice('')
     setConfirmApplyOpen(false)
-    const storedPreview = readStoredActionPreview(selectedActionPreviewStorageKey)
+    const storedPreview = readStoredActionPreview(
+      selectedActionPreviewStorageKey
+    )
     if (
       storedPreview?.profile_id === activeProfileId &&
       storedPreview.thread_id === selectedThreadId &&
@@ -628,8 +632,24 @@ export function Chats() {
           </div>
         ) : null}
 
-        <section className='grid h-full min-h-[520px] gap-4 lg:grid-cols-[320px_1fr]'>
-          <div className='rounded-md border p-3'>
+        <section
+          className='grid h-full min-h-[520px] overflow-hidden rounded-md border bg-background lg:grid-cols-[320px_1fr]'
+          data-testid='chat-layout'
+        >
+          <aside
+            className='flex min-h-0 flex-col border-b bg-muted/20 p-3 lg:border-e lg:border-b-0'
+            data-testid='chat-conversation-rail'
+          >
+            <div className='relative mb-3'>
+              <SearchIcon className='pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
+              <Input
+                data-testid='chat-conversation-search'
+                placeholder='Search messages'
+                value={threadSearch}
+                onChange={(event) => setThreadSearch(event.target.value)}
+                className='ps-9'
+              />
+            </div>
             <div className='mb-3 flex gap-2'>
               <Input
                 data-testid='chat-new-thread-input'
@@ -643,22 +663,23 @@ export function Chats() {
                 onClick={() => void createThread()}
                 disabled={threadCreationDisabled || !threadTitle.trim()}
               >
+                <Plus className='mr-1 h-4 w-4' />
                 Create
               </Button>
             </div>
-            <ScrollArea className='h-[420px]'>
+            <ScrollArea className='min-h-0 flex-1'>
               <div data-testid='chat-thread-list' className='space-y-1'>
                 {threads.length === 0 && !loading ? (
                   <p className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'>
                     No chat threads yet.
                   </p>
                 ) : null}
-                {threads.map((thread) => (
+                {filteredThreads.map((thread) => (
                   <button
                     key={thread.id}
                     type='button'
                     data-testid='chat-thread-item'
-                    className={`w-full rounded-md border px-3 py-2 text-left text-sm ${
+                    className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm ${
                       selectedThreadId === thread.id
                         ? 'border-primary bg-primary/5'
                         : 'hover:bg-muted/40'
@@ -668,241 +689,302 @@ export function Chats() {
                       void loadMessages(activeProfileId, thread.id)
                     }}
                   >
-                    {thread.title}
+                    <span
+                      className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary'
+                      data-testid='chat-thread-avatar'
+                    >
+                      {threadInitial(thread.title)}
+                    </span>
+                    <span className='min-w-0 flex-1'>
+                      <span className='block truncate font-medium'>
+                        {thread.title}
+                      </span>
+                      <span
+                        className='block truncate text-xs text-muted-foreground'
+                        data-testid='chat-thread-preview'
+                      >
+                        No messages yet
+                      </span>
+                    </span>
                   </button>
                 ))}
               </div>
             </ScrollArea>
-          </div>
+          </aside>
 
-          <div className='rounded-md border p-3'>
-            <div className='mb-3'>
-              <h2 className='font-semibold' data-testid='chat-thread-title'>
-                {selectedThread?.title ?? 'Select or create a thread'}
-              </h2>
-            </div>
-            <ScrollArea className='h-[380px] rounded-md border p-3'>
-              <div data-testid='chat-message-list' className='space-y-3'>
-                {messagesLoading ? (
-                  <p className='text-sm text-muted-foreground'>
-                    Loading messages...
-                  </p>
-                ) : null}
-                {!messagesLoading && selectedThread && messages.length === 0 ? (
-                  <p className='text-sm text-muted-foreground'>
-                    No messages in this thread yet.
-                  </p>
-                ) : null}
-                {messages.map((message) => (
-                  <div
-                    key={message.id}
-                    className='rounded-md border p-2 text-sm'
-                  >
-                    <p className='font-medium'>{prettyRole(message.role)}</p>
-                    <p>{message.content}</p>
-                  </div>
-                ))}
-              </div>
-            </ScrollArea>
-            {sendError ? (
-              <p
-                className='mt-2 text-sm text-destructive'
-                data-testid='chat-send-error'
-              >
-                {sendError}
-              </p>
-            ) : null}
-            <div className='mt-3 flex gap-2'>
-              <Input
-                data-testid='chat-compose-input'
-                value={draft}
-                onChange={(event) => setDraft(event.target.value)}
-                placeholder='Type your message...'
-                disabled={!selectedThreadId}
-              />
-              <Button
-                data-testid='chat-send-button'
-                onClick={() => void sendMessage()}
-                disabled={!selectedThreadId || !draft.trim()}
-              >
-                <Send className='mr-1 h-4 w-4' />
-                Send
-              </Button>
-            </div>
-
-            <div className='mt-4 space-y-3 rounded-md border p-3'>
-              <p className='text-sm font-medium'>Attachments</p>
-              <div className='flex items-center gap-2'>
-                <Input
-                  type='file'
-                  data-testid='chat-attachment-input'
-                  disabled={!selectedThreadId}
-                  onChange={(event) =>
-                    setPendingAttachment(event.target.files?.[0] ?? null)
-                  }
-                />
-                <Button
-                  type='button'
-                  data-testid='chat-upload-attachment-button'
-                  disabled={!selectedThreadId || !pendingAttachment}
-                  onClick={() => void uploadAttachment()}
-                >
-                  Upload
-                </Button>
-              </div>
+          <div className='flex min-h-0 flex-col p-3'>
+            {!selectedThread ? (
               <div
-                data-testid='chat-attachment-list'
-                className='space-y-1 text-sm'
+                className='flex min-h-[420px] flex-1 items-center justify-center'
+                data-testid='chat-empty-workspace-state'
               >
-                {attachments.length === 0 ? (
-                  <p className='text-muted-foreground'>
-                    No attachments uploaded.
+                <div className='mx-auto max-w-sm text-center'>
+                  <div className='mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border bg-muted/40'>
+                    <MessageCircle className='h-6 w-6 text-muted-foreground' />
+                  </div>
+                  <h2 className='text-lg font-semibold'>
+                    Select a conversation
+                  </h2>
+                  <p className='mt-2 text-sm text-muted-foreground'>
+                    Choose an existing thread or create a new one to continue a
+                    durable Cabinet conversation.
                   </p>
-                ) : (
-                  attachments.map((attachment) => (
-                    <p key={attachment.id}>{attachment.filename}</p>
-                  ))
-                )}
+                  <Button
+                    type='button'
+                    className='mt-4'
+                    data-testid='chat-empty-workspace-action'
+                    onClick={() =>
+                      document
+                        .querySelector<HTMLInputElement>(
+                          '[data-testid="chat-new-thread-input"]'
+                        )
+                        ?.focus()
+                    }
+                  >
+                    Start a conversation
+                  </Button>
+                </div>
               </div>
-            </div>
+            ) : (
+              <>
+                <div className='mb-3'>
+                  <h2 className='font-semibold' data-testid='chat-thread-title'>
+                    {selectedThread.title}
+                  </h2>
+                </div>
+                <ScrollArea className='h-[380px] rounded-md border p-3'>
+                  <div data-testid='chat-message-list' className='space-y-3'>
+                    {messagesLoading ? (
+                      <p className='text-sm text-muted-foreground'>
+                        Loading messages...
+                      </p>
+                    ) : null}
+                    {!messagesLoading &&
+                    selectedThread &&
+                    messages.length === 0 ? (
+                      <p className='text-sm text-muted-foreground'>
+                        No messages in this thread yet.
+                      </p>
+                    ) : null}
+                    {messages.map((message) => (
+                      <div
+                        key={message.id}
+                        className='rounded-md border p-2 text-sm'
+                      >
+                        <p className='font-medium'>
+                          {prettyRole(message.role)}
+                        </p>
+                        <p>{message.content}</p>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+                {sendError ? (
+                  <p
+                    className='mt-2 text-sm text-destructive'
+                    data-testid='chat-send-error'
+                  >
+                    {sendError}
+                  </p>
+                ) : null}
+                <div className='mt-3 flex gap-2'>
+                  <Input
+                    data-testid='chat-compose-input'
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    placeholder='Type your message...'
+                    disabled={!selectedThreadId}
+                  />
+                  <Button
+                    data-testid='chat-send-button'
+                    onClick={() => void sendMessage()}
+                    disabled={!selectedThreadId || !draft.trim()}
+                  >
+                    <Send className='mr-1 h-4 w-4' />
+                    Send
+                  </Button>
+                </div>
 
-            <div className='mt-4 space-y-3 rounded-md border p-3'>
-              <div className='flex flex-wrap items-start justify-between gap-2'>
-                <p className='text-sm font-medium'>Action Preview</p>
-                <p
-                  className='rounded-md border bg-muted/30 px-2 py-1 text-xs text-muted-foreground'
-                  data-testid='chat-assistant-defaults'
-                >
-                  Assistant default: {assistantDefaults.provider} /{' '}
-                  {assistantDefaults.model}
-                </p>
-              </div>
-              <label className='grid gap-1 text-sm'>
-                <span>Action Mode</span>
-                <select
-                  data-testid='chat-preview-action-mode'
-                  className='h-9 rounded-md border bg-background px-3'
-                  value={actionMode}
-                  onChange={(event) =>
-                    setActionMode(
-                      event.target.value as
-                        | 'create_inventory_item'
-                        | 'create_wishlist_entry'
-                        | 'update_inventory_item'
-                        | 'assign_collection_item'
-                    )
-                  }
-                  disabled={!selectedThreadId}
-                >
-                  <option value='create_inventory_item'>
-                    create_inventory_item
-                  </option>
-                  <option value='create_wishlist_entry'>
-                    create_wishlist_entry
-                  </option>
-                  <option value='update_inventory_item'>
-                    update_inventory_item
-                  </option>
-                  <option value='assign_collection_item'>
-                    assign_collection_item
-                  </option>
-                </select>
-              </label>
-              {actionMode === 'update_inventory_item' ||
-              actionMode === 'assign_collection_item' ? (
-                <Input
-                  data-testid='chat-preview-target-item-id'
-                  value={actionTargetItemID}
-                  onChange={(event) =>
-                    setActionTargetItemID(event.target.value)
-                  }
-                  placeholder='Existing item ID'
-                  disabled={!selectedThreadId}
-                />
-              ) : null}
-              {actionMode === 'assign_collection_item' ? (
-                <Input
-                  data-testid='chat-preview-collection-name'
-                  value={actionCollectionName}
-                  onChange={(event) =>
-                    setActionCollectionName(event.target.value)
-                  }
-                  placeholder='Collection name'
-                  disabled={!selectedThreadId}
-                />
-              ) : null}
-              <div className='grid gap-2 sm:grid-cols-2'>
-                <Input
-                  data-testid='chat-preview-part-number'
-                  value={actionPartNumber}
-                  onChange={(event) => setActionPartNumber(event.target.value)}
-                  placeholder='Part number'
-                  disabled={!selectedThreadId}
-                />
-                <Input
-                  data-testid='chat-preview-title'
-                  value={actionTitle}
-                  onChange={(event) => setActionTitle(event.target.value)}
-                  placeholder='Item title'
-                  disabled={!selectedThreadId}
-                />
-              </div>
-              <div className='flex flex-wrap gap-2'>
-                <Button
-                  type='button'
-                  data-testid='chat-preview-action-button'
-                  onClick={() => void previewCreateItemAction()}
-                  disabled={previewDisabled}
-                >
-                  Preview Action
-                </Button>
-                <Button
-                  type='button'
-                  variant='outline'
-                  data-testid='chat-apply-action-button'
-                  onClick={() => setConfirmApplyOpen(true)}
-                  disabled={
-                    !selectedThreadId ||
-                    !actionPreview?.id ||
-                    actionPreviewStatusLabel !== 'pending'
-                  }
-                >
-                  Apply Action
-                </Button>
-              </div>
-              {actionPreview ? (
-                <p
-                  data-testid='chat-action-preview'
-                  className='text-sm text-muted-foreground'
-                >
-                  Preview {actionPreview.id}: {actionPreview.action} (
-                  {actionPreviewStatusLabel}) via{' '}
-                  {String(
-                    actionPreview.payload?.assistant_provider ?? 'openai'
-                  )}{' '}
-                  /{' '}
-                  {String(
-                    actionPreview.payload?.assistant_model ?? 'gpt-4o-mini'
-                  )}
-                  {actionPreviewTargetSummary
-                    ? ` - ${actionPreviewTargetSummary}`
-                    : ''}
-                </p>
-              ) : null}
-              {applyResult ? (
-                <p data-testid='chat-action-apply-result' className='text-sm'>
-                  {applyResultSummary}
-                </p>
-              ) : null}
-              {applyNotice ? (
-                <p
-                  data-testid='chat-action-apply-notice'
-                  className='text-sm text-muted-foreground'
-                >
-                  {applyNotice}
-                </p>
-              ) : null}
-            </div>
+                <div className='mt-4 space-y-3 rounded-md border p-3'>
+                  <p className='text-sm font-medium'>Attachments</p>
+                  <div className='flex items-center gap-2'>
+                    <Input
+                      type='file'
+                      data-testid='chat-attachment-input'
+                      disabled={!selectedThreadId}
+                      onChange={(event) =>
+                        setPendingAttachment(event.target.files?.[0] ?? null)
+                      }
+                    />
+                    <Button
+                      type='button'
+                      data-testid='chat-upload-attachment-button'
+                      disabled={!selectedThreadId || !pendingAttachment}
+                      onClick={() => void uploadAttachment()}
+                    >
+                      Upload
+                    </Button>
+                  </div>
+                  <div
+                    data-testid='chat-attachment-list'
+                    className='space-y-1 text-sm'
+                  >
+                    {attachments.length === 0 ? (
+                      <p className='text-muted-foreground'>
+                        No attachments uploaded.
+                      </p>
+                    ) : (
+                      attachments.map((attachment) => (
+                        <p key={attachment.id}>{attachment.filename}</p>
+                      ))
+                    )}
+                  </div>
+                </div>
+
+                <div className='mt-4 space-y-3 rounded-md border p-3'>
+                  <div className='flex flex-wrap items-start justify-between gap-2'>
+                    <p className='text-sm font-medium'>Action Preview</p>
+                    <p
+                      className='rounded-md border bg-muted/30 px-2 py-1 text-xs text-muted-foreground'
+                      data-testid='chat-assistant-defaults'
+                    >
+                      Assistant default: {assistantDefaults.provider} /{' '}
+                      {assistantDefaults.model}
+                    </p>
+                  </div>
+                  <label className='grid gap-1 text-sm'>
+                    <span>Action Mode</span>
+                    <select
+                      data-testid='chat-preview-action-mode'
+                      className='h-9 rounded-md border bg-background px-3'
+                      value={actionMode}
+                      onChange={(event) =>
+                        setActionMode(
+                          event.target.value as
+                            | 'create_inventory_item'
+                            | 'create_wishlist_entry'
+                            | 'update_inventory_item'
+                            | 'assign_collection_item'
+                        )
+                      }
+                      disabled={!selectedThreadId}
+                    >
+                      <option value='create_inventory_item'>
+                        create_inventory_item
+                      </option>
+                      <option value='create_wishlist_entry'>
+                        create_wishlist_entry
+                      </option>
+                      <option value='update_inventory_item'>
+                        update_inventory_item
+                      </option>
+                      <option value='assign_collection_item'>
+                        assign_collection_item
+                      </option>
+                    </select>
+                  </label>
+                  {actionMode === 'update_inventory_item' ||
+                  actionMode === 'assign_collection_item' ? (
+                    <Input
+                      data-testid='chat-preview-target-item-id'
+                      value={actionTargetItemID}
+                      onChange={(event) =>
+                        setActionTargetItemID(event.target.value)
+                      }
+                      placeholder='Existing item ID'
+                      disabled={!selectedThreadId}
+                    />
+                  ) : null}
+                  {actionMode === 'assign_collection_item' ? (
+                    <Input
+                      data-testid='chat-preview-collection-name'
+                      value={actionCollectionName}
+                      onChange={(event) =>
+                        setActionCollectionName(event.target.value)
+                      }
+                      placeholder='Collection name'
+                      disabled={!selectedThreadId}
+                    />
+                  ) : null}
+                  <div className='grid gap-2 sm:grid-cols-2'>
+                    <Input
+                      data-testid='chat-preview-part-number'
+                      value={actionPartNumber}
+                      onChange={(event) =>
+                        setActionPartNumber(event.target.value)
+                      }
+                      placeholder='Part number'
+                      disabled={!selectedThreadId}
+                    />
+                    <Input
+                      data-testid='chat-preview-title'
+                      value={actionTitle}
+                      onChange={(event) => setActionTitle(event.target.value)}
+                      placeholder='Item title'
+                      disabled={!selectedThreadId}
+                    />
+                  </div>
+                  <div className='flex flex-wrap gap-2'>
+                    <Button
+                      type='button'
+                      data-testid='chat-preview-action-button'
+                      onClick={() => void previewCreateItemAction()}
+                      disabled={previewDisabled}
+                    >
+                      Preview Action
+                    </Button>
+                    <Button
+                      type='button'
+                      variant='outline'
+                      data-testid='chat-apply-action-button'
+                      onClick={() => setConfirmApplyOpen(true)}
+                      disabled={
+                        !selectedThreadId ||
+                        !actionPreview?.id ||
+                        actionPreviewStatusLabel !== 'pending'
+                      }
+                    >
+                      Apply Action
+                    </Button>
+                  </div>
+                  {actionPreview ? (
+                    <p
+                      data-testid='chat-action-preview'
+                      className='text-sm text-muted-foreground'
+                    >
+                      Preview {actionPreview.id}: {actionPreview.action} (
+                      {actionPreviewStatusLabel}) via{' '}
+                      {String(
+                        actionPreview.payload?.assistant_provider ?? 'openai'
+                      )}{' '}
+                      /{' '}
+                      {String(
+                        actionPreview.payload?.assistant_model ?? 'gpt-4o-mini'
+                      )}
+                      {actionPreviewTargetSummary
+                        ? ` - ${actionPreviewTargetSummary}`
+                        : ''}
+                    </p>
+                  ) : null}
+                  {applyResult ? (
+                    <p
+                      data-testid='chat-action-apply-result'
+                      className='text-sm'
+                    >
+                      {applyResultSummary}
+                    </p>
+                  ) : null}
+                  {applyNotice ? (
+                    <p
+                      data-testid='chat-action-apply-notice'
+                      className='text-sm text-muted-foreground'
+                    >
+                      {applyNotice}
+                    </p>
+                  ) : null}
+                </div>
+              </>
+            )}
           </div>
         </section>
       </Main>


### PR DESCRIPTION
## Summary
- restores the `/chats` workspace to the original/example dark two-pane layout with a compact conversation rail and centered empty workspace state
- adds CHATS-WORKSPACE-004 to the chats workspace OpenSpec contract
- adds focused Cypress coverage for rail/search/row preview/empty-state layout parity

## Validation
- `openspec validate --all --strict --no-interactive` -> pass (11 passed, 0 failed), log `.work-agent/logs/1042-20260601-1330/openspec-validate.log`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/chats/chats-workspace/spec.cy.ts -Browser chrome -RequireE2EHooks -StartupTimeoutSec 90` -> pass (4 passing), log `.work-agent/logs/1042-20260601-1330/cypress-chats-workspace-fresh-runtime.log`
- push pre-push hook also passed OpenSpec and `go test ./internal/app -run TestAPIDocsSmoke` equivalent fast API docs smoke test output

## Runtime note
Initial Cypress attempts failed because stale listeners on 17880/17881 served a static directory listing at `/sign-in`; after recycling those listeners and starting the project-local Cabinet runtime, the focused spec passed.

Closes #1042