### PR TITLE
#1096 test(cypress): add API contract smoke preflight

### DIFF
--- a/cypress.ps1
+++ b/cypress.ps1
@@ -5,6 +5,7 @@ param(
   [switch]$NoServer,
   [switch]$ReuseServer,
   [switch]$RequireE2EHooks,
+  [switch]$ApiContractSmoke,
   [string]$RuntimeExecutablePath = "",
   [switch]$AllowTempRuntimePath,
   [switch]$SkipDependencyPrep,
@@ -99,6 +100,28 @@ function Get-SourceCommit([string]$repoRoot) {
     return ""
   }
   return ""
+}
+
+function Invoke-ApiContractSmoke([string]$repoRoot, [string]$url, [string]$logDir, [bool]$requireE2EHooks) {
+  $args = @(
+    "-NoLogo",
+    "-NoProfile",
+    "-File", (Join-Path $repoRoot "scripts\run-api-contract-smoke.ps1"),
+    "-BaseUrl", $url,
+    "-LogRoot", $logDir,
+    "-RunId", "cypress-preflight-$runStamp"
+  )
+  if ($requireE2EHooks) {
+    $args += "-RequireE2EHooks"
+  }
+
+  Write-Step "Running API contract smoke preflight."
+  & pwsh @args | ForEach-Object {
+    Write-Host $_
+  }
+  if ($LASTEXITCODE -ne 0) {
+    throw "API contract smoke preflight failed with exit code $LASTEXITCODE."
+  }
 }
 
 function Stop-PortListener([string]$url) {
@@ -433,6 +456,10 @@ try {
       Write-Step "Server is healthy."
       Assert-AppPreflight $BaseUrl
     }
+  }
+
+  if ($ApiContractSmoke) {
+    Invoke-ApiContractSmoke $repoRoot $BaseUrl ".work-agent\logs\api-contract-smoke" $RequireE2EHooks.IsPresent
   }
 
   Write-Step "Running Cypress spec: $specPath"

--- a/cypress.ps1
+++ b/cypress.ps1
@@ -309,6 +309,7 @@ function Write-RunSummary(
   $apiContractSmokeStatus = ""
   $apiContractSmokeCheckCount = $null
   $apiContractSmokeFailedCount = $null
+  $apiContractSmokeElapsedMs = $null
   $apiContractSmokeFailedChecks = @()
   if (-not [string]::IsNullOrWhiteSpace($apiContractSmokeSummaryPath) -and (Test-Path $apiContractSmokeSummaryPath)) {
     try {
@@ -321,6 +322,9 @@ function Write-RunSummary(
       }
       if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "failed_count") {
         $apiContractSmokeFailedCount = [int]$apiContractSmokeSummary.failed_count
+      }
+      if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "elapsed_ms") {
+        $apiContractSmokeElapsedMs = [int]$apiContractSmokeSummary.elapsed_ms
       }
       if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "failed_checks") {
         $apiContractSmokeFailedChecks = @($apiContractSmokeSummary.failed_checks)
@@ -352,6 +356,7 @@ function Write-RunSummary(
     api_contract_smoke_status = $apiContractSmokeStatus
     api_contract_smoke_check_count = $apiContractSmokeCheckCount
     api_contract_smoke_failed_count = $apiContractSmokeFailedCount
+    api_contract_smoke_elapsed_ms = $apiContractSmokeElapsedMs
     api_contract_smoke_failed_checks = $apiContractSmokeFailedChecks
     steps = $script:CypressStepEvents
   }

--- a/cypress.ps1
+++ b/cypress.ps1
@@ -309,6 +309,7 @@ function Write-RunSummary(
   $apiContractSmokeStatus = ""
   $apiContractSmokeCheckCount = $null
   $apiContractSmokeFailedCount = $null
+  $apiContractSmokeFailedChecks = @()
   if (-not [string]::IsNullOrWhiteSpace($apiContractSmokeSummaryPath) -and (Test-Path $apiContractSmokeSummaryPath)) {
     try {
       $apiContractSmokeSummary = Get-Content -Raw -LiteralPath $apiContractSmokeSummaryPath | ConvertFrom-Json
@@ -320,6 +321,9 @@ function Write-RunSummary(
       }
       if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "failed_count") {
         $apiContractSmokeFailedCount = [int]$apiContractSmokeSummary.failed_count
+      }
+      if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "failed_checks") {
+        $apiContractSmokeFailedChecks = @($apiContractSmokeSummary.failed_checks)
       }
     }
     catch {
@@ -348,6 +352,7 @@ function Write-RunSummary(
     api_contract_smoke_status = $apiContractSmokeStatus
     api_contract_smoke_check_count = $apiContractSmokeCheckCount
     api_contract_smoke_failed_count = $apiContractSmokeFailedCount
+    api_contract_smoke_failed_checks = $apiContractSmokeFailedChecks
     steps = $script:CypressStepEvents
   }
 

--- a/cypress.ps1
+++ b/cypress.ps1
@@ -103,13 +103,16 @@ function Get-SourceCommit([string]$repoRoot) {
 }
 
 function Invoke-ApiContractSmoke([string]$repoRoot, [string]$url, [string]$logDir, [bool]$requireE2EHooks) {
+  $runId = "cypress-preflight-$runStamp"
+  $resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($logDir)) { $logDir } else { Join-Path $repoRoot $logDir }
+  $summaryPath = Join-Path (Join-Path $resolvedLogRoot $runId) "api-contract-smoke.summary.json"
   $args = @(
     "-NoLogo",
     "-NoProfile",
     "-File", (Join-Path $repoRoot "scripts\run-api-contract-smoke.ps1"),
     "-BaseUrl", $url,
     "-LogRoot", $logDir,
-    "-RunId", "cypress-preflight-$runStamp"
+    "-RunId", $runId
   )
   if ($requireE2EHooks) {
     $args += "-RequireE2EHooks"
@@ -122,6 +125,8 @@ function Invoke-ApiContractSmoke([string]$repoRoot, [string]$url, [string]$logDi
   if ($LASTEXITCODE -ne 0) {
     throw "API contract smoke preflight failed with exit code $LASTEXITCODE."
   }
+  Write-Step "API contract smoke summary: $summaryPath"
+  return $summaryPath
 }
 
 function Stop-PortListener([string]$url) {
@@ -296,6 +301,7 @@ function Write-RunSummary(
   [string]$runtimeExecutablePath,
   [string]$sourceCommit,
   [string]$logPath,
+  [string]$apiContractSmokeSummaryPath,
   [bool]$startedServer
 ) {
   $summary = [ordered]@{
@@ -315,6 +321,7 @@ function Write-RunSummary(
     source_commit = $sourceCommit
     started_server = $startedServer
     log_path = $logPath
+    api_contract_smoke_summary_path = $apiContractSmokeSummaryPath
     steps = $script:CypressStepEvents
   }
 
@@ -386,6 +393,7 @@ if ((Test-IsEphemeralRuntimePath $resolvedRuntimeExecutablePath) -and -not $Allo
 
 $serverProc = $null
 $startedServer = $false
+$apiContractSmokeSummaryPath = ""
 $exitCode = 1
 $runError = $null
 
@@ -459,7 +467,7 @@ try {
   }
 
   if ($ApiContractSmoke) {
-    Invoke-ApiContractSmoke $repoRoot $BaseUrl ".work-agent\logs\api-contract-smoke" $RequireE2EHooks.IsPresent
+    $apiContractSmokeSummaryPath = Invoke-ApiContractSmoke $repoRoot $BaseUrl ".work-agent\logs\api-contract-smoke" $RequireE2EHooks.IsPresent
   }
 
   Write-Step "Running Cypress spec: $specPath"
@@ -522,6 +530,7 @@ finally {
     -runtimeExecutablePath $resolvedRuntimeExecutablePath `
     -sourceCommit $sourceCommit `
     -logPath $logPath `
+    -apiContractSmokeSummaryPath $apiContractSmokeSummaryPath `
     -startedServer $startedServer
   Write-Step "Run summary written: $summaryPath"
   if ($transcriptStarted) {

--- a/cypress.ps1
+++ b/cypress.ps1
@@ -18,6 +18,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $script:CypressStepEvents = @()
+$script:LastApiContractSmokeSummaryPath = ""
 
 function Write-Step([string]$msg) {
   $timestamp = (Get-Date).ToString("o")
@@ -106,6 +107,7 @@ function Invoke-ApiContractSmoke([string]$repoRoot, [string]$url, [string]$logDi
   $runId = "cypress-preflight-$runStamp"
   $resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($logDir)) { $logDir } else { Join-Path $repoRoot $logDir }
   $summaryPath = Join-Path (Join-Path $resolvedLogRoot $runId) "api-contract-smoke.summary.json"
+  $script:LastApiContractSmokeSummaryPath = $summaryPath
   $args = @(
     "-NoLogo",
     "-NoProfile",
@@ -506,6 +508,9 @@ try {
 catch {
   $runError = $_
   $exitCode = 1
+  if ([string]::IsNullOrWhiteSpace($apiContractSmokeSummaryPath)) {
+    $apiContractSmokeSummaryPath = $script:LastApiContractSmokeSummaryPath
+  }
   Write-Step "Run failed: $($_.Exception.Message)"
 }
 finally {

--- a/cypress.ps1
+++ b/cypress.ps1
@@ -307,12 +307,16 @@ function Write-RunSummary(
   [bool]$startedServer
 ) {
   $apiContractSmokeStatus = ""
+  $apiContractSmokeCheckCount = $null
   $apiContractSmokeFailedCount = $null
   if (-not [string]::IsNullOrWhiteSpace($apiContractSmokeSummaryPath) -and (Test-Path $apiContractSmokeSummaryPath)) {
     try {
       $apiContractSmokeSummary = Get-Content -Raw -LiteralPath $apiContractSmokeSummaryPath | ConvertFrom-Json
       if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "status") {
         $apiContractSmokeStatus = [string]$apiContractSmokeSummary.status
+      }
+      if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "check_count") {
+        $apiContractSmokeCheckCount = [int]$apiContractSmokeSummary.check_count
       }
       if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "failed_count") {
         $apiContractSmokeFailedCount = [int]$apiContractSmokeSummary.failed_count
@@ -342,6 +346,7 @@ function Write-RunSummary(
     log_path = $logPath
     api_contract_smoke_summary_path = $apiContractSmokeSummaryPath
     api_contract_smoke_status = $apiContractSmokeStatus
+    api_contract_smoke_check_count = $apiContractSmokeCheckCount
     api_contract_smoke_failed_count = $apiContractSmokeFailedCount
     steps = $script:CypressStepEvents
   }

--- a/cypress.ps1
+++ b/cypress.ps1
@@ -306,6 +306,23 @@ function Write-RunSummary(
   [string]$apiContractSmokeSummaryPath,
   [bool]$startedServer
 ) {
+  $apiContractSmokeStatus = ""
+  $apiContractSmokeFailedCount = $null
+  if (-not [string]::IsNullOrWhiteSpace($apiContractSmokeSummaryPath) -and (Test-Path $apiContractSmokeSummaryPath)) {
+    try {
+      $apiContractSmokeSummary = Get-Content -Raw -LiteralPath $apiContractSmokeSummaryPath | ConvertFrom-Json
+      if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "status") {
+        $apiContractSmokeStatus = [string]$apiContractSmokeSummary.status
+      }
+      if ($apiContractSmokeSummary.PSObject.Properties.Name -contains "failed_count") {
+        $apiContractSmokeFailedCount = [int]$apiContractSmokeSummary.failed_count
+      }
+    }
+    catch {
+      Write-Step "Unable to read API contract smoke summary metadata: $($_.Exception.Message)"
+    }
+  }
+
   $summary = [ordered]@{
     timestamp = (Get-Date).ToString("o")
     exit_code = $exitCode
@@ -324,6 +341,8 @@ function Write-RunSummary(
     started_server = $startedServer
     log_path = $logPath
     api_contract_smoke_summary_path = $apiContractSmokeSummaryPath
+    api_contract_smoke_status = $apiContractSmokeStatus
+    api_contract_smoke_failed_count = $apiContractSmokeFailedCount
     steps = $script:CypressStepEvents
   }
 

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -127,6 +127,21 @@ function Get-SourceCommit([string]$repoRoot) {
   return ""
 }
 
+function Get-BaseUrlMetadata([string]$baseUrl) {
+  $metadata = [ordered]@{
+    host = ""
+    port = 0
+  }
+  try {
+    $uri = [System.Uri]$baseUrl
+    $metadata.host = $uri.Host
+    $metadata.port = $uri.Port
+  }
+  catch {
+  }
+  return $metadata
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $runStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 $runStamp = if ([string]::IsNullOrWhiteSpace($RunId)) { Get-Date -Format "yyyyMMdd-HHmmss" } else { ConvertTo-SafeSegment $RunId }
@@ -134,6 +149,7 @@ $resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($LogRoot)) { $LogRoot } el
 $runLogDir = Join-Path $resolvedLogRoot $runStamp
 $summaryPath = Join-Path $runLogDir "api-contract-smoke.summary.json"
 $sourceCommit = Get-SourceCommit $repoRoot
+$baseUrlMetadata = Get-BaseUrlMetadata $BaseUrl
 
 New-Item -ItemType Directory -Force -Path $runLogDir | Out-Null
 
@@ -199,6 +215,8 @@ $summary = [ordered]@{
   exit_code = $exitCode
   run_id = $runStamp
   base_url = $BaseUrl
+  base_url_host = $baseUrlMetadata.host
+  base_url_port = $baseUrlMetadata.port
   source_commit = $sourceCommit
   timeout_sec = $TimeoutSec
   elapsed_ms = [int]$runStopwatch.ElapsedMilliseconds

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -102,7 +102,7 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
     if ($check.ContainsKey("RuntimeHostMustMatchBaseUrl") -and $check.RuntimeHostMustMatchBaseUrl) {
       $runtimeHost = [string]$jsonPayload.runtime_host
       $baseUrlHost = [string]$baseUrlMetadata.host
-      if (-not [string]::IsNullOrWhiteSpace($baseUrlHost) -and $runtimeHost -ne $baseUrlHost) {
+      if (-not (Test-RuntimeHostMatchesBaseUrl $runtimeHost $baseUrlHost)) {
         $result.error = "runtime_host $runtimeHost did not match BaseUrl host $baseUrlHost"
         $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
         return [pscustomobject]$result
@@ -164,6 +164,20 @@ function Get-BaseUrlMetadata([string]$baseUrl) {
   return $metadata
 }
 
+function Test-RuntimeHostMatchesBaseUrl([string]$runtimeHost, [string]$baseUrlHost) {
+  if ([string]::IsNullOrWhiteSpace($baseUrlHost)) {
+    return $true
+  }
+  if ($runtimeHost -eq $baseUrlHost) {
+    return $true
+  }
+  $loopbackHosts = @("127.0.0.1", "localhost", "::1", "[::1]")
+  if (($runtimeHost -eq "0.0.0.0" -or $runtimeHost -eq "::") -and ($loopbackHosts -contains $baseUrlHost.ToLowerInvariant())) {
+    return $true
+  }
+  return $false
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $runStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 $runStamp = if ([string]::IsNullOrWhiteSpace($RunId)) { Get-Date -Format "yyyyMMdd-HHmmss" } else { ConvertTo-SafeSegment $RunId }
@@ -217,7 +231,6 @@ if ($RequireE2EHooks) {
     Path = "/api/test/reset"
     Status = 200
     Body = "{}"
-    ContentType = "json"
   }
 }
 

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -1,0 +1,177 @@
+param(
+  [string]$BaseUrl = "http://127.0.0.1:17880",
+  [string]$RunId = "",
+  [string]$LogRoot = ".work-agent\logs\api-contract-smoke",
+  [int]$TimeoutSec = 5,
+  [switch]$RequireE2EHooks
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-SafeSegment([string]$value) {
+  if ([string]::IsNullOrWhiteSpace($value)) {
+    return "run"
+  }
+  $safe = $value -replace '[^A-Za-z0-9._-]+', '-'
+  $safe = $safe.Trim('-')
+  if ([string]::IsNullOrWhiteSpace($safe)) {
+    return "run"
+  }
+  if ($safe.Length -gt 80) {
+    return $safe.Substring(0, 80)
+  }
+  return $safe
+}
+
+function Join-UrlPath([string]$baseUrl, [string]$path) {
+  return $baseUrl.TrimEnd("/") + "/" + $path.TrimStart("/")
+}
+
+function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeoutSec) {
+  $method = if ($check.ContainsKey("Method")) { $check.Method } else { "GET" }
+  $uri = Join-UrlPath $baseUrl $check.Path
+  $result = [ordered]@{
+    name = $check.Name
+    method = $method
+    path = $check.Path
+    url = $uri
+    expected_status = $check.Status
+    status = 0
+    passed = $false
+    error = ""
+  }
+
+  try {
+    $body = if ($check.ContainsKey("Body")) { $check.Body } else { $null }
+    $contentType = if ($body) { "application/json" } else { $null }
+    $response = Invoke-WebRequest -Uri $uri -Method $method -Body $body -ContentType $contentType -UseBasicParsing -TimeoutSec $timeoutSec
+    $result.status = [int]$response.StatusCode
+    if ([int]$response.StatusCode -ne [int]$check.Status) {
+      $result.error = "expected status $($check.Status), got $($response.StatusCode)"
+      return [pscustomobject]$result
+    }
+
+    if ($check.ContainsKey("ContentType")) {
+      $actualContentType = [string]$response.Headers["Content-Type"]
+      if (-not $actualContentType.ToLowerInvariant().Contains($check.ContentType.ToLowerInvariant())) {
+        $result.error = "expected content type containing $($check.ContentType), got $actualContentType"
+        return [pscustomobject]$result
+      }
+    }
+
+    $text = if ($response.Content -is [byte[]]) {
+      [System.Text.Encoding]::UTF8.GetString($response.Content)
+    } else {
+      [string]$response.Content
+    }
+    if ($check.ContainsKey("Contains") -and -not $text.Contains($check.Contains)) {
+      $result.error = "response body did not contain required marker $($check.Contains)"
+      return [pscustomobject]$result
+    }
+
+    if ($check.ContainsKey("Json") -and $check.Json) {
+      try {
+        $null = $text | ConvertFrom-Json
+      }
+      catch {
+        $result.error = "response body was not valid JSON: $($_.Exception.Message)"
+        return [pscustomobject]$result
+      }
+    }
+
+    $result.passed = $true
+    return [pscustomobject]$result
+  }
+  catch {
+    $statusCode = 0
+    if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    $result.status = $statusCode
+    $result.error = $_.Exception.Message
+    return [pscustomobject]$result
+  }
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$runStamp = if ([string]::IsNullOrWhiteSpace($RunId)) { Get-Date -Format "yyyyMMdd-HHmmss" } else { ConvertTo-SafeSegment $RunId }
+$resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($LogRoot)) { $LogRoot } else { Join-Path $repoRoot $LogRoot }
+$runLogDir = Join-Path $resolvedLogRoot $runStamp
+$summaryPath = Join-Path $runLogDir "api-contract-smoke.summary.json"
+
+New-Item -ItemType Directory -Force -Path $runLogDir | Out-Null
+
+$checks = @(
+  @{
+    Name = "healthz"
+    Method = "GET"
+    Path = "/healthz"
+    Status = 200
+  },
+  @{
+    Name = "runtime API"
+    Method = "GET"
+    Path = "/api/runtime"
+    Status = 200
+    ContentType = "json"
+    Json = $true
+  },
+  @{
+    Name = "OpenAPI YAML"
+    Method = "GET"
+    Path = "/api/openapi.yaml"
+    Status = 200
+    Contains = "openapi:"
+  },
+  @{
+    Name = "sign-in route"
+    Method = "GET"
+    Path = "/sign-in"
+    Status = 200
+    Contains = "<"
+  }
+)
+
+if ($RequireE2EHooks) {
+  $checks += @{
+    Name = "E2E reset hook"
+    Method = "POST"
+    Path = "/api/test/reset"
+    Status = 200
+    Body = "{}"
+    ContentType = "json"
+  }
+}
+
+Write-Host "[api-contract-smoke] Base URL: $BaseUrl"
+Write-Host "[api-contract-smoke] Summary: $summaryPath"
+
+$results = @()
+foreach ($check in $checks) {
+  $result = Invoke-ApiSmokeCheck $BaseUrl $check $TimeoutSec
+  $results += $result
+  $state = if ($result.passed) { "pass" } else { "fail" }
+  Write-Host "[api-contract-smoke] $state $($result.method) $($result.path) status=$($result.status)"
+}
+
+$failed = @($results | Where-Object { -not $_.passed })
+$exitCode = if ($failed.Count -gt 0) { 1 } else { 0 }
+$summary = [ordered]@{
+  timestamp = (Get-Date).ToString("o")
+  exit_code = $exitCode
+  base_url = $BaseUrl
+  check_count = $results.Count
+  failed_count = $failed.Count
+  require_e2e_hooks = $RequireE2EHooks.IsPresent
+  log_dir = $runLogDir
+  checks = $results
+}
+$summary | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
+
+if ($exitCode -ne 0) {
+  Write-Error "API contract smoke failed; summary written to $summaryPath"
+  exit $exitCode
+}
+
+Write-Host "[api-contract-smoke] All checks passed; summary written to $summaryPath"
+exit 0

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -93,11 +93,24 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
   }
 }
 
+function Get-SourceCommit([string]$repoRoot) {
+  try {
+    $commit = (& git -C $repoRoot rev-parse HEAD 2>$null)
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($commit)) {
+      return [string]$commit
+    }
+  }
+  catch {
+  }
+  return ""
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $runStamp = if ([string]::IsNullOrWhiteSpace($RunId)) { Get-Date -Format "yyyyMMdd-HHmmss" } else { ConvertTo-SafeSegment $RunId }
 $resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($LogRoot)) { $LogRoot } else { Join-Path $repoRoot $LogRoot }
 $runLogDir = Join-Path $resolvedLogRoot $runStamp
 $summaryPath = Join-Path $runLogDir "api-contract-smoke.summary.json"
+$sourceCommit = Get-SourceCommit $repoRoot
 
 New-Item -ItemType Directory -Force -Path $runLogDir | Out-Null
 
@@ -161,6 +174,7 @@ $summary = [ordered]@{
   timestamp = (Get-Date).ToString("o")
   exit_code = $exitCode
   base_url = $BaseUrl
+  source_commit = $sourceCommit
   check_count = $results.Count
   failed_count = $failed.Count
   require_e2e_hooks = $RequireE2EHooks.IsPresent

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -209,6 +209,15 @@ foreach ($check in $checks) {
 }
 
 $failed = @($results | Where-Object { -not $_.passed })
+$failedChecks = @($failed | ForEach-Object {
+  [ordered]@{
+    name = $_.name
+    method = $_.method
+    path = $_.path
+    status = $_.status
+    error = $_.error
+  }
+})
 $exitCode = if ($failed.Count -gt 0) { 1 } else { 0 }
 $summary = [ordered]@{
   timestamp = (Get-Date).ToString("o")
@@ -222,6 +231,7 @@ $summary = [ordered]@{
   elapsed_ms = [int]$runStopwatch.ElapsedMilliseconds
   check_count = $results.Count
   failed_count = $failed.Count
+  failed_checks = $failedChecks
   require_e2e_hooks = $RequireE2EHooks.IsPresent
   log_dir = $runLogDir
   summary_path = $summaryPath

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -87,13 +87,16 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
     }
 
     if ($check.ContainsKey("JsonFields")) {
+      $jsonFields = [ordered]@{}
       foreach ($field in $check.JsonFields) {
         if (-not $jsonPayload -or -not ($jsonPayload.PSObject.Properties.Name -contains $field)) {
           $result.error = "response JSON did not contain required field $field"
           $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
           return [pscustomobject]$result
         }
+        $jsonFields[$field] = $jsonPayload.$field
       }
+      $result.json_fields = $jsonFields
     }
 
     $result.passed = $true

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -121,6 +121,7 @@ $checks = @(
     Method = "GET"
     Path = "/api/openapi.yaml"
     Status = 200
+    ContentType = "yaml"
     Contains = "openapi:"
   },
   @{

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -28,6 +28,7 @@ function Join-UrlPath([string]$baseUrl, [string]$path) {
 }
 
 function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeoutSec) {
+  $checkStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
   $method = if ($check.ContainsKey("Method")) { $check.Method } else { "GET" }
   $uri = Join-UrlPath $baseUrl $check.Path
   $result = [ordered]@{
@@ -38,6 +39,7 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
     expected_status = $check.Status
     status = 0
     passed = $false
+    duration_ms = 0
     error = ""
   }
 
@@ -48,6 +50,7 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
     $result.status = [int]$response.StatusCode
     if ([int]$response.StatusCode -ne [int]$check.Status) {
       $result.error = "expected status $($check.Status), got $($response.StatusCode)"
+      $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
       return [pscustomobject]$result
     }
 
@@ -55,6 +58,7 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
       $actualContentType = [string]$response.Headers["Content-Type"]
       if (-not $actualContentType.ToLowerInvariant().Contains($check.ContentType.ToLowerInvariant())) {
         $result.error = "expected content type containing $($check.ContentType), got $actualContentType"
+        $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
         return [pscustomobject]$result
       }
     }
@@ -66,6 +70,7 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
     }
     if ($check.ContainsKey("Contains") -and -not $text.Contains($check.Contains)) {
       $result.error = "response body did not contain required marker $($check.Contains)"
+      $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
       return [pscustomobject]$result
     }
 
@@ -75,11 +80,13 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
       }
       catch {
         $result.error = "response body was not valid JSON: $($_.Exception.Message)"
+        $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
         return [pscustomobject]$result
       }
     }
 
     $result.passed = $true
+    $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
     return [pscustomobject]$result
   }
   catch {
@@ -89,6 +96,7 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
     }
     $result.status = $statusCode
     $result.error = $_.Exception.Message
+    $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
     return [pscustomobject]$result
   }
 }
@@ -106,6 +114,7 @@ function Get-SourceCommit([string]$repoRoot) {
 }
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
+$runStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 $runStamp = if ([string]::IsNullOrWhiteSpace($RunId)) { Get-Date -Format "yyyyMMdd-HHmmss" } else { ConvertTo-SafeSegment $RunId }
 $resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($LogRoot)) { $LogRoot } else { Join-Path $repoRoot $LogRoot }
 $runLogDir = Join-Path $resolvedLogRoot $runStamp
@@ -175,6 +184,7 @@ $summary = [ordered]@{
   exit_code = $exitCode
   base_url = $BaseUrl
   source_commit = $sourceCommit
+  elapsed_ms = [int]$runStopwatch.ElapsedMilliseconds
   check_count = $results.Count
   failed_count = $failed.Count
   require_e2e_hooks = $RequireE2EHooks.IsPresent

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -149,11 +149,13 @@ function Get-SourceCommit([string]$repoRoot) {
 
 function Get-BaseUrlMetadata([string]$baseUrl) {
   $metadata = [ordered]@{
+    scheme = ""
     host = ""
     port = 0
   }
   try {
     $uri = [System.Uri]$baseUrl
+    $metadata.scheme = $uri.Scheme
     $metadata.host = $uri.Host
     $metadata.port = $uri.Port
   }
@@ -248,6 +250,7 @@ $summary = [ordered]@{
   status = $status
   run_id = $runStamp
   base_url = $BaseUrl
+  base_url_scheme = $baseUrlMetadata.scheme
   base_url_host = $baseUrlMetadata.host
   base_url_port = $baseUrlMetadata.port
   source_commit = $sourceCommit

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -27,7 +27,7 @@ function Join-UrlPath([string]$baseUrl, [string]$path) {
   return $baseUrl.TrimEnd("/") + "/" + $path.TrimStart("/")
 }
 
-function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeoutSec) {
+function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeoutSec, $baseUrlMetadata) {
   $checkStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
   $method = if ($check.ContainsKey("Method")) { $check.Method } else { "GET" }
   $uri = Join-UrlPath $baseUrl $check.Path
@@ -99,6 +99,16 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
       $result.json_fields = $jsonFields
     }
 
+    if ($check.ContainsKey("RuntimePortMustMatchBaseUrl") -and $check.RuntimePortMustMatchBaseUrl) {
+      $runtimePort = [int]$jsonPayload.runtime_port
+      $baseUrlPort = [int]$baseUrlMetadata.port
+      if ($baseUrlPort -gt 0 -and $runtimePort -ne $baseUrlPort) {
+        $result.error = "runtime_port $runtimePort did not match BaseUrl port $baseUrlPort"
+        $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
+        return [pscustomobject]$result
+      }
+    }
+
     $result.passed = $true
     $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
     return [pscustomobject]$result
@@ -168,6 +178,7 @@ $checks = @(
     ContentType = "json"
     Json = $true
     JsonFields = @("app_version", "runtime_host", "runtime_port")
+    RuntimePortMustMatchBaseUrl = $true
   },
   @{
     Name = "OpenAPI YAML"
@@ -202,7 +213,7 @@ Write-Host "[api-contract-smoke] Summary: $summaryPath"
 
 $results = @()
 foreach ($check in $checks) {
-  $result = Invoke-ApiSmokeCheck $BaseUrl $check $TimeoutSec
+  $result = Invoke-ApiSmokeCheck $BaseUrl $check $TimeoutSec $baseUrlMetadata
   $results += $result
   $state = if ($result.passed) { "pass" } else { "fail" }
   Write-Host "[api-contract-smoke] $state $($result.method) $($result.path) status=$($result.status)"

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -241,9 +241,11 @@ $failedChecks = @($failed | ForEach-Object {
   }
 })
 $exitCode = if ($failed.Count -gt 0) { 1 } else { 0 }
+$status = if ($exitCode -eq 0) { "passed" } else { "failed" }
 $summary = [ordered]@{
   timestamp = (Get-Date).ToString("o")
   exit_code = $exitCode
+  status = $status
   run_id = $runStamp
   base_url = $BaseUrl
   base_url_host = $baseUrlMetadata.host

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -74,14 +74,25 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
       return [pscustomobject]$result
     }
 
+    $jsonPayload = $null
     if ($check.ContainsKey("Json") -and $check.Json) {
       try {
-        $null = $text | ConvertFrom-Json
+        $jsonPayload = $text | ConvertFrom-Json
       }
       catch {
         $result.error = "response body was not valid JSON: $($_.Exception.Message)"
         $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
         return [pscustomobject]$result
+      }
+    }
+
+    if ($check.ContainsKey("JsonFields")) {
+      foreach ($field in $check.JsonFields) {
+        if (-not $jsonPayload -or -not ($jsonPayload.PSObject.Properties.Name -contains $field)) {
+          $result.error = "response JSON did not contain required field $field"
+          $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
+          return [pscustomobject]$result
+        }
       }
     }
 
@@ -137,6 +148,7 @@ $checks = @(
     Status = 200
     ContentType = "json"
     Json = $true
+    JsonFields = @("app_version", "runtime_host", "runtime_port")
   },
   @{
     Name = "OpenAPI YAML"

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -99,6 +99,16 @@ function Invoke-ApiSmokeCheck([string]$baseUrl, [hashtable]$check, [int]$timeout
       $result.json_fields = $jsonFields
     }
 
+    if ($check.ContainsKey("RuntimeHostMustMatchBaseUrl") -and $check.RuntimeHostMustMatchBaseUrl) {
+      $runtimeHost = [string]$jsonPayload.runtime_host
+      $baseUrlHost = [string]$baseUrlMetadata.host
+      if (-not [string]::IsNullOrWhiteSpace($baseUrlHost) -and $runtimeHost -ne $baseUrlHost) {
+        $result.error = "runtime_host $runtimeHost did not match BaseUrl host $baseUrlHost"
+        $result.duration_ms = [int]$checkStopwatch.ElapsedMilliseconds
+        return [pscustomobject]$result
+      }
+    }
+
     if ($check.ContainsKey("RuntimePortMustMatchBaseUrl") -and $check.RuntimePortMustMatchBaseUrl) {
       $runtimePort = [int]$jsonPayload.runtime_port
       $baseUrlPort = [int]$baseUrlMetadata.port
@@ -178,6 +188,7 @@ $checks = @(
     ContentType = "json"
     Json = $true
     JsonFields = @("app_version", "runtime_host", "runtime_port")
+    RuntimeHostMustMatchBaseUrl = $true
     RuntimePortMustMatchBaseUrl = $true
   },
   @{

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -238,7 +238,9 @@ $failedChecks = @($failed | ForEach-Object {
     name = $_.name
     method = $_.method
     path = $_.path
+    expected_status = $_.expected_status
     status = $_.status
+    duration_ms = $_.duration_ms
     error = $_.error
   }
 })

--- a/scripts/run-api-contract-smoke.ps1
+++ b/scripts/run-api-contract-smoke.ps1
@@ -182,13 +182,16 @@ $exitCode = if ($failed.Count -gt 0) { 1 } else { 0 }
 $summary = [ordered]@{
   timestamp = (Get-Date).ToString("o")
   exit_code = $exitCode
+  run_id = $runStamp
   base_url = $BaseUrl
   source_commit = $sourceCommit
+  timeout_sec = $TimeoutSec
   elapsed_ms = [int]$runStopwatch.ElapsedMilliseconds
   check_count = $results.Count
   failed_count = $failed.Count
   require_e2e_hooks = $RequireE2EHooks.IsPresent
   log_dir = $runLogDir
+  summary_path = $summaryPath
   checks = $results
 }
 $summary | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $summaryPath -Encoding UTF8

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -302,6 +302,88 @@ func TestApiContractSmokeScriptDiagnosesSignInContentMismatch(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesOpenAPIContentTypeMismatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-openapi-content-type-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read OpenAPI content-type failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode OpenAPI content-type failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected OpenAPI content-type failure summary: %+v", summary)
+	}
+
+	var openAPICheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "OpenAPI YAML" {
+			openAPICheck = check
+			break
+		}
+	}
+	if openAPICheck.Name == "" {
+		t.Fatalf("summary did not include OpenAPI YAML check: %+v", summary.Checks)
+	}
+	if openAPICheck.Passed || openAPICheck.Status != http.StatusOK {
+		t.Fatalf("OpenAPI check did not record content-type mismatch: %+v", openAPICheck)
+	}
+	if !strings.Contains(openAPICheck.Error, "content type") {
+		t.Fatalf("OpenAPI content-type failure was not diagnostic: %q", openAPICheck.Error)
+	}
+}
+
 func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -1072,6 +1072,7 @@ func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
 		"API contract smoke summary:",
 		"$script:LastApiContractSmokeSummaryPath = $summaryPath",
 		"api_contract_smoke_summary_path",
+		"api_contract_smoke_check_count",
 		"$apiContractSmokeSummaryPath = $script:LastApiContractSmokeSummaryPath",
 		"API contract smoke preflight failed",
 	} {
@@ -1133,6 +1134,7 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 		Error                       string `json:"error"`
 		ApiContractSmokeSummaryPath string `json:"api_contract_smoke_summary_path"`
 		ApiContractSmokeStatus      string `json:"api_contract_smoke_status"`
+		ApiContractSmokeCheckCount  *int   `json:"api_contract_smoke_check_count"`
 		ApiContractSmokeFailedCount *int   `json:"api_contract_smoke_failed_count"`
 	}
 	if err := json.Unmarshal(raw, &cypressSummary); err != nil {
@@ -1150,6 +1152,9 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 	if cypressSummary.ApiContractSmokeStatus != "failed" || cypressSummary.ApiContractSmokeFailedCount == nil || *cypressSummary.ApiContractSmokeFailedCount == 0 {
 		t.Fatalf("Cypress summary did not include compact API smoke failure metadata: %+v", cypressSummary)
 	}
+	if cypressSummary.ApiContractSmokeCheckCount == nil || *cypressSummary.ApiContractSmokeCheckCount == 0 {
+		t.Fatalf("Cypress summary did not include API smoke check count metadata: %+v", cypressSummary)
+	}
 	if _, err := os.Stat(cypressSummary.ApiContractSmokeSummaryPath); err != nil {
 		t.Fatalf("API smoke summary path from Cypress summary was not readable: %v", err)
 	}
@@ -1161,6 +1166,7 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 	var apiSummary struct {
 		ExitCode    int    `json:"exit_code"`
 		Status      string `json:"status"`
+		CheckCount  int    `json:"check_count"`
 		FailedCount int    `json:"failed_count"`
 	}
 	if err := json.Unmarshal(apiRaw, &apiSummary); err != nil {
@@ -1168,6 +1174,9 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 	}
 	if apiSummary.ExitCode != 1 || apiSummary.Status != "failed" || apiSummary.FailedCount == 0 {
 		t.Fatalf("API smoke summary did not record preflight failure: %+v", apiSummary)
+	}
+	if *cypressSummary.ApiContractSmokeCheckCount != apiSummary.CheckCount {
+		t.Fatalf("Cypress summary API smoke check count = %d, want nested summary count %d", *cypressSummary.ApiContractSmokeCheckCount, apiSummary.CheckCount)
 	}
 }
 

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -1130,12 +1130,18 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 		t.Fatalf("read Cypress summary: %v", err)
 	}
 	var cypressSummary struct {
-		ExitCode                    int    `json:"exit_code"`
-		Error                       string `json:"error"`
-		ApiContractSmokeSummaryPath string `json:"api_contract_smoke_summary_path"`
-		ApiContractSmokeStatus      string `json:"api_contract_smoke_status"`
-		ApiContractSmokeCheckCount  *int   `json:"api_contract_smoke_check_count"`
-		ApiContractSmokeFailedCount *int   `json:"api_contract_smoke_failed_count"`
+		ExitCode                     int    `json:"exit_code"`
+		Error                        string `json:"error"`
+		ApiContractSmokeSummaryPath  string `json:"api_contract_smoke_summary_path"`
+		ApiContractSmokeStatus       string `json:"api_contract_smoke_status"`
+		ApiContractSmokeCheckCount   *int   `json:"api_contract_smoke_check_count"`
+		ApiContractSmokeFailedCount  *int   `json:"api_contract_smoke_failed_count"`
+		ApiContractSmokeFailedChecks []struct {
+			Name   string `json:"name"`
+			Method string `json:"method"`
+			Path   string `json:"path"`
+			Error  string `json:"error"`
+		} `json:"api_contract_smoke_failed_checks"`
 	}
 	if err := json.Unmarshal(raw, &cypressSummary); err != nil {
 		t.Fatalf("decode Cypress summary: %v\n%s", err, string(raw))
@@ -1154,6 +1160,13 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 	}
 	if cypressSummary.ApiContractSmokeCheckCount == nil || *cypressSummary.ApiContractSmokeCheckCount == 0 {
 		t.Fatalf("Cypress summary did not include API smoke check count metadata: %+v", cypressSummary)
+	}
+	if len(cypressSummary.ApiContractSmokeFailedChecks) == 0 {
+		t.Fatalf("Cypress summary did not surface compact API smoke failed checks: %+v", cypressSummary)
+	}
+	failedCheck := cypressSummary.ApiContractSmokeFailedChecks[0]
+	if failedCheck.Name != "healthz" || failedCheck.Method != http.MethodGet || failedCheck.Path != "/healthz" || failedCheck.Error == "" {
+		t.Fatalf("Cypress summary failed check was not diagnostic: %+v", failedCheck)
 	}
 	if _, err := os.Stat(cypressSummary.ApiContractSmokeSummaryPath); err != nil {
 		t.Fatalf("API smoke summary path from Cypress summary was not readable: %v", err)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -59,6 +59,7 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 
 	var summary struct {
 		ExitCode     int    `json:"exit_code"`
+		Status       string `json:"status"`
 		RunID        string `json:"run_id"`
 		BaseURLHost  string `json:"base_url_host"`
 		BaseURLPort  int    `json:"base_url_port"`
@@ -82,6 +83,9 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	}
 	if summary.ExitCode != 0 || summary.CheckCount != 4 || summary.FailedCount != 0 {
 		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if summary.Status != "passed" {
+		t.Fatalf("summary status = %q, want passed", summary.Status)
 	}
 	if len(summary.FailedChecks) != 0 {
 		t.Fatalf("passing summary unexpectedly listed failed checks: %+v", summary.FailedChecks)
@@ -161,9 +165,10 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 	}
 
 	var summary struct {
-		ExitCode     int `json:"exit_code"`
-		CheckCount   int `json:"check_count"`
-		FailedCount  int `json:"failed_count"`
+		ExitCode     int    `json:"exit_code"`
+		Status       string `json:"status"`
+		CheckCount   int    `json:"check_count"`
+		FailedCount  int    `json:"failed_count"`
 		FailedChecks []struct {
 			Name   string `json:"name"`
 			Method string `json:"method"`
@@ -182,6 +187,9 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 	}
 	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
 		t.Fatalf("unexpected failure summary: %+v", summary)
+	}
+	if summary.Status != "failed" {
+		t.Fatalf("failure summary status = %q, want failed", summary.Status)
 	}
 	if len(summary.FailedChecks) != 1 {
 		t.Fatalf("failure summary did not include compact failed_checks triage: %+v", summary.FailedChecks)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -58,14 +58,15 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	}
 
 	var summary struct {
-		ExitCode     int    `json:"exit_code"`
-		Status       string `json:"status"`
-		RunID        string `json:"run_id"`
-		BaseURLHost  string `json:"base_url_host"`
-		BaseURLPort  int    `json:"base_url_port"`
-		CheckCount   int    `json:"check_count"`
-		FailedCount  int    `json:"failed_count"`
-		FailedChecks []struct {
+		ExitCode      int    `json:"exit_code"`
+		Status        string `json:"status"`
+		RunID         string `json:"run_id"`
+		BaseURLScheme string `json:"base_url_scheme"`
+		BaseURLHost   string `json:"base_url_host"`
+		BaseURLPort   int    `json:"base_url_port"`
+		CheckCount    int    `json:"check_count"`
+		FailedCount   int    `json:"failed_count"`
+		FailedChecks  []struct {
 			Name string `json:"name"`
 		} `json:"failed_checks"`
 		SourceCommit string `json:"source_commit"`
@@ -97,8 +98,8 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse mock runtime URL: %v", err)
 	}
-	if summary.BaseURLHost != mockRuntimeURL.Hostname() || fmt.Sprint(summary.BaseURLPort) != mockRuntimeURL.Port() {
-		t.Fatalf("summary base URL metadata = %s:%d, want %s:%s", summary.BaseURLHost, summary.BaseURLPort, mockRuntimeURL.Hostname(), mockRuntimeURL.Port())
+	if summary.BaseURLScheme != mockRuntimeURL.Scheme || summary.BaseURLHost != mockRuntimeURL.Hostname() || fmt.Sprint(summary.BaseURLPort) != mockRuntimeURL.Port() {
+		t.Fatalf("summary base URL metadata = %s://%s:%d, want %s://%s:%s", summary.BaseURLScheme, summary.BaseURLHost, summary.BaseURLPort, mockRuntimeURL.Scheme, mockRuntimeURL.Hostname(), mockRuntimeURL.Port())
 	}
 	if summary.ElapsedMS == nil || *summary.ElapsedMS < 0 {
 		t.Fatalf("summary did not include elapsed_ms timing: %+v", summary)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -547,6 +547,93 @@ func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesMissingE2EHooksWhenRequired(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-missing-e2e-hooks"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID, "-RequireE2EHooks")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed without E2E hooks\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read missing E2E hooks summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode        int  `json:"exit_code"`
+		CheckCount      int  `json:"check_count"`
+		FailedCount     int  `json:"failed_count"`
+		RequireE2EHooks bool `json:"require_e2e_hooks"`
+		Checks          []struct {
+			Name   string `json:"name"`
+			Method string `json:"method"`
+			Path   string `json:"path"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode missing E2E hooks summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 5 || summary.FailedCount != 1 || !summary.RequireE2EHooks {
+		t.Fatalf("unexpected missing E2E hooks summary: %+v", summary)
+	}
+
+	var resetHookCheck struct {
+		Name   string `json:"name"`
+		Method string `json:"method"`
+		Path   string `json:"path"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "E2E reset hook" {
+			resetHookCheck = check
+			break
+		}
+	}
+	if resetHookCheck.Name == "" {
+		t.Fatalf("summary did not include E2E reset hook check: %+v", summary.Checks)
+	}
+	if resetHookCheck.Passed || resetHookCheck.Method != http.MethodPost || resetHookCheck.Path != "/api/test/reset" || resetHookCheck.Status != http.StatusNotFound {
+		t.Fatalf("reset hook check did not record missing hook failure: %+v", resetHookCheck)
+	}
+	if !strings.Contains(resetHookCheck.Error, "404") {
+		t.Fatalf("missing E2E hook failure was not diagnostic: %q", resetHookCheck.Error)
+	}
+}
+
 func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
 	repoRoot := filepath.Dir(currentFileDir(t))
 	cypressPath := filepath.Join(repoRoot, "cypress.ps1")

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -1136,6 +1136,7 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 		ApiContractSmokeStatus       string `json:"api_contract_smoke_status"`
 		ApiContractSmokeCheckCount   *int   `json:"api_contract_smoke_check_count"`
 		ApiContractSmokeFailedCount  *int   `json:"api_contract_smoke_failed_count"`
+		ApiContractSmokeElapsedMS    *int   `json:"api_contract_smoke_elapsed_ms"`
 		ApiContractSmokeFailedChecks []struct {
 			Name   string `json:"name"`
 			Method string `json:"method"`
@@ -1161,6 +1162,9 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 	if cypressSummary.ApiContractSmokeCheckCount == nil || *cypressSummary.ApiContractSmokeCheckCount == 0 {
 		t.Fatalf("Cypress summary did not include API smoke check count metadata: %+v", cypressSummary)
 	}
+	if cypressSummary.ApiContractSmokeElapsedMS == nil {
+		t.Fatalf("Cypress summary did not include API smoke elapsed timing metadata: %+v", cypressSummary)
+	}
 	if len(cypressSummary.ApiContractSmokeFailedChecks) == 0 {
 		t.Fatalf("Cypress summary did not surface compact API smoke failed checks: %+v", cypressSummary)
 	}
@@ -1181,6 +1185,7 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 		Status      string `json:"status"`
 		CheckCount  int    `json:"check_count"`
 		FailedCount int    `json:"failed_count"`
+		ElapsedMS   int    `json:"elapsed_ms"`
 	}
 	if err := json.Unmarshal(apiRaw, &apiSummary); err != nil {
 		t.Fatalf("decode API smoke summary: %v\n%s", err, string(apiRaw))
@@ -1190,6 +1195,9 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 	}
 	if *cypressSummary.ApiContractSmokeCheckCount != apiSummary.CheckCount {
 		t.Fatalf("Cypress summary API smoke check count = %d, want nested summary count %d", *cypressSummary.ApiContractSmokeCheckCount, apiSummary.CheckCount)
+	}
+	if *cypressSummary.ApiContractSmokeElapsedMS != apiSummary.ElapsedMS {
+		t.Fatalf("Cypress summary API smoke elapsed_ms = %d, want nested summary elapsed_ms %d", *cypressSummary.ApiContractSmokeElapsedMS, apiSummary.ElapsedMS)
 	}
 }
 

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -63,6 +63,9 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 		BaseURLPort  int    `json:"base_url_port"`
 		CheckCount   int    `json:"check_count"`
 		FailedCount  int    `json:"failed_count"`
+		FailedChecks []struct {
+			Name string `json:"name"`
+		} `json:"failed_checks"`
 		SourceCommit string `json:"source_commit"`
 		TimeoutSec   int    `json:"timeout_sec"`
 		ElapsedMS    *int   `json:"elapsed_ms"`
@@ -78,6 +81,9 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	}
 	if summary.ExitCode != 0 || summary.CheckCount != 4 || summary.FailedCount != 0 {
 		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if len(summary.FailedChecks) != 0 {
+		t.Fatalf("passing summary unexpectedly listed failed checks: %+v", summary.FailedChecks)
 	}
 	if summary.RunID != runID || summary.TimeoutSec != 5 || summary.SummaryPath != summaryPath {
 		t.Fatalf("summary metadata was not traceable: %+v", summary)
@@ -153,10 +159,17 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 	}
 
 	var summary struct {
-		ExitCode    int `json:"exit_code"`
-		CheckCount  int `json:"check_count"`
-		FailedCount int `json:"failed_count"`
-		Checks      []struct {
+		ExitCode     int `json:"exit_code"`
+		CheckCount   int `json:"check_count"`
+		FailedCount  int `json:"failed_count"`
+		FailedChecks []struct {
+			Name   string `json:"name"`
+			Method string `json:"method"`
+			Path   string `json:"path"`
+			Status int    `json:"status"`
+			Error  string `json:"error"`
+		} `json:"failed_checks"`
+		Checks []struct {
 			Name   string `json:"name"`
 			Passed bool   `json:"passed"`
 			Error  string `json:"error"`
@@ -167,6 +180,16 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 	}
 	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
 		t.Fatalf("unexpected failure summary: %+v", summary)
+	}
+	if len(summary.FailedChecks) != 1 {
+		t.Fatalf("failure summary did not include compact failed_checks triage: %+v", summary.FailedChecks)
+	}
+	failedCheck := summary.FailedChecks[0]
+	if failedCheck.Name != "runtime API" || failedCheck.Method != http.MethodGet || failedCheck.Path != "/api/runtime" || failedCheck.Status != http.StatusOK {
+		t.Fatalf("failed_checks entry did not identify runtime API failure: %+v", failedCheck)
+	}
+	if !strings.Contains(failedCheck.Error, "not valid JSON") {
+		t.Fatalf("failed_checks error was not diagnostic: %q", failedCheck.Error)
 	}
 
 	var runtimeCheckError string

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -1065,7 +1065,9 @@ func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
 		"scripts\\run-api-contract-smoke.ps1",
 		"Running API contract smoke preflight.",
 		"API contract smoke summary:",
+		"$script:LastApiContractSmokeSummaryPath = $summaryPath",
 		"api_contract_smoke_summary_path",
+		"$apiContractSmokeSummaryPath = $script:LastApiContractSmokeSummaryPath",
 		"API contract smoke preflight failed",
 	} {
 		if !strings.Contains(content, snippet) {

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -20,14 +20,15 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
+			_, _ = w.Write(mockRuntimeMetadataJSON(t, srv.URL))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -106,7 +107,7 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 			t.Fatalf("check %q did not include duration_ms timing: %+v", check.Name, check)
 		}
 		if check.Name == "runtime API" {
-			if check.JsonFields["app_version"] != "test" || check.JsonFields["runtime_host"] != "127.0.0.1" || fmt.Sprint(check.JsonFields["runtime_port"]) != "17880" {
+			if check.JsonFields["app_version"] != "test" || check.JsonFields["runtime_host"] != mockRuntimeURL.Hostname() || fmt.Sprint(check.JsonFields["runtime_port"]) != mockRuntimeURL.Port() {
 				t.Fatalf("runtime API check did not record runtime metadata fields: %+v", check.JsonFields)
 			}
 		}
@@ -122,7 +123,8 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
@@ -212,7 +214,8 @@ func TestApiContractSmokeScriptDiagnosesRuntimeMetadataMismatch(t *testing.T) {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
@@ -289,18 +292,106 @@ func TestApiContractSmokeScriptDiagnosesRuntimeMetadataMismatch(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesRuntimePortMismatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":1}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-runtime-port-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed with mismatched runtime port\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read runtime port failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode runtime port failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected runtime port failure summary: %+v", summary)
+	}
+
+	var runtimeCheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "runtime API" {
+			runtimeCheck = check
+			break
+		}
+	}
+	if runtimeCheck.Name == "" {
+		t.Fatalf("summary did not include runtime API check: %+v", summary.Checks)
+	}
+	if runtimeCheck.Passed || runtimeCheck.Status != http.StatusOK {
+		t.Fatalf("runtime API check did not record port mismatch: %+v", runtimeCheck)
+	}
+	mockRuntimeURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse mock runtime URL: %v", err)
+	}
+	if !strings.Contains(runtimeCheck.Error, "runtime_port 1") || !strings.Contains(runtimeCheck.Error, mockRuntimeURL.Port()) {
+		t.Fatalf("runtime port mismatch failure was not diagnostic: %q", runtimeCheck.Error)
+	}
+}
+
 func TestApiContractSmokeScriptDiagnosesHealthzFailure(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			http.Error(w, "stale runtime", http.StatusServiceUnavailable)
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
+			_, _ = w.Write(mockRuntimeMetadataJSON(t, srv.URL))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -447,14 +538,15 @@ func TestApiContractSmokeScriptDiagnosesSignInContentMismatch(t *testing.T) {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
+			_, _ = w.Write(mockRuntimeMetadataJSON(t, srv.URL))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -529,14 +621,15 @@ func TestApiContractSmokeScriptDiagnosesOpenAPIContentTypeMismatch(t *testing.T)
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
+			_, _ = w.Write(mockRuntimeMetadataJSON(t, srv.URL))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "text/plain")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -611,14 +704,15 @@ func TestApiContractSmokeScriptDiagnosesOpenAPIBodyMismatch(t *testing.T) {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
+			_, _ = w.Write(mockRuntimeMetadataJSON(t, srv.URL))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("info:\n  title: Wrong Runtime\n"))
@@ -693,14 +787,15 @@ func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
+			_, _ = w.Write(mockRuntimeMetadataJSON(t, srv.URL))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -774,14 +869,15 @@ func TestApiContractSmokeScriptDiagnosesMissingE2EHooksWhenRequired(t *testing.T
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
+			_, _ = w.Write(mockRuntimeMetadataJSON(t, srv.URL))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -885,6 +981,15 @@ func currentFileDir(t *testing.T) string {
 		t.Fatal("runtime.Caller failed")
 	}
 	return filepath.Dir(filename)
+}
+
+func mockRuntimeMetadataJSON(t *testing.T, baseURL string) []byte {
+	t.Helper()
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse mock runtime URL: %v", err)
+	}
+	return []byte(fmt.Sprintf(`{"app_version":"test","runtime_host":%q,"runtime_port":%s}`, parsed.Hostname(), parsed.Port()))
 }
 
 func currentGitCommit(t *testing.T, repoRoot string) string {

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -151,6 +151,8 @@ func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
 		"[switch]$ApiContractSmoke",
 		"scripts\\run-api-contract-smoke.ps1",
 		"Running API contract smoke preflight.",
+		"API contract smoke summary:",
+		"api_contract_smoke_summary_path",
 		"API contract smoke preflight failed",
 	} {
 		if !strings.Contains(content, snippet) {

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -57,10 +57,13 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 
 	var summary struct {
 		ExitCode     int    `json:"exit_code"`
+		RunID        string `json:"run_id"`
 		CheckCount   int    `json:"check_count"`
 		FailedCount  int    `json:"failed_count"`
 		SourceCommit string `json:"source_commit"`
+		TimeoutSec   int    `json:"timeout_sec"`
 		ElapsedMS    *int   `json:"elapsed_ms"`
+		SummaryPath  string `json:"summary_path"`
 		Checks       []struct {
 			Name       string `json:"name"`
 			DurationMS *int   `json:"duration_ms"`
@@ -71,6 +74,9 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	}
 	if summary.ExitCode != 0 || summary.CheckCount != 4 || summary.FailedCount != 0 {
 		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if summary.RunID != runID || summary.TimeoutSec != 5 || summary.SummaryPath != summaryPath {
+		t.Fatalf("summary metadata was not traceable: %+v", summary)
 	}
 	if summary.ElapsedMS == nil || *summary.ElapsedMS < 0 {
 		t.Fatalf("summary did not include elapsed_ms timing: %+v", summary)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -139,6 +139,87 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesHealthzFailure(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			http.Error(w, "stale runtime", http.StatusServiceUnavailable)
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-healthz-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read healthz failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode healthz failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected healthz failure summary: %+v", summary)
+	}
+
+	var healthzCheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "healthz" {
+			healthzCheck = check
+			break
+		}
+	}
+	if healthzCheck.Name == "" {
+		t.Fatalf("summary did not include healthz check: %+v", summary.Checks)
+	}
+	if healthzCheck.Passed || healthzCheck.Status != http.StatusServiceUnavailable {
+		t.Fatalf("healthz check did not record stale runtime status: %+v", healthzCheck)
+	}
+	if !strings.Contains(healthzCheck.Error, "503") {
+		t.Fatalf("healthz failure was not diagnostic: %q", healthzCheck.Error)
+	}
+}
+
 func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -292,6 +292,97 @@ func TestApiContractSmokeScriptDiagnosesRuntimeMetadataMismatch(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesRuntimeHostMismatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			mockRuntimeURL, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatalf("parse mock runtime URL: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"app_version":"test","runtime_host":"stale-runtime.local","runtime_port":%s}`, mockRuntimeURL.Port())))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-runtime-host-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed with mismatched runtime host\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read runtime host failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode runtime host failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected runtime host failure summary: %+v", summary)
+	}
+
+	var runtimeCheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "runtime API" {
+			runtimeCheck = check
+			break
+		}
+	}
+	if runtimeCheck.Name == "" {
+		t.Fatalf("summary did not include runtime API check: %+v", summary.Checks)
+	}
+	if runtimeCheck.Passed || runtimeCheck.Status != http.StatusOK {
+		t.Fatalf("runtime API check did not record host mismatch: %+v", runtimeCheck)
+	}
+	mockRuntimeURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse mock runtime URL: %v", err)
+	}
+	if !strings.Contains(runtimeCheck.Error, "runtime_host stale-runtime.local") || !strings.Contains(runtimeCheck.Error, mockRuntimeURL.Hostname()) {
+		t.Fatalf("runtime host mismatch failure was not diagnostic: %q", runtimeCheck.Error)
+	}
+}
+
 func TestApiContractSmokeScriptDiagnosesRuntimePortMismatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("api contract smoke script failed: %v\n%s", err, string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 0 || summary.CheckCount != 4 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
+	repoRoot := filepath.Dir(currentFileDir(t))
+	cypressPath := filepath.Join(repoRoot, "cypress.ps1")
+	raw, err := os.ReadFile(cypressPath)
+	if err != nil {
+		t.Fatalf("read cypress.ps1: %v", err)
+	}
+	content := string(raw)
+	for _, snippet := range []string{
+		"[switch]$ApiContractSmoke",
+		"scripts\\run-api-contract-smoke.ps1",
+		"Running API contract smoke preflight.",
+		"API contract smoke preflight failed",
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("cypress.ps1 missing API smoke preflight snippet %q", snippet)
+		}
+	}
+}
+
+func currentFileDir(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(filename)
+}

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -26,7 +26,7 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -168,6 +168,88 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesRuntimeMetadataMismatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"other-runtime"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-runtime-metadata-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed with wrong runtime metadata\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read runtime metadata failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode runtime metadata failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected runtime metadata failure summary: %+v", summary)
+	}
+
+	var runtimeCheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "runtime API" {
+			runtimeCheck = check
+			break
+		}
+	}
+	if runtimeCheck.Name == "" {
+		t.Fatalf("summary did not include runtime API check: %+v", summary.Checks)
+	}
+	if runtimeCheck.Passed || runtimeCheck.Status != http.StatusOK {
+		t.Fatalf("runtime API check did not record metadata mismatch: %+v", runtimeCheck)
+	}
+	if !strings.Contains(runtimeCheck.Error, "required field app_version") {
+		t.Fatalf("runtime metadata failure was not diagnostic: %q", runtimeCheck.Error)
+	}
+}
+
 func TestApiContractSmokeScriptDiagnosesHealthzFailure(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
@@ -179,7 +261,7 @@ func TestApiContractSmokeScriptDiagnosesHealthzFailure(t *testing.T) {
 			http.Error(w, "stale runtime", http.StatusServiceUnavailable)
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -333,7 +415,7 @@ func TestApiContractSmokeScriptDiagnosesSignInContentMismatch(t *testing.T) {
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -415,7 +497,7 @@ func TestApiContractSmokeScriptDiagnosesOpenAPIContentTypeMismatch(t *testing.T)
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "text/plain")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -497,7 +579,7 @@ func TestApiContractSmokeScriptDiagnosesOpenAPIBodyMismatch(t *testing.T) {
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("info:\n  title: Wrong Runtime\n"))
@@ -579,7 +661,7 @@ func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
@@ -660,7 +742,7 @@ func TestApiContractSmokeScriptDiagnosesMissingE2EHooksWhenRequired(t *testing.T
 			_, _ = w.Write([]byte("ok"))
 		case "/api/runtime":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+			_, _ = w.Write([]byte(`{"app_version":"test","runtime_host":"127.0.0.1","runtime_port":17880}`))
 		case "/api/openapi.yaml":
 			w.Header().Set("Content-Type", "application/yaml")
 			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -65,8 +65,9 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 		ElapsedMS    *int   `json:"elapsed_ms"`
 		SummaryPath  string `json:"summary_path"`
 		Checks       []struct {
-			Name       string `json:"name"`
-			DurationMS *int   `json:"duration_ms"`
+			Name       string         `json:"name"`
+			DurationMS *int           `json:"duration_ms"`
+			JsonFields map[string]any `json:"json_fields"`
 		} `json:"checks"`
 	}
 	if err := json.Unmarshal(raw, &summary); err != nil {
@@ -87,6 +88,11 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	for _, check := range summary.Checks {
 		if check.DurationMS == nil || *check.DurationMS < 0 {
 			t.Fatalf("check %q did not include duration_ms timing: %+v", check.Name, check)
+		}
+		if check.Name == "runtime API" {
+			if check.JsonFields["app_version"] != "test" || check.JsonFields["runtime_host"] != "127.0.0.1" || fmt.Sprint(check.JsonFields["runtime_port"]) != "17880" {
+				t.Fatalf("runtime API check did not record runtime metadata fields: %+v", check.JsonFields)
+			}
 		}
 	}
 	expectedCommit := currentGitCommit(t, repoRoot)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -217,6 +219,78 @@ func TestApiContractSmokeScriptDiagnosesHealthzFailure(t *testing.T) {
 	}
 	if !strings.Contains(healthzCheck.Error, "503") {
 		t.Fatalf("healthz failure was not diagnostic: %q", healthzCheck.Error)
+	}
+}
+
+func TestApiContractSmokeScriptDiagnosesDeadRuntime(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve dead runtime port: %v", err)
+	}
+	deadBaseURL := fmt.Sprintf("http://%s", listener.Addr().String())
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release dead runtime port: %v", err)
+	}
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-dead-runtime"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", deadBaseURL, "-LogRoot", logRoot, "-RunId", runID, "-TimeoutSec", "1")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed against dead runtime\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read dead runtime summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode dead runtime summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 4 {
+		t.Fatalf("unexpected dead runtime summary: %+v", summary)
+	}
+
+	var healthzCheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "healthz" {
+			healthzCheck = check
+			break
+		}
+	}
+	if healthzCheck.Name == "" {
+		t.Fatalf("summary did not include healthz check: %+v", summary.Checks)
+	}
+	if healthzCheck.Passed || healthzCheck.Status != 0 {
+		t.Fatalf("healthz check did not record dead runtime failure: %+v", healthzCheck)
+	}
+	lowerError := strings.ToLower(healthzCheck.Error)
+	if !strings.Contains(lowerError, "connection") && !strings.Contains(lowerError, "refused") && !strings.Contains(lowerError, "timeout") {
+		t.Fatalf("dead runtime failure was not diagnostic: %q", healthzCheck.Error)
 	}
 }
 

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -139,6 +139,87 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		case "/api/test/reset":
+			if r.Method != http.MethodPost {
+				t.Fatalf("reset hook used method %s, want POST", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-e2e-hooks"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID, "-RequireE2EHooks")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("api contract smoke script with E2E hooks failed: %v\n%s", err, string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read E2E hooks summary: %v", err)
+	}
+
+	var summary struct {
+		ExitCode        int  `json:"exit_code"`
+		CheckCount      int  `json:"check_count"`
+		FailedCount     int  `json:"failed_count"`
+		RequireE2EHooks bool `json:"require_e2e_hooks"`
+		Checks          []struct {
+			Name   string `json:"name"`
+			Method string `json:"method"`
+			Path   string `json:"path"`
+			Passed bool   `json:"passed"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode E2E hooks summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 0 || summary.CheckCount != 5 || summary.FailedCount != 0 || !summary.RequireE2EHooks {
+		t.Fatalf("unexpected E2E hooks summary: %+v", summary)
+	}
+
+	var sawResetHook bool
+	for _, check := range summary.Checks {
+		if check.Name == "E2E reset hook" {
+			sawResetHook = true
+			if check.Method != http.MethodPost || check.Path != "/api/test/reset" || !check.Passed {
+				t.Fatalf("unexpected reset hook check: %+v", check)
+			}
+			break
+		}
+	}
+	if !sawResetHook {
+		t.Fatalf("summary did not include E2E reset hook check: %+v", summary.Checks)
+	}
+}
+
 func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
 	repoRoot := filepath.Dir(currentFileDir(t))
 	cypressPath := filepath.Join(repoRoot, "cypress.ps1")

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,6 +59,8 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	var summary struct {
 		ExitCode     int    `json:"exit_code"`
 		RunID        string `json:"run_id"`
+		BaseURLHost  string `json:"base_url_host"`
+		BaseURLPort  int    `json:"base_url_port"`
 		CheckCount   int    `json:"check_count"`
 		FailedCount  int    `json:"failed_count"`
 		SourceCommit string `json:"source_commit"`
@@ -78,6 +81,13 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	}
 	if summary.RunID != runID || summary.TimeoutSec != 5 || summary.SummaryPath != summaryPath {
 		t.Fatalf("summary metadata was not traceable: %+v", summary)
+	}
+	mockRuntimeURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse mock runtime URL: %v", err)
+	}
+	if summary.BaseURLHost != mockRuntimeURL.Hostname() || fmt.Sprint(summary.BaseURLPort) != mockRuntimeURL.Port() {
+		t.Fatalf("summary base URL metadata = %s:%d, want %s:%s", summary.BaseURLHost, summary.BaseURLPort, mockRuntimeURL.Hostname(), mockRuntimeURL.Port())
 	}
 	if summary.ElapsedMS == nil || *summary.ElapsedMS < 0 {
 		t.Fatalf("summary did not include elapsed_ms timing: %+v", summary)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -1132,6 +1132,8 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 		ExitCode                    int    `json:"exit_code"`
 		Error                       string `json:"error"`
 		ApiContractSmokeSummaryPath string `json:"api_contract_smoke_summary_path"`
+		ApiContractSmokeStatus      string `json:"api_contract_smoke_status"`
+		ApiContractSmokeFailedCount *int   `json:"api_contract_smoke_failed_count"`
 	}
 	if err := json.Unmarshal(raw, &cypressSummary); err != nil {
 		t.Fatalf("decode Cypress summary: %v\n%s", err, string(raw))
@@ -1144,6 +1146,9 @@ func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *test
 	}
 	if cypressSummary.ApiContractSmokeSummaryPath == "" {
 		t.Fatalf("Cypress summary did not preserve API smoke summary path: %+v", cypressSummary)
+	}
+	if cypressSummary.ApiContractSmokeStatus != "failed" || cypressSummary.ApiContractSmokeFailedCount == nil || *cypressSummary.ApiContractSmokeFailedCount == 0 {
+		t.Fatalf("Cypress summary did not include compact API smoke failure metadata: %+v", cypressSummary)
 	}
 	if _, err := os.Stat(cypressSummary.ApiContractSmokeSummaryPath); err != nil {
 		t.Fatalf("API smoke summary path from Cypress summary was not readable: %v", err)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -384,6 +384,88 @@ func TestApiContractSmokeScriptDiagnosesOpenAPIContentTypeMismatch(t *testing.T)
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesOpenAPIBodyMismatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("info:\n  title: Wrong Runtime\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-openapi-body-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read OpenAPI body failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode OpenAPI body failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected OpenAPI body failure summary: %+v", summary)
+	}
+
+	var openAPICheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "OpenAPI YAML" {
+			openAPICheck = check
+			break
+		}
+	}
+	if openAPICheck.Name == "" {
+		t.Fatalf("summary did not include OpenAPI YAML check: %+v", summary.Checks)
+	}
+	if openAPICheck.Passed || openAPICheck.Status != http.StatusOK {
+		t.Fatalf("OpenAPI check did not record body mismatch: %+v", openAPICheck)
+	}
+	if !strings.Contains(openAPICheck.Error, "required marker") {
+		t.Fatalf("OpenAPI body failure was not diagnostic: %q", openAPICheck.Error)
+	}
+}
+
 func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -171,11 +171,13 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 		CheckCount   int    `json:"check_count"`
 		FailedCount  int    `json:"failed_count"`
 		FailedChecks []struct {
-			Name   string `json:"name"`
-			Method string `json:"method"`
-			Path   string `json:"path"`
-			Status int    `json:"status"`
-			Error  string `json:"error"`
+			Name           string `json:"name"`
+			Method         string `json:"method"`
+			Path           string `json:"path"`
+			ExpectedStatus int    `json:"expected_status"`
+			Status         int    `json:"status"`
+			DurationMS     *int   `json:"duration_ms"`
+			Error          string `json:"error"`
 		} `json:"failed_checks"`
 		Checks []struct {
 			Name   string `json:"name"`
@@ -196,8 +198,11 @@ func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
 		t.Fatalf("failure summary did not include compact failed_checks triage: %+v", summary.FailedChecks)
 	}
 	failedCheck := summary.FailedChecks[0]
-	if failedCheck.Name != "runtime API" || failedCheck.Method != http.MethodGet || failedCheck.Path != "/api/runtime" || failedCheck.Status != http.StatusOK {
+	if failedCheck.Name != "runtime API" || failedCheck.Method != http.MethodGet || failedCheck.Path != "/api/runtime" || failedCheck.ExpectedStatus != http.StatusOK || failedCheck.Status != http.StatusOK {
 		t.Fatalf("failed_checks entry did not identify runtime API failure: %+v", failedCheck)
+	}
+	if failedCheck.DurationMS == nil || *failedCheck.DurationMS < 0 {
+		t.Fatalf("failed_checks entry did not include compact timing evidence: %+v", failedCheck)
 	}
 	if !strings.Contains(failedCheck.Error, "not valid JSON") {
 		t.Fatalf("failed_checks error was not diagnostic: %q", failedCheck.Error)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -60,12 +60,28 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 		CheckCount   int    `json:"check_count"`
 		FailedCount  int    `json:"failed_count"`
 		SourceCommit string `json:"source_commit"`
+		ElapsedMS    *int   `json:"elapsed_ms"`
+		Checks       []struct {
+			Name       string `json:"name"`
+			DurationMS *int   `json:"duration_ms"`
+		} `json:"checks"`
 	}
 	if err := json.Unmarshal(raw, &summary); err != nil {
 		t.Fatalf("decode summary: %v\n%s", err, string(raw))
 	}
 	if summary.ExitCode != 0 || summary.CheckCount != 4 || summary.FailedCount != 0 {
 		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if summary.ElapsedMS == nil || *summary.ElapsedMS < 0 {
+		t.Fatalf("summary did not include elapsed_ms timing: %+v", summary)
+	}
+	if len(summary.Checks) != summary.CheckCount {
+		t.Fatalf("summary checks length = %d, want %d", len(summary.Checks), summary.CheckCount)
+	}
+	for _, check := range summary.Checks {
+		if check.DurationMS == nil || *check.DurationMS < 0 {
+			t.Fatalf("check %q did not include duration_ms timing: %+v", check.Name, check)
+		}
 	}
 	expectedCommit := currentGitCommit(t, repoRoot)
 	if summary.SourceCommit != expectedCommit {

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -56,15 +56,20 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	}
 
 	var summary struct {
-		ExitCode    int `json:"exit_code"`
-		CheckCount  int `json:"check_count"`
-		FailedCount int `json:"failed_count"`
+		ExitCode     int    `json:"exit_code"`
+		CheckCount   int    `json:"check_count"`
+		FailedCount  int    `json:"failed_count"`
+		SourceCommit string `json:"source_commit"`
 	}
 	if err := json.Unmarshal(raw, &summary); err != nil {
 		t.Fatalf("decode summary: %v\n%s", err, string(raw))
 	}
 	if summary.ExitCode != 0 || summary.CheckCount != 4 || summary.FailedCount != 0 {
 		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	expectedCommit := currentGitCommit(t, repoRoot)
+	if summary.SourceCommit != expectedCommit {
+		t.Fatalf("summary source_commit = %q, want %q", summary.SourceCommit, expectedCommit)
 	}
 }
 
@@ -737,4 +742,14 @@ func currentFileDir(t *testing.T) string {
 		t.Fatal("runtime.Caller failed")
 	}
 	return filepath.Dir(filename)
+}
+
+func currentGitCommit(t *testing.T, repoRoot string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD failed: %v", err)
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -66,6 +66,79 @@ func TestApiContractSmokeScriptWritesMachineReadableSummary(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptWritesFailureSummary(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`not-json`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected failure summary: %+v", summary)
+	}
+
+	var runtimeCheckError string
+	for _, check := range summary.Checks {
+		if check.Name == "runtime API" {
+			if check.Passed {
+				t.Fatalf("runtime API check unexpectedly passed: %+v", check)
+			}
+			runtimeCheckError = check.Error
+			break
+		}
+	}
+	if !strings.Contains(runtimeCheckError, "not valid JSON") {
+		t.Fatalf("runtime API failure was not diagnostic: %q", runtimeCheckError)
+	}
+}
+
 func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
 	repoRoot := filepath.Dir(currentFileDir(t))
 	cypressPath := filepath.Join(repoRoot, "cypress.ps1")

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -1081,6 +1081,91 @@ func TestCypressHarnessCanRunApiContractSmokeBeforeBrowserSpec(t *testing.T) {
 	}
 }
 
+func TestCypressHarnessPreservesApiContractSmokeSummaryArtifactOnFailure(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve dead runtime port: %v", err)
+	}
+	deadBaseURL := fmt.Sprintf("http://%s", listener.Addr().String())
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release dead runtime port: %v", err)
+	}
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	cmd := exec.Command(
+		"pwsh",
+		"-NoLogo",
+		"-NoProfile",
+		"-File", filepath.Join(repoRoot, "cypress.ps1"),
+		"-NoServer",
+		"-SkipDependencyPrep",
+		"-RuntimeExecutablePath", filepath.Join(repoRoot, "cypress.ps1"),
+		"-ApiContractSmoke",
+		"-BaseUrl", deadBaseURL,
+		"-LogDir", logRoot,
+		"-LogName", "api-smoke-failure-artifact",
+	)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("cypress harness unexpectedly passed against dead API smoke runtime\n%s", string(output))
+	}
+
+	cypressSummaries, err := filepath.Glob(filepath.Join(logRoot, "*-api-smoke-failure-artifact.summary.json"))
+	if err != nil {
+		t.Fatalf("glob Cypress summaries: %v", err)
+	}
+	if len(cypressSummaries) != 1 {
+		t.Fatalf("expected one Cypress summary, got %d: %v\n%s", len(cypressSummaries), cypressSummaries, string(output))
+	}
+
+	raw, err := os.ReadFile(cypressSummaries[0])
+	if err != nil {
+		t.Fatalf("read Cypress summary: %v", err)
+	}
+	var cypressSummary struct {
+		ExitCode                    int    `json:"exit_code"`
+		Error                       string `json:"error"`
+		ApiContractSmokeSummaryPath string `json:"api_contract_smoke_summary_path"`
+	}
+	if err := json.Unmarshal(raw, &cypressSummary); err != nil {
+		t.Fatalf("decode Cypress summary: %v\n%s", err, string(raw))
+	}
+	if cypressSummary.ExitCode != 1 {
+		t.Fatalf("Cypress summary exit_code = %d, want 1: %+v", cypressSummary.ExitCode, cypressSummary)
+	}
+	if !strings.Contains(cypressSummary.Error, "API contract smoke preflight failed") {
+		t.Fatalf("Cypress summary error did not identify API smoke failure: %q", cypressSummary.Error)
+	}
+	if cypressSummary.ApiContractSmokeSummaryPath == "" {
+		t.Fatalf("Cypress summary did not preserve API smoke summary path: %+v", cypressSummary)
+	}
+	if _, err := os.Stat(cypressSummary.ApiContractSmokeSummaryPath); err != nil {
+		t.Fatalf("API smoke summary path from Cypress summary was not readable: %v", err)
+	}
+
+	apiRaw, err := os.ReadFile(cypressSummary.ApiContractSmokeSummaryPath)
+	if err != nil {
+		t.Fatalf("read API smoke summary: %v", err)
+	}
+	var apiSummary struct {
+		ExitCode    int    `json:"exit_code"`
+		Status      string `json:"status"`
+		FailedCount int    `json:"failed_count"`
+	}
+	if err := json.Unmarshal(apiRaw, &apiSummary); err != nil {
+		t.Fatalf("decode API smoke summary: %v\n%s", err, string(apiRaw))
+	}
+	if apiSummary.ExitCode != 1 || apiSummary.Status != "failed" || apiSummary.FailedCount == 0 {
+		t.Fatalf("API smoke summary did not record preflight failure: %+v", apiSummary)
+	}
+}
+
 func currentFileDir(t *testing.T) string {
 	t.Helper()
 	_, filename, _, ok := runtime.Caller(0)

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -397,6 +397,65 @@ func TestApiContractSmokeScriptDiagnosesRuntimeHostMismatch(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptAcceptsWildcardRuntimeHostForLoopback(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			mockRuntimeURL, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatalf("parse mock runtime URL: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"app_version":"test","runtime_host":"0.0.0.0","runtime_port":%s}`, mockRuntimeURL.Port())))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>Sign in</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-wildcard-host"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("api contract smoke script rejected wildcard runtime host for loopback base URL: %v\n%s", err, string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read wildcard host summary: %v", err)
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode wildcard host summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 0 || summary.CheckCount != 4 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected wildcard host summary: %+v", summary)
+	}
+}
+
 func TestApiContractSmokeScriptDiagnosesRuntimePortMismatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
@@ -911,8 +970,8 @@ func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Fatalf("reset hook used method %s, want POST", r.Method)
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"ok":true}`))
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("ok"))
 		default:
 			http.NotFound(w, r)
 		}

--- a/tests/api_contract_smoke_test.go
+++ b/tests/api_contract_smoke_test.go
@@ -220,6 +220,88 @@ func TestApiContractSmokeScriptDiagnosesHealthzFailure(t *testing.T) {
 	}
 }
 
+func TestApiContractSmokeScriptDiagnosesSignInContentMismatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case "/api/runtime":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mode":"test","version":"mock"}`))
+		case "/api/openapi.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("openapi: 3.0.0\ninfo:\n  title: Cabinet Mock\n"))
+		case "/sign-in":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"wrong route"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := filepath.Dir(currentFileDir(t))
+	logRoot := t.TempDir()
+	runID := "go-api-contract-smoke-sign-in-content-failure"
+	cmd := exec.Command("pwsh", "-NoLogo", "-NoProfile", "-File", filepath.Join(repoRoot, "scripts", "run-api-contract-smoke.ps1"), "-BaseUrl", srv.URL, "-LogRoot", logRoot, "-RunId", runID)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("api contract smoke script unexpectedly passed\n%s", string(output))
+	}
+
+	summaryPath := filepath.Join(logRoot, runID, "api-contract-smoke.summary.json")
+	raw, readErr := os.ReadFile(summaryPath)
+	if readErr != nil {
+		t.Fatalf("read sign-in content failure summary: %v\n%s", readErr, string(output))
+	}
+
+	var summary struct {
+		ExitCode    int `json:"exit_code"`
+		CheckCount  int `json:"check_count"`
+		FailedCount int `json:"failed_count"`
+		Checks      []struct {
+			Name   string `json:"name"`
+			Status int    `json:"status"`
+			Passed bool   `json:"passed"`
+			Error  string `json:"error"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("decode sign-in content failure summary: %v\n%s", err, string(raw))
+	}
+	if summary.ExitCode != 1 || summary.CheckCount != 4 || summary.FailedCount != 1 {
+		t.Fatalf("unexpected sign-in content failure summary: %+v", summary)
+	}
+
+	var signInCheck struct {
+		Name   string `json:"name"`
+		Status int    `json:"status"`
+		Passed bool   `json:"passed"`
+		Error  string `json:"error"`
+	}
+	for _, check := range summary.Checks {
+		if check.Name == "sign-in route" {
+			signInCheck = check
+			break
+		}
+	}
+	if signInCheck.Name == "" {
+		t.Fatalf("summary did not include sign-in route check: %+v", summary.Checks)
+	}
+	if signInCheck.Passed || signInCheck.Status != http.StatusOK {
+		t.Fatalf("sign-in check did not record route content mismatch: %+v", signInCheck)
+	}
+	if !strings.Contains(signInCheck.Error, "required marker") {
+		t.Fatalf("sign-in content failure was not diagnostic: %q", signInCheck.Error)
+	}
+}
+
 func TestApiContractSmokeScriptRequiresE2EHooksWhenRequested(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell harness validation is exercised on the Windows QA lane")

--- a/ui.web/package.json
+++ b/ui.web/package.json
@@ -15,6 +15,7 @@
     "e2e:ci-smoke": "node ../scripts/run-cypress.mjs run --browser electron --config-file cypress.config.runtime.cjs --spec \"cypress/e2e/general/ui-login-session/spec.cy.ts\"",
     "e2e:matrix": "pwsh -NoLogo -NoProfile -File ../scripts/run-cypress-matrix.ps1",
     "e2e:foundation": "pwsh -NoLogo -NoProfile -File ../cypress.ps1 -Spec cypress/e2e/general/ui-login-session/spec.cy.ts -Browser chrome",
+    "e2e:api-smoke": "pwsh -NoLogo -NoProfile -File ../scripts/run-api-contract-smoke.ps1",
     "e2e:run-smoke": "pwsh -NoLogo -NoProfile -File ../cypress.ps1 -Spec cypress/e2e/general/ui-login-session/spec.cy.ts -Browser chrome",
     "e2e:run-inventory": "pwsh -NoLogo -NoProfile -File ../cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser chrome",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary
- add scripts/run-api-contract-smoke.ps1 for pre-browser API contract checks against healthz, runtime API, OpenAPI YAML, and sign-in route
- write machine-readable api-contract-smoke.summary.json under .work-agent/logs/api-contract-smoke/<run-id>
- wire cypress.ps1 to run the API smoke preflight via -ApiContractSmoke before browser specs, with optional E2E hook checking
- add focused Go coverage that runs the PowerShell smoke script against a mock runtime and verifies summary output

## Validation
- go test ./tests -run ApiContractSmoke -count=1
- node -e "JSON.parse(require('fs').readFileSync('ui.web/package.json','utf8')); console.log('package json ok')"

Refs #1096
Parent #1058
