### PR TITLE
#1112 feat(integrations): add paginated provider table

### DIFF
--- a/openspec/specs/integrations/ui-screen-integrations/spec.md
+++ b/openspec/specs/integrations/ui-screen-integrations/spec.md
@@ -18,6 +18,23 @@ Integrations screen SHALL expose integration-type selector (default `All Integra
 - **WHEN** user toggles `Rows` and `Cards`
 - **THEN** provider presentation MUST switch deterministically and preserve active filter context
 
+### Requirement UI-SCREEN-INTEGRATIONS-011: Integrations screen SHALL use a paginated full-page table as the primary provider list
+Integrations screen SHALL render the primary provider list as a scan-friendly full-page table with pagination and stable operational columns.
+
+#### Scenario: Default integrations table renders stable scan columns
+- **GIVEN** integrations route is loaded with provider registry data
+- **WHEN** the primary provider list renders
+- **THEN** the default presentation MUST be a table, not cards
+- **AND** the table MUST include stable columns for provider/name, category/type, connection/config status, action availability, health/last-run state, and row actions
+- **AND** row actions MUST keep the provider configuration/details flow reachable
+
+#### Scenario: Integrations table paginates larger provider lists
+- **GIVEN** integrations route has more providers than the table page size
+- **WHEN** user uses pagination controls
+- **THEN** the visible rows MUST advance between pages
+- **AND** pagination status MUST report the visible range and current page
+- **AND** filter/type/sort changes MUST reset pagination to the first matching page
+
 #### Scenario: Filter and sort integrations
 - **GIVEN** integrations route is loaded with provider cards
 - **WHEN** user applies text filter, type filter, and sort order
@@ -149,3 +166,5 @@ Integrations provider configuration dialogs MUST render stable visible labels as
 | UC-INT-UI-11 | Provider API support detail display | Detail panel shows API family + support profile metadata | `ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-009 + UC-INT-UI-11 + INTEGRATION-024: detail panel shows API family + support profile metadata from registry` |
 | UC-INT-UI-12 | Provider edit fields are labeled | Dialog config fields have visible labels associated by `htmlFor`/`id` | `internal/app/ui_template_contract_test.go` `TestIntegrationsProviderConfigInputsHaveLabels` |
 | UC-INT-UI-13 | Validate provider health | Validation shows progress, reconciles health/last-run/last-checked, and reports resulting status | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-003 + UI-SCREEN-INTEGRATIONS-004 + UI-SCREEN-INTEGRATIONS-008: persists settings and reconciles validation health state` |
+| UC-INT-UI-14 | Primary integrations table | Default list renders full-page table columns with provider identity, type, connection, actions, health/last-run, and row actions | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-001 + UI-SCREEN-INTEGRATIONS-006 + INTEGRATION-022: defaults to table and supports filter/sort/view using registry data` |
+| UC-INT-UI-15 | Integrations table pagination | Larger provider lists page through stable table rows and reset to page 1 when filters change | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-011 + #1112: paginates the full-page integrations table` |

--- a/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
@@ -15,7 +15,7 @@ describe('ui-screen-integrations', () => {
     cy.clearLocalStorage()
   })
 
-  it('UI-SCREEN-INTEGRATIONS-001 + UI-SCREEN-INTEGRATIONS-006 + INTEGRATION-022: defaults to cards and supports filter/sort/view using registry data', () => {
+  it('UI-SCREEN-INTEGRATIONS-001 + UI-SCREEN-INTEGRATIONS-006 + INTEGRATION-022: defaults to table and supports filter/sort/view using registry data', () => {
     cy.intercept('GET', '/api/profiles/active', {
       statusCode: 200,
       body: { id: 'profile-e2e-001', name: 'E2E Local' },
@@ -80,20 +80,103 @@ describe('ui-screen-integrations', () => {
     cy.contains('integrations.title').should('not.exist')
     cy.contains('integrations.description').should('not.exist')
 
-    cy.get('[data-testid="provider-card-ebay"]').should('be.visible')
-    cy.get('[data-testid="provider-card-au-webshop-bonzaslotcars-com-au"]').should(
+    cy.get('[data-testid="integrations-table-surface"]').should('be.visible')
+    cy.contains('th', 'Provider').should('be.visible')
+    cy.contains('th', 'Category / Type').should('exist')
+    cy.contains('th', 'Connection').should('exist')
+    cy.contains('th', 'Actions').should('exist')
+    cy.contains('th', 'Health / Last run').should('exist')
+    cy.contains('th', 'Row actions').should('exist')
+    cy.get('[data-testid="provider-row-ebay"]').should('be.visible')
+    cy.get('[data-testid="provider-row-au-webshop-bonzaslotcars-com-au"]').should(
       'be.visible'
     )
 
     cy.get('input[placeholder="Filter providers..."]').clear().type('bonza')
+    cy.get('[data-testid="provider-row-au-webshop-bonzaslotcars-com-au"]').should(
+      'be.visible'
+    )
+    cy.get('[data-testid="provider-row-ebay"]').should('not.exist')
+
+    cy.contains('button', 'Cards').click()
+    cy.location('search').should('contain', 'view=cards')
     cy.get('[data-testid="provider-card-au-webshop-bonzaslotcars-com-au"]').should(
       'be.visible'
     )
-    cy.get('[data-testid="provider-card-ebay"]').should('not.exist')
-
     cy.contains('button', 'Rows').click()
-    cy.location('search').should('contain', 'view=rows')
     cy.get('table').should('be.visible')
+  })
+
+  it('UI-SCREEN-INTEGRATIONS-011 + #1112: paginates the full-page integrations table', () => {
+    const providers = Array.from({ length: 12 }, (_, index) => {
+      const number = index + 1
+      return {
+        provider_id: `provider-${String(number).padStart(2, '0')}`,
+        display_name: `Provider ${String(number).padStart(2, '0')}`,
+        base_domain: `provider-${number}.example.test`,
+        integration_mode: number % 2 === 0 ? 'official_api' : 'web_ingestion',
+        auth_mode: number % 2 === 0 ? 'api_key' : 'none',
+        state: 'ready',
+        has_token: number % 2 === 0,
+        setup_instructions: 'Configure provider credentials.',
+        capabilities: {
+          search: true,
+          stock_observation: number % 2 !== 0,
+          pricing: true,
+          health: true,
+        },
+        health: { status: number % 2 === 0 ? 'ok' : 'unknown' },
+        last_run: { status: number % 2 === 0 ? 'success' : 'never' },
+      }
+    })
+
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: { id: 'profile-e2e-001', name: 'E2E Local' },
+    }).as('activeProfile')
+    cy.intercept('GET', '/api/providers/registry', {
+      statusCode: 200,
+      body: { providers },
+    }).as('registry')
+    cy.intercept('GET', '/api/profiles/*/settings', {
+      statusCode: 200,
+      body: { settings: {} },
+    }).as('settings')
+
+    signIn()
+    cy.wait('@activeProfile')
+    cy.wait('@registry')
+    cy.wait('@settings')
+
+    cy.get('[data-testid="integrations-table-pagination"]').should(
+      'contain',
+      'Showing 1-10 of 12 integrations'
+    )
+    cy.get('[data-testid="integrations-table-page-status"]').should(
+      'contain',
+      'Page 1 of 2'
+    )
+    cy.get('[data-testid="provider-row-provider-01"]').should('be.visible')
+    cy.get('[data-testid="provider-row-provider-11"]').should('not.exist')
+
+    cy.get('[data-testid="integrations-table-next-page"]').click()
+    cy.get('[data-testid="integrations-table-pagination"]').should(
+      'contain',
+      'Showing 11-12 of 12 integrations'
+    )
+    cy.get('[data-testid="integrations-table-page-status"]').should(
+      'contain',
+      'Page 2 of 2'
+    )
+    cy.get('[data-testid="provider-row-provider-11"]').should('be.visible')
+    cy.get('[data-testid="provider-row-provider-01"]').should('not.exist')
+
+    cy.get('input[placeholder="Filter providers..."]').clear().type('12')
+    cy.get('[data-testid="integrations-table-page-status"]').should(
+      'contain',
+      'Page 1 of 1'
+    )
+    cy.get('[data-testid="provider-row-provider-12"]').should('be.visible')
   })
 
   it('UI-SCREEN-INTEGRATIONS-010: applies direct route query state on first render', () => {
@@ -258,6 +341,7 @@ describe('ui-screen-integrations', () => {
     cy.wait('@registry')
     cy.wait('@settings')
 
+    cy.contains('button', 'Cards').click()
     cy.get('[data-testid="provider-card-telegram"]')
       .should('be.visible')
       .and('contain', 'Telegram')
@@ -851,8 +935,8 @@ describe('ui-screen-integrations', () => {
       .scrollIntoView()
       .should('be.visible')
     cy.contains('button', 'Cancel').click()
-    cy.contains('[data-testid="provider-card-ebay"]', 'Health: ok').should('be.visible')
-    cy.contains('[data-testid="provider-card-ebay"]', 'Last run: success').should('be.visible')
+    cy.contains('[data-testid="provider-row-ebay"]', 'Health: ok').should('be.visible')
+    cy.contains('[data-testid="provider-row-ebay"]', 'Last run: success').should('be.visible')
     cy.get('[data-testid="provider-open-ebay"]').click()
     cy.get('[data-testid="replace-token"]').click()
     cy.get('[data-testid="provider-token-input"]').type('new-secret-token')
@@ -945,7 +1029,7 @@ describe('ui-screen-integrations', () => {
     cy.wait('@setActiveProfile')
     cy.wait('@registryRecovered')
     cy.wait('@settingsRecovered')
-    cy.get('[data-testid="provider-card-ebay"]').should('be.visible')
+    cy.get('[data-testid="provider-row-ebay"]').should('be.visible')
     cy.get('[data-testid="integrations-bootstrap-error"]').should('not.exist')
   })
 
@@ -1019,6 +1103,7 @@ describe('ui-screen-integrations', () => {
     })
 
     signIn()
+    cy.contains('button', 'Cards').click()
     cy.get('[data-testid="provider-card-au-webshop-voglers-com-au"]').should('be.visible')
     cy.get('[data-testid="provider-api-family-au-webshop-voglers-com-au"]')
       .should('be.visible')

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -299,6 +299,8 @@ type AppsProps = {
   description?: string
 }
 
+const integrationTablePageSize = 10
+
 const appText = new Map<AppType, string>([
   ['all', 'All Integrations'],
   ['connected', 'Connected'],
@@ -415,6 +417,19 @@ function sellerOperationState(status: SellerOperationStatus) {
   return 'Blocked'
 }
 
+function capabilityLabels(provider: ProviderRecord) {
+  return [
+    provider.capabilities.search ? 'Search' : null,
+    provider.capabilities.stock_observation ? 'Stock' : null,
+    provider.capabilities.pricing ? 'Pricing' : null,
+    provider.capabilities.health ? 'Health' : null,
+    provider.capabilities.assistant ? 'Assistant' : null,
+    provider.capabilities.image_help ? 'Image help' : null,
+    provider.capabilities.media_capture ? 'Media capture' : null,
+    provider.capabilities.text_capture ? 'Text capture' : null,
+  ].filter((label): label is string => Boolean(label))
+}
+
 function providerSettingsKeys(providerID: string) {
   if (providerID === 'ebay') {
     return {
@@ -509,7 +524,8 @@ export function Apps({
   const [sort, setSort] = useState(initSort)
   const [appType, setAppType] = useState(type)
   const [searchTerm, setSearchTerm] = useState(filter)
-  const viewMode: ViewMode = view ?? 'cards'
+  const viewMode: ViewMode = view ?? 'rows'
+  const [tablePage, setTablePage] = useState(1)
   const [activeProfileId, setActiveProfileId] = useState('')
   const [settings, setSettings] = useState<Record<string, string>>({})
   const [providers, setProviders] = useState<ProviderRecord[]>([])
@@ -683,10 +699,29 @@ export function Apps({
     .filter((provider) =>
       provider.display_name.toLowerCase().includes(searchTerm.toLowerCase())
     )
+  const tablePageCount = Math.max(
+    1,
+    Math.ceil(filteredProviders.length / integrationTablePageSize)
+  )
+  const tableStart = (tablePage - 1) * integrationTablePageSize
+  const paginatedProviders = filteredProviders.slice(
+    tableStart,
+    tableStart + integrationTablePageSize
+  )
+  const tableRangeStart = filteredProviders.length ? tableStart + 1 : 0
+  const tableRangeEnd = Math.min(
+    filteredProviders.length,
+    tableStart + paginatedProviders.length
+  )
+
+  useEffect(() => {
+    setTablePage((page) => Math.min(page, tablePageCount))
+  }, [tablePageCount])
 
   const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
     setSearchTerm(value)
+    setTablePage(1)
     navigate({
       search: (prev) => ({
         ...prev,
@@ -763,6 +798,7 @@ export function Apps({
 
   const handleTypeChange = (value: AppType) => {
     setAppType(value)
+    setTablePage(1)
     navigate({
       search: (prev) => ({
         ...prev,
@@ -773,6 +809,7 @@ export function Apps({
 
   const handleSortChange = (nextSort: 'asc' | 'desc') => {
     setSort(nextSort)
+    setTablePage(1)
     navigate({ search: (prev) => ({ ...prev, sort: nextSort }) })
   }
 
@@ -780,7 +817,7 @@ export function Apps({
     navigate({
       search: (prev) => ({
         ...prev,
-        view: nextView === 'cards' ? undefined : nextView,
+        view: nextView === 'rows' ? undefined : nextView,
       }),
     })
   }
@@ -1713,68 +1750,144 @@ export function Apps({
         ) : null}
 
         {!loading && viewMode === 'rows' ? (
-          <div className='overflow-hidden rounded-md border'>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Provider</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Health</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead className='text-right'>Action</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredProviders.length ? (
-                  filteredProviders.map((provider) => (
-                    <TableRow
-                      key={provider.provider_id}
-                      onClick={(event) => handleRowClick(provider, event)}
-                      onDoubleClick={(event) =>
-                        handleRowDoubleClick(provider, event)
-                      }
-                    >
-                      <TableCell>
-                        <div className='flex items-center gap-2'>
-                          <div className='flex size-8 items-center justify-center rounded-md bg-muted p-1.5'>
-                            <Store className='size-4' />
-                          </div>
-                          <span className='font-medium'>
-                            {provider.display_name}
-                          </span>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        {isConnected(provider, settings)
-                          ? 'Connected'
-                          : 'Not Connected'}
-                      </TableCell>
-                      <TableCell>
-                        {provider.health?.status ?? 'unknown'}
-                      </TableCell>
-                      <TableCell className='text-muted-foreground'>
-                        {provider.integration_mode}
-                      </TableCell>
-                      <TableCell className='text-right'>
-                        <Button
-                          variant='outline'
-                          size='sm'
-                          onClick={() => openIntegration(provider)}
+          <div className='space-y-3' data-testid='integrations-table-surface'>
+            <div className='overflow-x-auto rounded-md border'>
+              <Table className='min-w-[72rem] table-fixed'>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className='w-[18rem]'>Provider</TableHead>
+                    <TableHead className='w-[14rem]'>Category / Type</TableHead>
+                    <TableHead className='w-[11rem]'>Connection</TableHead>
+                    <TableHead>Actions</TableHead>
+                    <TableHead className='w-[14rem]'>
+                      Health / Last run
+                    </TableHead>
+                    <TableHead className='w-[8rem] text-right'>
+                      Row actions
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginatedProviders.length ? (
+                    paginatedProviders.map((provider) => {
+                      const capabilities = capabilityLabels(provider)
+                      return (
+                        <TableRow
+                          key={provider.provider_id}
+                          data-testid={`provider-row-${provider.provider_id}`}
+                          onClick={(event) => handleRowClick(provider, event)}
+                          onDoubleClick={(event) =>
+                            handleRowDoubleClick(provider, event)
+                          }
                         >
-                          {isConnected(provider, settings) ? 'Edit' : 'Connect'}
-                        </Button>
+                          <TableCell className='align-top'>
+                            <div className='flex min-w-0 items-center gap-2'>
+                              <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-muted p-1.5'>
+                                <Store className='size-4' />
+                              </div>
+                              <div className='min-w-0'>
+                                <p className='truncate font-medium'>
+                                  {provider.display_name}
+                                </p>
+                                <p className='truncate text-xs text-muted-foreground'>
+                                  {provider.base_domain || provider.provider_id}
+                                </p>
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell className='align-top text-sm'>
+                            <p className='truncate'>
+                              {provider.integration_mode}
+                            </p>
+                            <p className='truncate text-xs text-muted-foreground'>
+                              API Family: {provider.api_family ?? 'custom'}
+                            </p>
+                          </TableCell>
+                          <TableCell className='align-top text-sm'>
+                            {isConnected(provider, settings)
+                              ? 'Connected'
+                              : 'Not Connected'}
+                            <p className='text-xs text-muted-foreground'>
+                              Auth: {provider.auth_mode}
+                            </p>
+                          </TableCell>
+                          <TableCell className='align-top text-sm text-muted-foreground'>
+                            {capabilities.length
+                              ? capabilities.join(', ')
+                              : 'None'}
+                          </TableCell>
+                          <TableCell className='align-top text-sm'>
+                            <p>
+                              Health: {provider.health?.status ?? 'unknown'}
+                            </p>
+                            <p className='text-xs text-muted-foreground'>
+                              Last run: {provider.last_run?.status ?? 'never'}
+                            </p>
+                          </TableCell>
+                          <TableCell className='text-right align-top'>
+                            <Button
+                              variant='outline'
+                              size='sm'
+                              data-testid={`provider-open-${provider.provider_id}`}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                openIntegration(provider)
+                              }}
+                            >
+                              {isConnected(provider, settings)
+                                ? 'Edit'
+                                : 'Connect'}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={6} className='h-24 text-center'>
+                        No integrations match current filters.
                       </TableCell>
                     </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={5} className='h-24 text-center'>
-                      No integrations match current filters.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+            <div
+              className='flex flex-col gap-2 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between'
+              data-testid='integrations-table-pagination'
+            >
+              <p>
+                Showing {tableRangeStart}-{tableRangeEnd} of{' '}
+                {filteredProviders.length} integrations
+              </p>
+              <div className='flex items-center gap-2'>
+                <Button
+                  type='button'
+                  size='sm'
+                  variant='outline'
+                  disabled={tablePage === 1}
+                  data-testid='integrations-table-prev-page'
+                  onClick={() => setTablePage((page) => Math.max(1, page - 1))}
+                >
+                  Previous
+                </Button>
+                <span data-testid='integrations-table-page-status'>
+                  Page {tablePage} of {tablePageCount}
+                </span>
+                <Button
+                  type='button'
+                  size='sm'
+                  variant='outline'
+                  disabled={tablePage >= tablePageCount}
+                  data-testid='integrations-table-next-page'
+                  onClick={() =>
+                    setTablePage((page) => Math.min(tablePageCount, page + 1))
+                  }
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
           </div>
         ) : null}
 


### PR DESCRIPTION
## Summary
- Changes `/integrations` default provider list from cards to a full-page rows/table surface.
- Adds stable scan columns for provider identity, category/type, connection, action availability, health/last-run state, and row actions.
- Adds 10-row pagination with previous/next controls, visible range status, and page reset on filter/type/sort changes.
- Updates Integrations OpenSpec traceability and targeted Cypress coverage for table rendering and pagination.

## Validation
- PASS: `openspec validate --all --strict --no-interactive`
  - log: `.work-agent/logs/issue-1112-integrations-table/openspec-validate.log`
- PASS: changed-file ESLint from `ui.web`: `npx eslint src/features/apps/index.tsx cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts`
  - log: `.work-agent/logs/issue-1112-integrations-table/changed-file-eslint.log`
- PASS: `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts -Browser chrome -RequireE2EHooks`
  - 14 passing, 0 failing
  - wrapper log: `.work-agent/logs/issue-1112-integrations-table/cypress-integrations.log`
  - cypress summary: `.work-agent/logs/cypress/20260608-110321-spec.cy.summary.json`
- PASS: `git diff --check`
  - log: `.work-agent/logs/issue-1112-integrations-table/git-diff-check.log`
- PASS during push hook: OpenSpec and fast API docs smoke test
  - log: `.work-agent/logs/issue-1112-integrations-table/git-push.log`

## Deployment
- Not merged or deployed in this run. PR targets `develop`; next step is PR review/full merge gates, then merge and recycle demo lane from `develop`.

Closes #1112