### PR TITLE
#1143 fix(collections): submit create dialog with Enter

### DIFF
--- a/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/ui-screen-collections/spec.cy.ts
@@ -383,6 +383,9 @@ describe('ui-screen-collections', () => {
     cy.get('[data-testid="collections-create-error"]')
       .should('be.visible')
       .and('contain.text', 'Enter a unique collection name.')
+    cy.get('[data-testid="collections-create-input"]')
+      .should('have.attr', 'aria-invalid', 'true')
+      .and('be.focused')
     cy.get('@saveCollectionSettings.all').should('have.length', 0)
 
     cy.get('[data-testid="collections-create-input"]').type(

--- a/ui.web/src/features/collections/index.tsx
+++ b/ui.web/src/features/collections/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   type ColumnDef,
   flexRender,
@@ -320,6 +320,7 @@ export function Collections() {
   const [createValue, setCreateValue] = useState('')
   const [createError, setCreateError] = useState('')
   const [createSubmitting, setCreateSubmitting] = useState(false)
+  const createInputRef = useRef<HTMLInputElement>(null)
   const [editValue, setEditValue] = useState('')
   const [inventoryMembers, setInventoryMembers] = useState<
     CollectionMemberRow[]
@@ -595,6 +596,7 @@ export function Collections() {
       const created = await addCollection(createValue)
       if (!created) {
         setCreateError('Enter a unique collection name.')
+        createInputRef.current?.focus()
         return
       }
       setSelectedCollectionID(collectionKey(created))
@@ -913,12 +915,20 @@ export function Collections() {
             </DialogHeader>
             <div className='space-y-2'>
               <Input
+                ref={createInputRef}
                 value={createValue}
                 onChange={(event) => {
                   setCreateValue(event.target.value)
                   if (createError) {
                     setCreateError('')
                   }
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== 'Enter') {
+                    return
+                  }
+                  event.preventDefault()
+                  void handleCreateCollection()
                 }}
                 placeholder='Collection name'
                 aria-invalid={createError ? 'true' : undefined}


### PR DESCRIPTION
## Summary
- Restores Enter submit for the Collections create-dialog name input by routing Enter through the existing create handler.
- Keeps the invalid Enter path focused on the input with `aria-invalid` so validation is visible and keyboard-friendly.
- Tightens `UI-SCREEN-COLLECTIONS-022` Cypress coverage for invalid Enter focus plus valid Enter persistence.

## Validation
- `openspec validate --all --strict --no-interactive` -> PASS
- `npm exec eslint -- src/features/collections/index.tsx cypress/e2e/collections/ui-screen-collections/spec.cy.ts` from `ui.web` -> PASS
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/collections/ui-screen-collections/spec.cy.ts -Browser chrome -RequireE2EHooks` -> PASS, 22/22
- `git diff --check` -> PASS

## Logs
- `.work-agent/logs/1143-collections-enter-create/20260609-0200-cron/validation-summary.json`
- `.work-agent/logs/1143-collections-enter-create/20260609-0200-cron/openspec-validate.log`
- `.work-agent/logs/1143-collections-enter-create/20260609-0200-cron/eslint-changed-ui-rerun.log`
- `.work-agent/logs/1143-collections-enter-create/20260609-0200-cron/cypress-collections-ui-screen.log`
- `.work-agent/logs/1143-collections-enter-create/20260609-0200-cron/git-diff-check.log`

Note: the first lint invocation was run from the wrong working directory and recorded exit 2 in `eslint-changed-ui.log`; the corrected changed-file lint rerun passed and is recorded in `eslint-changed-ui-rerun.log`.

Closes #1143