### PR TITLE
#1046 feat(wishlist): expose purchase delivery controls

### DIFF
--- a/internal/app/e2e_hooks.go
+++ b/internal/app/e2e_hooks.go
@@ -251,28 +251,37 @@ func registerE2ETestHooks(mux *http.ServeMux, conn *sql.DB, cfg config.Config) {
 }
 
 func resetE2EDatabase(ctx context.Context, conn *sql.DB) error {
+	if _, err := conn.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		return fmt.Errorf("disable foreign keys: %w", err)
+	}
+	defer func() { _, _ = conn.ExecContext(context.Background(), `PRAGMA foreign_keys = ON`) }()
+
 	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin reset tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if _, err := tx.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
-		return fmt.Errorf("disable foreign keys: %w", err)
-	}
-
 	tables := []string{
 		"activity_logs",
 		"ai_failures",
 		"app_state",
+		"assistant_workflow_runs",
+		"audit_events",
 		"chat_action_previews",
 		"chat_attachments",
+		"chat_inbox_items",
 		"chat_messages",
 		"chat_threads",
 		"discovery_actions",
+		"expected_arrivals",
+		"forwarder_package_link_events",
+		"forwarder_package_links",
+		"forwarder_packages",
 		"ignored_candidates",
 		"item_barcodes",
 		"item_photos",
+		"media_asset_links",
 		"price_snapshots",
 		"profile_licenses",
 		"profile_secrets",
@@ -285,6 +294,7 @@ func resetE2EDatabase(ctx context.Context, conn *sql.DB) error {
 		"webauthn_credentials",
 		"wishlist_entries",
 		"pokemon_graded_overrides",
+		"commerce_lifecycle_entries",
 		"instances",
 		"profile_settings",
 		"scanner_query_sets",

--- a/internal/app/e2e_hooks_reset_test.go
+++ b/internal/app/e2e_hooks_reset_test.go
@@ -35,6 +35,23 @@ func TestE2EResetEndpointSkipsMissingLegacyTables(t *testing.T) {
 	assertLegacyResetCleared(t, a)
 }
 
+func TestE2EResetEndpointClearsWishlistPurchaseDeliveryState(t *testing.T) {
+	t.Parallel()
+
+	a := newE2ETestApp(t)
+	seedWishlistPurchaseDeliveryResetState(t, a)
+
+	reset := doRequest(t, a, http.MethodPost, "/api/test/reset", nil, nil)
+	if reset.Code != http.StatusOK {
+		t.Fatalf("reset status=%d body=%s", reset.Code, reset.Body.String())
+	}
+	assertTableEmpty(t, a, "expected_arrivals")
+	assertTableEmpty(t, a, "commerce_lifecycle_entries")
+	assertTableEmpty(t, a, "wishlist_entries")
+	assertTableEmpty(t, a, "instances")
+	assertTableEmpty(t, a, "canonical_items")
+}
+
 func seedLegacyResetState(t *testing.T, a *App) {
 	t.Helper()
 	ctx := context.Background()
@@ -46,14 +63,57 @@ func seedLegacyResetState(t *testing.T, a *App) {
 	}
 }
 
+func seedWishlistPurchaseDeliveryResetState(t *testing.T, a *App) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := a.db.ExecContext(ctx, `INSERT INTO profiles(id, name) VALUES ('reset-profile', 'Reset Profile')`); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `
+		INSERT INTO canonical_items(id, profile_id, brand, part_number, title, status, category)
+		VALUES ('reset-item', 'reset-profile', 'Reset Brand', 'RESET-001', 'Reset Item', 'wishlist', 'Trading Cards')
+	`); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `
+		INSERT INTO wishlist_entries(id, profile_id, item_id, owned, delivered)
+		VALUES ('reset-wish', 'reset-profile', 'reset-item', 1, 1)
+	`); err != nil {
+		t.Fatalf("seed wishlist: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `
+		INSERT INTO commerce_lifecycle_entries(id, profile_id, item_id, state, source, external_ref, quantity)
+		VALUES ('reset-life', 'reset-profile', 'reset-item', 'purchase', 'wishlist', 'reset-wish', 1)
+	`); err != nil {
+		t.Fatalf("seed lifecycle: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `
+		INSERT INTO instances(id, item_id, status, quantity)
+		VALUES ('reset-instance', 'reset-item', 'sealed', 1)
+	`); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `
+		INSERT INTO expected_arrivals(id, profile_id, item_id, lifecycle_entry_id, source, external_ref, quantity, status, reconciled_instance_id)
+		VALUES ('reset-arrival', 'reset-profile', 'reset-item', 'reset-life', 'wishlist', 'reset-wish', 1, 'delivered', 'reset-instance')
+	`); err != nil {
+		t.Fatalf("seed arrival: %v", err)
+	}
+}
+
 func assertLegacyResetCleared(t *testing.T, a *App) {
 	t.Helper()
+	assertTableEmpty(t, a, "activity_logs")
+}
+
+func assertTableEmpty(t *testing.T, a *App, table string) {
+	t.Helper()
 	var remaining int
-	if err := a.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM activity_logs`).Scan(&remaining); err != nil {
-		t.Fatalf("count activity logs after reset: %v", err)
+	if err := a.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM `+table).Scan(&remaining); err != nil {
+		t.Fatalf("count %s after reset: %v", table, err)
 	}
 	if remaining != 0 {
-		t.Fatalf("expected reset to clear present tables, got %d activity logs", remaining)
+		t.Fatalf("expected reset to clear %s, got %d rows", table, remaining)
 	}
 }
 

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -641,6 +641,127 @@ describe("ui-screen-wishlist", () => {
     });
   });
 
+  it("UI-SCREEN-WISHLIST-020 edits Purchased, Delivered, and Category workflow fields", () => {
+    let wishlistEntries = [
+      {
+        id: "wish-workflow-1",
+        item_id: "item-collector-1",
+        priority: "medium",
+        below_target_now: false,
+        owned: false,
+        delivered: false,
+        target_price: 20,
+        quantity: 0,
+        needed_quantity: 1,
+      },
+    ];
+    let wishlistItems = [
+      {
+        id: "item-collector-1",
+        title: "AFX Mega-G+ Camaro Wildfire",
+        part_number: "22073",
+        status: "wishlist",
+        category: "Slot Cars",
+        priority: "medium",
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistEntries } });
+    }).as("wishlistItems");
+    cy.intercept("GET", "/api/items?status=wishlist", (req) => {
+      req.reply({ statusCode: 200, body: { items: wishlistItems } });
+    }).as("catalogItems");
+    cy.intercept("PUT", "/api/items/item-collector-1", (req) => {
+      expect(req.body.category).to.eq("Race Cars");
+      wishlistItems = wishlistItems.map((item) =>
+        item.id === "item-collector-1"
+          ? { ...item, category: req.body.category }
+          : item
+      );
+      req.reply({ statusCode: 200, body: wishlistItems[0] });
+    }).as("updateWishlistItemCategory");
+    cy.intercept("PUT", "/api/wishlist", (req) => {
+      expect(req.body).to.include({
+        id: "wish-workflow-1",
+        item_id: "item-collector-1",
+        owned: true,
+        delivered: true,
+      });
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === "wish-workflow-1"
+          ? { ...entry, owned: req.body.owned, delivered: req.body.delivered }
+          : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("updateWishlistWorkflow");
+
+    signInToWishlist({ skipStub: true, useExistingIntercepts: true });
+    cy.get('button[aria-label="Switch to rows view"]').click();
+    cy.get('[data-testid="wishlist-table-surface"]').scrollTo("left", {
+      ensureScrollable: false,
+    });
+    cy.contains("th", "Purchased").should("exist");
+    cy.contains("th", "Delivered").should("exist");
+    cy.contains("th", "Category").should("exist");
+    cy.contains("th", "Owned").should("not.exist");
+    cy.get('[data-testid="wishlist-category-item-collector-1"]').should(
+      "contain.text",
+      "Slot Cars"
+    );
+    cy.get('[data-testid="wishlist-delivered-checkbox-item-collector-1"]')
+      .scrollIntoView()
+      .should("be.visible")
+      .and("have.attr", "aria-checked", "false");
+
+    openWishlistRowActions("AFX Mega-G+ Camaro Wildfire");
+    cy.contains('[role="menuitem"]', "Edit").click({ force: true });
+    cy.contains("Edit Wishlist Entry").should("be.visible");
+    cy.contains("Owned").should("not.exist");
+    cy.contains("Purchased").should("exist");
+    cy.contains("Delivered").should("exist");
+    cy.get('input[name="category"]').clear().type("Race Cars");
+    cy.get('[data-testid="wishlist-edit-owned"]')
+      .scrollIntoView()
+      .should("be.visible");
+    cy.get('[data-testid="wishlist-edit-delivered"]')
+      .scrollIntoView()
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="wishlist-edit-owned"]').should(
+      "have.attr",
+      "aria-checked",
+      "true"
+    );
+    cy.contains("button", "Save changes").click();
+
+    cy.wait("@updateWishlistItemCategory");
+    cy.wait("@updateWishlistWorkflow");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.get('[data-testid="wishlist-edit-panel"]').should("not.exist");
+    cy.get('[data-testid="wishlist-category-item-collector-1"]').should(
+      "contain.text",
+      "Race Cars"
+    );
+    cy.get('[data-testid="wishlist-delivered-checkbox-item-collector-1"]').should(
+      "have.attr",
+      "aria-checked",
+      "true"
+    );
+
+    cy.contains("button", "Cards").click();
+    cy.get('[data-testid="wishlist-card-purchased-item-collector-1"]').should(
+      "contain.text",
+      "Purchased: Yes"
+    );
+    cy.get('[data-testid="wishlist-card-delivered-item-collector-1"]').should(
+      "contain.text",
+      "Delivered: Yes"
+    );
+    cy.contains("Category: Race Cars").should("be.visible");
+  });
+
   it("UI-SCREEN-WISHLIST-006 does not expose Mark owned from the row action menu", () => {
     const wishlistEntries = [
       {

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { type ColumnDef } from '@tanstack/react-table'
 import {
   BarcodeIcon,
@@ -53,6 +53,7 @@ type WishlistInlineChanges = {
   targetPrice?: number
   priority?: string
   owned?: boolean
+  delivered?: boolean
   pricePaid?: number
   purchaseUrl?: string
   purchaseDate?: string
@@ -416,10 +417,6 @@ function WishlistCostCell({
 }) {
   const [draft, setDraft] = useState(formatCostDraft(task.targetPrice))
 
-  useEffect(() => {
-    setDraft(formatCostDraft(task.targetPrice))
-  }, [task.targetPrice])
-
   const persistValue = async (rawValue: string) => {
     const trimmed = rawValue.trim()
     const nextValue = trimmed === '' ? 0 : Number(trimmed)
@@ -537,7 +534,7 @@ function WishlistPriorityCell({
   )
 }
 
-function WishlistOwnedCell({
+function WishlistPurchasedCell({
   task,
   onWishlistPurchaseRow,
 }: {
@@ -556,12 +553,51 @@ function WishlistOwnedCell({
         size='icon'
         className='h-8 w-8'
         data-testid={`wishlist-purchase-open-${task.id}`}
-        aria-label={`Add purchase details for ${task.title}`}
+        aria-label={
+          task.owned
+            ? `Edit purchase details for ${task.title}`
+            : `Add purchase details for ${task.title}`
+        }
         onClick={() => onWishlistPurchaseRow?.(task)}
       >
         <PlusIcon className='h-4 w-4' />
+        <span className='sr-only'>{task.owned ? 'Purchased' : 'Add'}</span>
       </Button>
+      <span
+        className='ml-2 text-xs text-muted-foreground'
+        data-testid={`wishlist-purchased-state-${task.id}`}
+      >
+        {task.owned ? 'Yes' : 'No'}
+      </span>
     </div>
+  )
+}
+
+function WishlistDeliveredCell({
+  task,
+  onWishlistInlineUpdate,
+}: {
+  task: Task
+  onWishlistInlineUpdate?: (
+    task: Task,
+    changes: WishlistInlineChanges
+  ) => Promise<void>
+}) {
+  const toggleDelivered = (checked: boolean) => {
+    void onWishlistInlineUpdate?.(task, {
+      delivered: checked,
+      owned: checked ? true : task.owned,
+    })
+  }
+
+  return (
+    <Checkbox
+      checked={Boolean(task.delivered)}
+      data-testid={`wishlist-delivered-checkbox-${task.id}`}
+      aria-label={`Delivered for ${task.title}`}
+      onClick={(event) => event.stopPropagation()}
+      onCheckedChange={(checked) => toggleDelivered(Boolean(checked))}
+    />
   )
 }
 
@@ -596,10 +632,6 @@ function WishlistNumberCell({
 }) {
   const normalizedValue = value ?? minValue
   const [draft, setDraft] = useState(String(normalizedValue))
-
-  useEffect(() => {
-    setDraft(String(normalizedValue))
-  }, [normalizedValue])
 
   const persistValue = async (rawValue: string) => {
     const parsed = Number(rawValue.trim())
@@ -872,19 +904,48 @@ export function getTasksColumns({
           {
             accessorKey: 'owned',
             header: ({ column }) => (
-              <DataTableColumnHeader column={column} title='Owned' />
+              <DataTableColumnHeader column={column} title='Purchased' />
             ),
             meta: {
-              className: 'w-16 min-w-16 ps-1',
+              className: 'w-[7.5rem] min-w-[7.5rem] ps-1',
               tdClassName: 'ps-4 pe-3',
             },
             cell: ({ row }) => (
-              <WishlistOwnedCell
+              <WishlistPurchasedCell
                 task={row.original}
                 onWishlistPurchaseRow={onWishlistPurchaseRow}
               />
             ),
             enableSorting: false,
+          } satisfies ColumnDef<Task>,
+          {
+            accessorKey: 'delivered',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Delivered' />
+            ),
+            meta: {
+              className: 'w-[7rem] min-w-[7rem] ps-1',
+              tdClassName: 'ps-4 pe-3',
+            },
+            cell: ({ row }) => (
+              <WishlistDeliveredCell
+                task={row.original}
+                onWishlistInlineUpdate={onWishlistInlineUpdate}
+              />
+            ),
+            enableSorting: false,
+          } satisfies ColumnDef<Task>,
+          {
+            accessorKey: 'label',
+            header: ({ column }) => (
+              <DataTableColumnHeader column={column} title='Category' />
+            ),
+            meta: { className: 'ps-1', tdClassName: 'ps-4' },
+            cell: ({ row }) => (
+              <span data-testid={`wishlist-category-${row.original.id}`}>
+                {row.original.label || 'General'}
+              </span>
+            ),
           } satisfies ColumnDef<Task>,
           {
             accessorKey: 'pricePaid',
@@ -957,6 +1018,7 @@ export function getTasksColumns({
             meta: { className: 'ps-1', tdClassName: 'ps-4' },
             cell: ({ row }) => (
               <WishlistCostCell
+                key={`${row.original.id}-${row.original.targetPrice ?? 0}`}
                 task={row.original}
                 onWishlistInlineUpdate={onWishlistInlineUpdate}
               />
@@ -970,6 +1032,7 @@ export function getTasksColumns({
             meta: { className: 'ps-1', tdClassName: 'ps-4' },
             cell: ({ row }) => (
               <WishlistNumberCell
+                key={`${row.original.id}-quantity-${row.original.quantity ?? 0}`}
                 task={row.original}
                 field='quantity'
                 label='Quantity'
@@ -987,6 +1050,7 @@ export function getTasksColumns({
             meta: { className: 'ps-1', tdClassName: 'ps-4' },
             cell: ({ row }) => (
               <WishlistNumberCell
+                key={`${row.original.id}-needed-${row.original.neededQuantity ?? 1}`}
                 task={row.original}
                 field='neededQuantity'
                 label='Needs'

--- a/ui.web/src/features/tasks/components/tasks-import-dialog.tsx
+++ b/ui.web/src/features/tasks/components/tasks-import-dialog.tsx
@@ -107,6 +107,7 @@ function parseWishlistImportCsv(text: string): WishlistEntryDraft[] {
       notes: cells[columnIndex('notes')]?.trim() ?? '',
       targetPrice: cells[columnIndex('target_price')]?.trim() ?? '',
       owned: false,
+      delivered: false,
       pricePaid: '',
       purchaseUrl: '',
       purchaseDate: '',

--- a/ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx
+++ b/ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx
@@ -38,6 +38,7 @@ export type WishlistEntryDraft = {
   notes: string
   targetPrice: string
   owned: boolean
+  delivered: boolean
   pricePaid: string
   purchaseUrl: string
   purchaseDate: string
@@ -82,6 +83,7 @@ const wishlistFormSchema = z.object({
   priority: z.string().trim().min(1, 'Please choose a priority.'),
   notes: z.string(),
   owned: z.boolean(),
+  delivered: z.boolean(),
   targetPrice: z.string().refine((value) => {
       if (value.trim() === '') {
         return true
@@ -130,6 +132,7 @@ function wishlistDefaults(currentRow?: Task): WishlistForm {
     priority: currentRow?.priority ?? 'medium',
     notes: currentRow?.notes ?? '',
     owned: Boolean(currentRow?.owned),
+    delivered: Boolean(currentRow?.delivered),
     targetPrice:
       typeof currentRow?.targetPrice === 'number' && currentRow.targetPrice > 0
         ? String(currentRow.targetPrice)
@@ -220,7 +223,8 @@ export function TasksMutateDrawer({
         priority: data.priority.trim(),
         notes: data.notes.trim(),
         targetPrice: data.targetPrice.trim(),
-        owned: data.owned,
+        owned: data.owned || data.delivered,
+        delivered: data.delivered,
         pricePaid: data.pricePaid.trim(),
         purchaseUrl: data.purchaseUrl.trim(),
         purchaseDate: data.purchaseDate.trim(),
@@ -435,7 +439,7 @@ export function TasksMutateDrawer({
                 name='owned'
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Owned</FormLabel>
+                    <FormLabel>Purchased</FormLabel>
                     <FormControl>
                       <button
                         type='button'
@@ -446,13 +450,49 @@ export function TasksMutateDrawer({
                         onClick={() => field.onChange(!field.value)}
                       >
                         <span>
-                          {field.value ? 'Owned' : 'Still on wishlist'}
+                          {field.value ? 'Purchased' : 'Still on wishlist'}
                         </span>
                         <span aria-hidden='true'>
                           {field.value ? 'Yes' : 'No'}
                         </span>
                       </button>
                     </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={wishlistForm.control}
+                name='delivered'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Delivered</FormLabel>
+                    <FormControl>
+                      <button
+                        type='button'
+                        role='checkbox'
+                        aria-checked={field.value}
+                        data-testid='wishlist-edit-delivered'
+                        className='flex h-10 w-full items-center justify-between rounded-md border px-3 text-sm'
+                        onClick={() => {
+                          const nextDelivered = !field.value
+                          field.onChange(nextDelivered)
+                          if (nextDelivered) {
+                            wishlistForm.setValue('owned', true)
+                          }
+                        }}
+                      >
+                        <span>
+                          {field.value ? 'Delivered' : 'Awaiting delivery'}
+                        </span>
+                        <span aria-hidden='true'>
+                          {field.value ? 'Yes' : 'No'}
+                        </span>
+                      </button>
+                    </FormControl>
+                    <p className='text-xs text-muted-foreground'>
+                      Delivered items are also saved as Purchased.
+                    </p>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -75,6 +75,7 @@ type DataTableProps = {
       targetPrice?: number
       priority?: string
       owned?: boolean
+      delivered?: boolean
       pricePaid?: number
       purchaseUrl?: string
       purchaseDate?: string
@@ -897,6 +898,7 @@ export function TasksTable({
 
     await onWishlistInlineUpdate?.(purchaseTask, {
       owned: true,
+      delivered: purchaseTask.delivered,
       pricePaid: parsedPrice,
       purchaseUrl: purchaseUrl.trim(),
       purchaseDate: purchaseDate || todayISODate(),
@@ -1277,9 +1279,19 @@ export function TasksTable({
                       : row.original.status}
                   </span>
                   <span>Priority: {row.original.priority}</span>
-                  <span>Type: {row.original.label}</span>
+                  <span>Category: {row.original.label}</span>
                   {routePath === '/_authenticated/wishlist/' ? (
                     <>
+                      <span
+                        data-testid={`wishlist-card-purchased-${row.original.id}`}
+                      >
+                        Purchased: {row.original.owned ? 'Yes' : 'No'}
+                      </span>
+                      <span
+                        data-testid={`wishlist-card-delivered-${row.original.id}`}
+                      >
+                        Delivered: {row.original.delivered ? 'Yes' : 'No'}
+                      </span>
                       <span
                         data-testid={`wishlist-card-date-added-${row.original.id}`}
                       >

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -32,6 +32,7 @@ export const taskSchema = z.object({
   priceStockCount: z.number().optional(),
   highlightHit: z.boolean().optional(),
   owned: z.boolean().optional(),
+  delivered: z.boolean().optional(),
   pricePaid: z.number().optional(),
   purchaseUrl: z.string().optional(),
   purchaseDate: z.string().optional(),

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -133,6 +133,7 @@ type WishlistEntryPayload = {
   target_price?: number
   highlight_hit?: boolean
   owned?: boolean
+  delivered?: boolean
   price_paid?: number
   purchase_url?: string
   purchase_date?: string
@@ -154,6 +155,7 @@ type WishlistInlineChanges = {
   targetPrice?: number
   priority?: string
   owned?: boolean
+  delivered?: boolean
   pricePaid?: number
   purchaseUrl?: string
   purchaseDate?: string
@@ -750,6 +752,7 @@ export function Tasks({
           priceStockCount: pricingSummary.priceStockCount,
           highlightHit: Boolean(wishlistEntry?.highlight_hit),
           owned: Boolean(wishlistEntry?.owned),
+          delivered: Boolean(wishlistEntry?.delivered),
           pricePaid:
             typeof wishlistEntry?.price_paid === 'number'
               ? wishlistEntry.price_paid
@@ -927,6 +930,7 @@ export function Tasks({
           notes: draft.notes,
           target_price: normalizeTargetPrice(draft.targetPrice),
           owned: draft.owned,
+          delivered: draft.delivered,
           price_paid: normalizeOptionalMoney(draft.pricePaid),
           purchase_url: draft.purchaseUrl,
           purchase_date: draft.purchaseDate,
@@ -1003,6 +1007,7 @@ export function Tasks({
       )
       let nextTargetPrice = changes.targetPrice ?? currentTask.targetPrice ?? 0
       const nextOwned = changes.owned ?? currentTask.owned ?? false
+      const nextDelivered = changes.delivered ?? currentTask.delivered ?? false
       const nextPricePaid = changes.pricePaid ?? currentTask.pricePaid ?? 0
       const nextPurchaseUrl =
         changes.purchaseUrl ?? currentTask.purchaseUrl ?? ''
@@ -1041,6 +1046,7 @@ export function Tasks({
               priority: nextPriority,
               targetPrice: nextTargetPrice,
               owned: nextOwned,
+              delivered: nextDelivered,
               pricePaid: nextPricePaid,
               purchaseUrl: nextPurchaseUrl,
               purchaseDate: nextPurchaseDate,
@@ -1059,6 +1065,7 @@ export function Tasks({
                 priority: nextPriority,
                 targetPrice: nextTargetPrice,
                 owned: nextOwned,
+                delivered: nextDelivered,
                 pricePaid: nextPricePaid,
                 purchaseUrl: nextPurchaseUrl,
                 purchaseDate: nextPurchaseDate,
@@ -1081,6 +1088,12 @@ export function Tasks({
         }
         if (changes.owned !== undefined) {
           requestBody.owned = nextOwned
+        }
+        if (changes.delivered !== undefined) {
+          requestBody.delivered = nextDelivered
+          if (nextDelivered) {
+            requestBody.owned = true
+          }
         }
         if (changes.pricePaid !== undefined) {
           requestBody.price_paid = nextPricePaid
@@ -1350,6 +1363,7 @@ export function Tasks({
       notes: content,
       targetPrice: '',
       owned: false,
+      delivered: false,
       pricePaid: '',
       purchaseUrl: extractFirstUrl(content),
       purchaseDate: '',
@@ -1406,6 +1420,7 @@ export function Tasks({
         notes: 'Created from screenshot.',
         targetPrice: '',
         owned: false,
+        delivered: false,
         pricePaid: '',
         purchaseUrl: '',
         purchaseDate: '',
@@ -1464,6 +1479,7 @@ export function Tasks({
           notes: `Created from dropped image: ${file.name}`,
           targetPrice: '',
           owned: false,
+          delivered: false,
           pricePaid: '',
           purchaseUrl: '',
           purchaseDate: '',
@@ -1587,6 +1603,7 @@ export function Tasks({
         notes: `Created from barcode ${barcode}.`,
         targetPrice: '',
         owned: false,
+        delivered: false,
         pricePaid: '',
         purchaseUrl: '',
         purchaseDate: '',


### PR DESCRIPTION
## Summary
- Exposes Wishlist `Purchased`, `Delivered`, and `Category` fields in the shared Wishlist table/card/edit UI.
- Persists `delivered` through create/edit/import/inline update payloads, with Delivered setting Purchased for consistency.
- Adds `UI-SCREEN-WISHLIST-020` Cypress coverage for editing category plus purchased/delivered state and verifying refreshed row/card outcomes.

## Validation
- PASS `openspec validate --all --strict --no-interactive` (`.work-agent/logs/1046-20260612-0500-ui/openspec-after.log`)
- PASS `npx eslint ui.web/src/features/tasks/index.tsx ui.web/src/features/tasks/data/schema.ts ui.web/src/features/tasks/components/tasks-columns.tsx ui.web/src/features/tasks/components/tasks-table.tsx ui.web/src/features/tasks/components/tasks-mutate-drawer.tsx ui.web/src/features/tasks/components/tasks-import-dialog.tsx ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` (`.work-agent/logs/1046-20260612-0500-ui/changed-file-eslint-final.log`; known Fast Refresh warnings only)
- PASS `git diff --check` (`.work-agent/logs/1046-20260612-0500-ui/git-diff-check-final.log`)
- PASS `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser chrome -RequireE2EHooks` (`.work-agent/logs/1046-20260612-0500-ui/cypress-ui-screen-wishlist-rerun3.log`; 21 passing)
- PASS pre-push OpenSpec hook and fast API docs smoke test

## Demo
- Not deployed: this PR is open and `develop` was not updated by this run.