### PR TITLE
#1110 fix(wishlist): allow title-only create

### DIFF
--- a/openspec/specs/wishlist/ui-screen-wishlist/spec.md
+++ b/openspec/specs/wishlist/ui-screen-wishlist/spec.md
@@ -149,6 +149,20 @@ Wishlist rows view SHALL render a compact thumbnail before each item title. When
 - **AND** the thumbnail MUST be decorative for assistive technology and MUST NOT duplicate the item title
 - **AND** the dense wishlist table layout MUST keep the title and notes readable on desktop and mobile widths
 
+### Requirement UI-SCREEN-WISHLIST-019: Wishlist create SHALL persist title-only drafts with defaults
+
+Wishlist create SHALL accept a draft with only `Title` populated, create the backing canonical wishlist item with generated part-number metadata and default planning values, then create the wishlist metadata entry without surfacing generic save failure copy.
+
+#### Scenario: Create title-only wishlist entry
+
+- **GIVEN** wishlist route is loaded and the create panel is open
+- **WHEN** user enters only a title and clicks `Save changes`
+- **THEN** Cabinet MUST create a canonical item with status `wishlist`, the submitted title, generated part number metadata, and default priority
+- **AND** Cabinet MUST create the wishlist metadata entry linked to that item
+- **AND** the created title MUST appear in the refreshed wishlist rows/cards
+- **AND** the create panel MUST close after persistence succeeds
+- **AND** the UI MUST NOT show generic `Wishlist save failed` copy for this valid title-only draft
+
 ## Use-Case IDs and E2E Mapping
 
 | UC ID     | Flow                             | Expected Result                                                                                                        | E2E Mapping                                                                                                                                            |
@@ -159,3 +173,4 @@ Wishlist rows view SHALL render a compact thumbnail before each item title. When
 | UC-WSH-04 | Sort wishlist by title           | Title sort control reorders rows deterministically                                                                     | planned: `ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` `wishlist-title-sort`                                                             |
 | UC-WSH-17 | Edit wishlist Cost and Quantity  | Inline numeric fields support keyboard entry plus accessible fixed-width stepper controls with lower-bound constraints | implemented: `ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` `UI-SCREEN-WISHLIST-017 edits cost and quantity with stable stepper controls` |
 | UC-WSH-18 | Show row thumbnails              | Rows render stable decorative thumbnails with deterministic fallback styling                                            | implemented: `ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` `UI-SCREEN-WISHLIST-018 renders compact deterministic row thumbnails`        |
+| UC-WSH-19 | Create title-only wishlist entry | Title-only drafts persist with generated metadata and no generic failure copy                                           | implemented: `ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` `UI-SCREEN-WISHLIST-019 creates a title-only wishlist entry`                  |

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -771,6 +771,75 @@ describe("ui-screen-wishlist", () => {
     cy.contains("Import Wishlist Entries").should("be.visible");
   });
 
+  it("UI-SCREEN-WISHLIST-019 creates a title-only wishlist entry", () => {
+    let wishlistEntries: Array<Record<string, unknown>> = [];
+    let wishlistItems: Array<Record<string, unknown>> = [];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistItems } });
+    }).as("catalogItems");
+    cy.intercept("POST", "/api/items", (req) => {
+      expect(req.body.title).to.eq("Title Only Wishlist Save");
+      expect(req.body.status).to.eq("wishlist");
+      expect(req.body.priority).to.eq("medium");
+      expect(req.body.part_number).to.match(/^WISH-TITLE-ONLY-WISHLIST-SAVE-/);
+      wishlistItems = [
+        ...wishlistItems,
+        {
+          id: "item-title-only-1",
+          title: req.body.title,
+          part_number: req.body.part_number,
+          status: "wishlist",
+          category: req.body.category || "General",
+          priority: req.body.priority,
+        },
+      ];
+      req.reply({
+        statusCode: 201,
+        body: wishlistItems[wishlistItems.length - 1],
+      });
+    }).as("createWishlistItem");
+    cy.intercept("POST", "/api/wishlist", (req) => {
+      expect(req.body.item_id).to.eq("item-title-only-1");
+      expect(req.body.priority).to.eq("medium");
+      expect(req.body.target_price).to.eq(0);
+      wishlistEntries = [
+        ...wishlistEntries,
+        {
+          id: "wish-title-only-1",
+          item_id: req.body.item_id,
+          priority: req.body.priority,
+          target_price: req.body.target_price,
+          notes: req.body.notes,
+          quantity: req.body.quantity,
+          needed_quantity: req.body.needed_quantity,
+        },
+      ];
+      req.reply({
+        statusCode: 201,
+        body: wishlistEntries[wishlistEntries.length - 1],
+      });
+    }).as("createWishlistEntry");
+
+    signInToWishlist({ skipStub: true, useExistingIntercepts: true });
+
+    cy.get('[data-testid="wishlist-new-action"]').click();
+    cy.contains("Create Wishlist Entry").should("be.visible");
+    cy.get('input[name="title"]').type("Title Only Wishlist Save");
+    cy.contains("button", "Save changes").click();
+
+    cy.wait("@createWishlistItem");
+    cy.wait("@createWishlistEntry");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("Wishlist save failed").should("not.exist");
+    cy.get('[data-testid="wishlist-create-panel"]').should("not.exist");
+    cy.contains("Title Only Wishlist Save").should("be.visible");
+  });
+
   it("UI-SCREEN-WISHLIST-010 persists wishlist edit and delete actions", () => {
     let wishlistEntries = [
       {

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -197,6 +197,20 @@ function normalizeOptionalWholeNumber(raw: string, fallback: number) {
   return parsed
 }
 
+function wishlistPartNumberFallback(title: string) {
+  const slug =
+    title
+      .trim()
+      .toUpperCase()
+      .replace(/[^A-Z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 24) || 'ITEM'
+  const suffix =
+    globalThis.crypto?.randomUUID?.().slice(0, 8).toUpperCase() ??
+    Date.now().toString(36).toUpperCase()
+  return `WISH-${slug}-${suffix}`
+}
+
 function firstImageFileFromDataTransfer(
   dataTransfer: DataTransfer | null
 ): File | null {
@@ -807,11 +821,13 @@ export function Tasks({
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               title: draft.title,
-              part_number: draft.partNumber,
+              part_number:
+                draft.partNumber || wishlistPartNumberFallback(draft.title),
               category: draft.category,
               item_type: draft.itemType,
               packaging_grade_type: draft.packagingGradeType,
               condition: draft.condition,
+              status: 'wishlist',
               priority: normalizeWishlistPriority(draft.priority),
             }),
           })


### PR DESCRIPTION
## Summary
- Fixes #1110 by allowing Wishlist title-only creates to persist with generated canonical part-number metadata.
- Marks newly created canonical items as `wishlist` before linking wishlist metadata.
- Adds OpenSpec requirement `UI-SCREEN-WISHLIST-019` and targeted Cypress coverage for the valid title-only flow.

## Validation
- `openspec validate --all --strict --no-interactive` (pass)
  - log: `.work-agent/logs/issue-1110/openspec-validate.log`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser chrome -RequireE2EHooks` (pass, 20/20)
  - log: `.work-agent/logs/issue-1110/cypress-ui-screen-wishlist-rerun.log`
  - summary: `.work-agent/logs/cypress/20260608-013757-spec.cy.summary.json`
  - runtime: `C:\projects\collectors-tech\cabinet\bin\cabinet.exe`
  - base URL: `http://127.0.0.1:17880`

## Notes
- First Cypress invocation used a doubled `ui.web` path and failed before running tests; rerun used the script-expected relative path and passed.