### PR TITLE
#1089 test(cypress): cover settings save failures

### DIFF
--- a/ui.web/cypress/e2e/settings/account/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/account/spec.cy.ts
@@ -33,6 +33,23 @@ describe('settings/account', () => {
     cy.contains('Please enter your name.').should('be.visible')
   })
 
+  it('UI-SCREEN-SETTINGS-ACCOUNT-003 preserves account values on save failure', () => {
+    cy.intercept('PUT', '/api/profiles/*/settings', {
+      statusCode: 500,
+      body: { error: 'failed_to_update_settings' },
+    }).as('accountSaveFailure')
+
+    cy.contains('button', 'Update account').should('not.be.disabled')
+    cy.get('input[name="name"]').clear().type('Settings Failure Name')
+    cy.get('[data-testid="settings-account-language-trigger"]').click()
+    cy.contains('[role="option"]', 'Korean').click()
+    cy.contains('button', 'Update account').click()
+    cy.wait('@accountSaveFailure')
+    cy.contains('profile_settings_save_500').should('be.visible')
+    cy.get('input[name="name"]').should('have.value', 'Settings Failure Name')
+    cy.contains('button[role="combobox"]', 'Korean').should('be.visible')
+  })
+
   it('UI-SCREEN-SETTINGS-ACCOUNT-004 retries account settings load failure without route reload', () => {
     let settingsAttempt = 0
     cy.intercept('GET', '/api/profiles/*/settings', (req) => {

--- a/ui.web/cypress/e2e/settings/appearance/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/appearance/spec.cy.ts
@@ -97,7 +97,27 @@ describe('settings/appearance', () => {
     cy.window().its('localStorage.i18nextLng').should('eq', 'ja')
   })
 
-  it('UI-SCREEN-SETTINGS-APPEARANCE-005 retries appearance settings load failure without route reload', () => {
+  it('UI-SCREEN-SETTINGS-APPEARANCE-006 preserves preference values on save failure', () => {
+    signInToSettings()
+    cy.intercept('PUT', '/api/profiles/*/settings', {
+      statusCode: 500,
+      body: { error: 'failed_to_update_settings' },
+    }).as('appearanceSaveFailure')
+
+    cy.contains('button', 'Update preferences').should('not.be.disabled')
+    cy.get('select[name="font"]').select('inter')
+    cy.get('[data-testid="appearance-language-select"]').select('ja')
+    cy.contains('span', 'Light').click()
+    cy.contains('button', 'Update preferences').click()
+
+    cy.wait('@appearanceSaveFailure')
+    cy.contains('profile_settings_save_500').should('be.visible')
+    cy.get('select[name="font"]').should('have.value', 'inter')
+    cy.get('[data-testid="appearance-language-select"]').should('have.value', 'ja')
+    cy.get('html').should('have.class', 'light')
+  })
+
+  it('UI-SCREEN-SETTINGS-APPEARANCE-007 retries appearance settings load failure without route reload', () => {
     signInToSettings()
     let settingsAttempt = 0
     cy.intercept('GET', '/api/profiles/*/settings', (req) => {

--- a/ui.web/cypress/e2e/settings/display/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/display/spec.cy.ts
@@ -91,7 +91,7 @@ describe('settings/display', () => {
     cy.contains('button', 'Update display').should('not.be.disabled')
   })
 
-  it('UI-SCREEN-SETTINGS-DISPLAY-004 updates display with deterministic success feedback', () => {
+  it('UI-SCREEN-SETTINGS-DISPLAY-005 updates display with deterministic success feedback', () => {
     cy.intercept('PUT', '/api/profiles/*/settings').as('saveDisplay')
 
     cy.contains('button', 'Clear selection').click()
@@ -119,5 +119,35 @@ describe('settings/display', () => {
         )
       })
     })
+  })
+
+  it('UI-SCREEN-SETTINGS-DISPLAY-006 preserves selected items on save failure', () => {
+    cy.intercept('PUT', '/api/profiles/*/settings', {
+      statusCode: 500,
+      body: { error: 'failed_to_update_settings' },
+    }).as('displaySaveFailure')
+
+    cy.contains('button', 'Clear selection').click()
+    cy.get('[data-testid="settings-display-documents"]').click()
+    cy.get('[data-testid="settings-display-downloads"]').click()
+    cy.contains('button', 'Update display').click()
+
+    cy.wait('@displaySaveFailure')
+    cy.contains('profile_settings_save_500').should('be.visible')
+    cy.get('[data-testid="settings-display-documents"]').should(
+      'have.attr',
+      'data-state',
+      'checked'
+    )
+    cy.get('[data-testid="settings-display-downloads"]').should(
+      'have.attr',
+      'data-state',
+      'checked'
+    )
+    cy.get('[data-testid="settings-display-home"]').should(
+      'have.attr',
+      'data-state',
+      'unchecked'
+    )
   })
 })


### PR DESCRIPTION
## Summary
- add save-failure retention coverage for settings account, appearance, and display forms
- keep values selected/typed after a rejected `/api/profiles/*/settings` save
- normalize touched settings case IDs so the E2E labels are unique

## Validation
- `npx eslint cypress/e2e/settings/account/spec.cy.ts cypress/e2e/settings/appearance/spec.cy.ts cypress/e2e/settings/display/spec.cy.ts`
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/settings/account/spec.cy.ts -Browser electron -RequireE2EHooks -LogDir .work-agent\logs\1089-settings-form-save-guards -LogName settings-account` -> 4 passing
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/settings/appearance/spec.cy.ts -Browser electron -RequireE2EHooks -SkipRuntimeBuild -LogDir .work-agent\logs\1089-settings-form-save-guards -LogName settings-appearance` -> 7 passing
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/settings/display/spec.cy.ts -Browser electron -RequireE2EHooks -SkipRuntimeBuild -LogDir .work-agent\logs\1089-settings-form-save-guards -LogName settings-display` -> 6 passing

Logs/summaries are under `.work-agent/logs/1089-settings-form-save-guards/`.

Closes #1089