### PR TITLE
#1092 test(users): persist bulk user actions

### DIFF
--- a/openspec/specs/users/ui-screen-users/spec.md
+++ b/openspec/specs/users/ui-screen-users/spec.md
@@ -66,6 +66,16 @@ Users screen SHALL expose a table view-options control for hideable columns and 
 - **THEN** the table MUST hide the email header and cells while preserving username/status/role/action context
 - **AND** the route MUST remain on `/users` without losing the current users rows
 
+### Requirement UI-SCREEN-USERS-008: Users screen SHALL persist bulk toolbar actions through Cabinet API
+Users screen SHALL make selected-row bulk invite, status, and delete actions durable through Cabinet API calls and SHALL refresh the table from the resulting users source of truth.
+
+#### Scenario: Run selected-row bulk actions
+- **GIVEN** an authenticated desktop user has selected multiple users from the Users table
+- **WHEN** the user invokes bulk invite, bulk deactivate or activate, and bulk delete actions from the selected-row toolbar
+- **THEN** invite actions MUST call `POST /api/users/invite` for each selected user with the selected user's email and role
+- **AND** status actions MUST call `PUT /api/users/{id}` for each selected user and refresh the table with the persisted status
+- **AND** delete actions MUST require explicit confirmation, call `DELETE /api/users/{id}` for each selected user, refresh the table, and remove deleted rows from the visible source-of-truth state
+
 ## Use-Case IDs and E2E Mapping
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |
@@ -77,3 +87,4 @@ Users screen SHALL expose a table view-options control for hideable columns and 
 | UC-USR-06 | Missing active profile fallback | Users screen loads list without 404 fallback error | `ui.web/cypress/e2e/users/ui-screen-users/fallback-profile-scope.cy.ts` |
 | UC-USR-07 | Loading and empty list states | Pending users list shows loading feedback; empty API response renders table empty state without stale rows or error banner | implemented: `ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts` `UI-SCREEN-USERS-006 renders deterministic loading and empty states` |
 | UC-USR-08 | Table view options | View menu hides optional columns while preserving core row context | implemented: `ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts` `UI-SCREEN-USERS-007 hides optional table columns from the View menu` |
+| UC-USR-09 | Bulk user actions | Selected-row invite, status, and delete actions call Cabinet APIs, refresh the users list, and prove persisted table outcomes | implemented: `ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts` `UI-SCREEN-USERS-008 persists bulk invite, status, and delete actions through Cabinet API` |

--- a/ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts
+++ b/ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts
@@ -304,4 +304,124 @@ describe('ui-screen-users', () => {
       cy.location('pathname').should('match', /^\/users\/?$/)
     })
   })
+
+  it('UI-SCREEN-USERS-008 persists bulk invite, status, and delete actions through Cabinet API', () => {
+    let users = [
+      {
+        id: 'bulk-user-001',
+        firstName: 'Bulk',
+        lastName: 'Alpha',
+        username: 'bulk_alpha',
+        email: 'bulk.alpha@example.com',
+        phoneNumber: '+61000000101',
+        status: 'active',
+        role: 'view',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'bulk-user-002',
+        firstName: 'Bulk',
+        lastName: 'Beta',
+        username: 'bulk_beta',
+        email: 'bulk.beta@example.com',
+        phoneNumber: '+61000000102',
+        status: 'active',
+        role: 'admin',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+
+    cy.intercept('GET', '/api/users*', (req) => {
+      req.reply({ statusCode: 200, body: { users } })
+    }).as('bulkUsersList')
+    cy.intercept('POST', '/api/users/invite', (req) => {
+      expect(req.body).to.include({ desc: 'Bulk invitation' })
+      expect(['bulk.alpha@example.com', 'bulk.beta@example.com']).to.include(
+        req.body.email
+      )
+      req.reply({ statusCode: 201, body: { user: req.body } })
+    }).as('bulkInviteUser')
+    cy.intercept('PUT', '/api/users/*', (req) => {
+      const id = req.url.split('/').pop()
+      expect(req.body).to.include({ status: 'inactive' })
+      users = users.map((user) =>
+        user.id === id ? { ...user, status: 'inactive' } : user
+      )
+      req.reply({
+        statusCode: 200,
+        body: { user: users.find((user) => user.id === id) },
+      })
+    }).as('bulkStatusUser')
+    cy.intercept('DELETE', '/api/users/*', (req) => {
+      const id = req.url.split('/').pop()
+      users = users.filter((user) => user.id !== id)
+      req.reply({ statusCode: 204 })
+    }).as('bulkDeleteUser')
+
+    cy.reload()
+    cy.wait('@bulkUsersList')
+    cy.contains('bulk_alpha').should('be.visible')
+    cy.contains('bulk_beta').should('be.visible')
+
+    cy.get('tbody tr')
+      .eq(0)
+      .find('[role="checkbox"]')
+      .first()
+      .click({ force: true })
+    cy.get('tbody tr')
+      .eq(1)
+      .find('[role="checkbox"]')
+      .first()
+      .click({ force: true })
+    cy.get('button[aria-label="Invite selected users"]').click()
+    cy.wait(['@bulkInviteUser', '@bulkInviteUser'])
+    cy.wait('@bulkUsersList')
+
+    cy.get('tbody tr')
+      .eq(0)
+      .find('[role="checkbox"]')
+      .first()
+      .click({ force: true })
+    cy.get('tbody tr')
+      .eq(1)
+      .find('[role="checkbox"]')
+      .first()
+      .click({ force: true })
+    cy.get('button[aria-label="Deactivate selected users"]').click()
+    cy.wait(['@bulkStatusUser', '@bulkStatusUser'])
+    cy.wait('@bulkUsersList')
+    cy.contains('bulk_alpha')
+      .parents('tr')
+      .contains('inactive')
+      .should('be.visible')
+    cy.contains('bulk_beta')
+      .parents('tr')
+      .contains('inactive')
+      .should('be.visible')
+
+    cy.get('tbody tr')
+      .eq(0)
+      .find('[role="checkbox"]')
+      .first()
+      .click({ force: true })
+    cy.get('tbody tr')
+      .eq(1)
+      .find('[role="checkbox"]')
+      .first()
+      .click({ force: true })
+    cy.get('button[aria-label="Delete selected users"]').click()
+    cy.contains('[role="alertdialog"], [role="dialog"]', 'Delete 2 users')
+      .should('be.visible')
+      .within(() => {
+        cy.get('input[placeholder=\'Type "DELETE" to confirm.\']').type('DELETE')
+        cy.contains('button', 'Delete').click()
+      })
+    cy.wait(['@bulkDeleteUser', '@bulkDeleteUser'])
+    cy.wait('@bulkUsersList')
+    cy.contains('bulk_alpha').should('not.exist')
+    cy.contains('bulk_beta').should('not.exist')
+    cy.contains('No results.').should('be.visible')
+  })
 })

--- a/ui.web/src/features/users/components/data-table-bulk-actions.tsx
+++ b/ui.web/src/features/users/components/data-table-bulk-actions.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { type Table } from '@tanstack/react-table'
 import { Trash2, UserX, UserCheck, Mail } from 'lucide-react'
 import { toast } from 'sonner'
-import { sleep } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
   Tooltip,
@@ -15,38 +14,74 @@ import { UsersMultiDeleteDialog } from './users-multi-delete-dialog'
 
 type DataTableBulkActionsProps<TData> = {
   table: Table<TData>
+  onMutated: () => Promise<void> | void
 }
 
 export function DataTableBulkActions<TData>({
   table,
+  onMutated,
 }: DataTableBulkActionsProps<TData>) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const selectedRows = table.getFilteredSelectedRowModel().rows
 
   const handleBulkStatusChange = (status: 'active' | 'inactive') => {
     const selectedUsers = selectedRows.map((row) => row.original as User)
-    toast.promise(sleep(2000), {
-      loading: `${status === 'active' ? 'Activating' : 'Deactivating'} users...`,
-      success: () => {
+    toast.promise(
+      async () => {
+        await Promise.all(
+          selectedUsers.map((user) =>
+            fetch(`/api/users/${user.id}`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ ...user, status }),
+            }).then((response) => {
+              if (!response.ok) {
+                throw new Error(`users_bulk_status_failed_${response.status}`)
+              }
+            })
+          )
+        )
+        await onMutated()
         table.resetRowSelection()
-        return `${status === 'active' ? 'Activated' : 'Deactivated'} ${selectedUsers.length} user${selectedUsers.length > 1 ? 's' : ''}`
       },
-      error: `Error ${status === 'active' ? 'activating' : 'deactivating'} users`,
-    })
-    table.resetRowSelection()
+      {
+        loading: `${status === 'active' ? 'Activating' : 'Deactivating'} users...`,
+        success: `${status === 'active' ? 'Activated' : 'Deactivated'} ${selectedUsers.length} user${selectedUsers.length > 1 ? 's' : ''}`,
+        error: `Error ${status === 'active' ? 'activating' : 'deactivating'} users`,
+      }
+    )
   }
 
   const handleBulkInvite = () => {
     const selectedUsers = selectedRows.map((row) => row.original as User)
-    toast.promise(sleep(2000), {
-      loading: 'Inviting users...',
-      success: () => {
+    toast.promise(
+      async () => {
+        await Promise.all(
+          selectedUsers.map((user) =>
+            fetch('/api/users/invite', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                email: user.email,
+                role: user.role,
+                desc: 'Bulk invitation',
+              }),
+            }).then((response) => {
+              if (!response.ok) {
+                throw new Error(`users_bulk_invite_failed_${response.status}`)
+              }
+            })
+          )
+        )
+        await onMutated()
         table.resetRowSelection()
-        return `Invited ${selectedUsers.length} user${selectedUsers.length > 1 ? 's' : ''}`
       },
-      error: 'Error inviting users',
-    })
-    table.resetRowSelection()
+      {
+        loading: 'Inviting users...',
+        success: `Invited ${selectedUsers.length} user${selectedUsers.length > 1 ? 's' : ''}`,
+        error: 'Error inviting users',
+      }
+    )
   }
 
   return (
@@ -133,6 +168,7 @@ export function DataTableBulkActions<TData>({
         table={table}
         open={showDeleteConfirm}
         onOpenChange={setShowDeleteConfirm}
+        onDeleted={onMutated}
       />
     </>
   )

--- a/ui.web/src/features/users/components/users-multi-delete-dialog.tsx
+++ b/ui.web/src/features/users/components/users-multi-delete-dialog.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { type Table } from '@tanstack/react-table'
 import { AlertTriangle } from 'lucide-react'
 import { toast } from 'sonner'
-import { sleep } from '@/lib/utils'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -14,6 +13,7 @@ type UserMultiDeleteDialogProps<TData> = {
   open: boolean
   onOpenChange: (open: boolean) => void
   table: Table<TData>
+  onDeleted: () => Promise<void> | void
 }
 
 const CONFIRM_WORD = 'DELETE'
@@ -22,6 +22,7 @@ export function UsersMultiDeleteDialog<TData>({
   open,
   onOpenChange,
   table,
+  onDeleted,
 }: UserMultiDeleteDialogProps<TData>) {
   const [value, setValue] = useState('')
 
@@ -33,19 +34,32 @@ export function UsersMultiDeleteDialog<TData>({
       return
     }
 
-    onOpenChange(false)
-
-    toast.promise(sleep(2000), {
-      loading: 'Deleting users...',
-      success: () => {
+    toast.promise(
+      async () => {
+        await Promise.all(
+          selectedRows.map((row) =>
+            fetch(`/api/users/${(row.original as { id: string }).id}`, {
+              method: 'DELETE',
+            }).then((response) => {
+              if (!response.ok) {
+                throw new Error(`users_bulk_delete_failed_${response.status}`)
+              }
+            })
+          )
+        )
+        await onDeleted()
         setValue('')
         table.resetRowSelection()
-        return `Deleted ${selectedRows.length} ${
-          selectedRows.length > 1 ? 'users' : 'user'
-        }`
+        onOpenChange(false)
       },
-      error: 'Error',
-    })
+      {
+        loading: 'Deleting users...',
+        success: `Deleted ${selectedRows.length} ${
+          selectedRows.length > 1 ? 'users' : 'user'
+        }`,
+        error: 'Error',
+      }
+    )
   }
 
   return (

--- a/ui.web/src/features/users/components/users-table.tsx
+++ b/ui.web/src/features/users/components/users-table.tsx
@@ -39,9 +39,15 @@ type DataTableProps = {
   data: User[]
   search: Record<string, unknown>
   navigate: NavigateFn
+  onMutated: () => Promise<void> | void
 }
 
-export function UsersTable({ data, search, navigate }: DataTableProps) {
+export function UsersTable({
+  data,
+  search,
+  navigate,
+  onMutated,
+}: DataTableProps) {
   // Local UI-only states
   const [rowSelection, setRowSelection] = useState({})
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
@@ -267,7 +273,7 @@ export function UsersTable({ data, search, navigate }: DataTableProps) {
         </Table>
       </div>
       <DataTablePagination table={table} className='mt-auto' />
-      <DataTableBulkActions table={table} />
+      <DataTableBulkActions table={table} onMutated={onMutated} />
       <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
         <DialogContent data-testid='users-row-details-modal'>
           <DialogHeader>

--- a/ui.web/src/features/users/index.tsx
+++ b/ui.web/src/features/users/index.tsx
@@ -102,7 +102,12 @@ export function Users() {
             Loading users...
           </div>
         ) : (
-          <UsersTable data={users} search={search} navigate={navigate} />
+          <UsersTable
+            data={users}
+            search={search}
+            navigate={navigate}
+            onMutated={loadUsers}
+          />
         )}
       </Main>
 

--- a/ui.web/src/routes/clerk/_authenticated/user-management.tsx
+++ b/ui.web/src/routes/clerk/_authenticated/user-management.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import { useEffect, useState } from 'react'
 import {
   createFileRoute,
@@ -102,7 +101,12 @@ function UserManagement() {
               <UsersPrimaryButtons />
             </div>
             <div className='-mx-4 flex-1 overflow-auto px-4 py-1 lg:flex-row lg:space-y-0 lg:space-x-12'>
-              <UsersTable data={users} navigate={navigate} search={search} />
+              <UsersTable
+                data={users}
+                navigate={navigate}
+                search={search}
+                onMutated={async () => undefined}
+              />
             </div>
           </Main>
 


### PR DESCRIPTION
## Summary
- Binds Users bulk toolbar behavior to new OpenSpec requirement UI-SCREEN-USERS-008.
- Makes selected-row invite/status/delete toolbar actions call Cabinet APIs, refresh the users source of truth, and clear selection only after success.
- Adds Cypress coverage for bulk invite, deactivate, and delete persistence outcomes.

## Validation
- openspec validate --all --strict --no-interactive: PASS (.work-agent/logs/issue-1092/openspec-validate.log)
- changed-file ESLint: PASS (.work-agent/logs/issue-1092/eslint-changed-files-rerun.log)
- pwsh -NoLogo -NoProfile -File .\\cypress.ps1 -Spec cypress/e2e/users/ui-screen-users/spec.cy.ts -Browser chrome -RequireE2EHooks: PASS, 9/9 (.work-agent/logs/issue-1092/cypress-users-ui-screen-users-rerun.log)

Closes #1092