### PR TITLE
#1058 test(cypress): record matrix lane failure summaries

### DIFF
--- a/openspec/specs/general/continuous-ui-validation/spec.md
+++ b/openspec/specs/general/continuous-ui-validation/spec.md
@@ -94,3 +94,8 @@ Cabinet SHALL allow the bounded Cypress matrix runner to start one repo-local co
 - **WHEN** an active lane starts
 - **THEN** the runner MUST start the configured Cabinet container image with a unique host port, named writable data volume, E2E hooks enabled, E2E profile, instance name, and parallel-runtime flag before invoking Cypress against that lane.
 - **AND** the runner MUST reuse the already-started lane runtime for Cypress, wait for `/healthz` before assertions, and stop/remove the lane container and volume unless keep-container diagnostics are explicitly requested.
+
+#### Scenario: Report lane failures in machine-readable summary
+- **GIVEN** a Cypress matrix lane fails during container cleanup, container start, runtime health, or Cypress execution
+- **WHEN** the runner writes `matrix.summary.json`
+- **THEN** the failed lane MUST record a nonzero exit code plus `failure_stage` and `error_message` fields so operators can distinguish setup/runtime failures from browser assertion failures.

--- a/scripts/run-cypress-matrix.ps1
+++ b/scripts/run-cypress-matrix.ps1
@@ -157,6 +157,8 @@ for ($laneIndex = 0; $laneIndex -lt $LaneCount; $laneIndex++) {
     container_name = if ($UseContainerImage) { $containerName } else { $null }
     container_volume = if ($UseContainerImage) { $containerVolume } else { $null }
     source_commit = $sourceCommit
+    failure_stage = $null
+    error_message = $null
     log_dir = $laneLogDir
     specs = @($laneSpecs[$laneIndex])
   }
@@ -258,42 +260,48 @@ for ($laneIndex = 0; $laneIndex -lt $LaneCount; $laneIndex++) {
     }
 
     $containerStarted = $false
-    if ($useContainerImage) {
-      docker rm -f $containerName *> $null
-      docker volume rm $containerVolume *> $null
-      $dockerArgs = @(
-        "run", "-d",
-        "--name", $containerName,
-        "-e", "CABINET_E2E_MODE=1",
-        "-p", "$($lanePort):17880",
-        "-v", "$($containerVolume):/data",
-        $containerImage,
-        "--no-open-browser",
-        "--listen", "0.0.0.0:17880",
-        "--data-dir", "/data",
-        "--profile", $laneProfile,
-        "--instance-name", $laneInstanceName,
-        "--allow-parallel"
-      )
-      & docker @dockerArgs | Out-Host
-      if ($LASTEXITCODE -ne 0) {
-        throw "Failed to start container lane $laneNumber from image $containerImage"
-      }
-      $containerStarted = $true
-      $deadline = (Get-Date).AddSeconds($containerStartupTimeoutSec)
-      while ((Get-Date) -lt $deadline) {
-        if (Test-LaneHealth "http://127.0.0.1:$lanePort") {
-          break
-        }
-        Start-Sleep -Seconds 1
-      }
-      if (-not (Test-LaneHealth "http://127.0.0.1:$lanePort")) {
-        throw "Container lane $laneNumber did not become healthy at http://127.0.0.1:$lanePort within $containerStartupTimeoutSec seconds."
-      }
-    }
-
     $laneResults = @()
+    $laneExitCode = 0
+    $failureStage = $null
+    $errorMessage = $null
     try {
+      if ($useContainerImage) {
+        $failureStage = "container_cleanup"
+        docker rm -f $containerName *> $null
+        docker volume rm $containerVolume *> $null
+        $dockerArgs = @(
+          "run", "-d",
+          "--name", $containerName,
+          "-e", "CABINET_E2E_MODE=1",
+          "-p", "$($lanePort):17880",
+          "-v", "$($containerVolume):/data",
+          $containerImage,
+          "--no-open-browser",
+          "--listen", "0.0.0.0:17880",
+          "--data-dir", "/data",
+          "--profile", $laneProfile,
+          "--instance-name", $laneInstanceName,
+          "--allow-parallel"
+        )
+        $failureStage = "container_start"
+        & docker @dockerArgs | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to start container lane $laneNumber from image $containerImage"
+        }
+        $containerStarted = $true
+        $failureStage = "runtime_health"
+        $deadline = (Get-Date).AddSeconds($containerStartupTimeoutSec)
+        while ((Get-Date) -lt $deadline) {
+          if (Test-LaneHealth "http://127.0.0.1:$lanePort") {
+            break
+          }
+          Start-Sleep -Seconds 1
+        }
+        if (-not (Test-LaneHealth "http://127.0.0.1:$lanePort")) {
+          throw "Container lane $laneNumber did not become healthy at http://127.0.0.1:$lanePort within $containerStartupTimeoutSec seconds."
+        }
+      }
+      $failureStage = "cypress"
       foreach ($spec in $assignedSpecs) {
       $specRelativeToUi = $spec
       if ($specRelativeToUi.StartsWith("ui.web\")) {
@@ -333,9 +341,21 @@ for ($laneIndex = 0; $laneIndex -lt $LaneCount; $laneIndex++) {
         exit_code = $exitCode
       }
       if ($exitCode -ne 0) {
+        $laneExitCode = 1
+        $errorMessage = "Cypress spec $spec failed with exit code $exitCode."
         break
       }
     }
+      if ($laneExitCode -eq 0) {
+        $failureStage = $null
+      }
+    }
+    catch {
+      $laneExitCode = 1
+      if ([string]::IsNullOrWhiteSpace($failureStage)) {
+        $failureStage = "lane"
+      }
+      $errorMessage = $_.Exception.Message
     }
     finally {
       if ($containerStarted -and -not $keepContainers) {
@@ -358,9 +378,11 @@ for ($laneIndex = 0; $laneIndex -lt $LaneCount; $laneIndex++) {
       container_started = $containerStarted
       container_kept = $keepContainers
       source_commit = $sourceCommit
+      failure_stage = $failureStage
+      error_message = $errorMessage
       log_dir = $laneLogDir
       results = $laneResults
-      exit_code = if (($laneResults | Where-Object { $_.exit_code -ne 0 }).Count -gt 0) { 1 } else { 0 }
+      exit_code = if ($laneExitCode -ne 0 -or ($laneResults | Where-Object { $_.exit_code -ne 0 }).Count -gt 0) { 1 } else { 0 }
     }
   }
   [void]$jobs.Add($job)
@@ -388,6 +410,8 @@ $cleanLaneResults = @(
       container_started = $_.container_started
       container_kept = $_.container_kept
       source_commit = $_.source_commit
+      failure_stage = $_.failure_stage
+      error_message = $_.error_message
       log_dir = $_.log_dir
       results = $_.results
       exit_code = $_.exit_code

--- a/tests/cypress_matrix_contract_test.go
+++ b/tests/cypress_matrix_contract_test.go
@@ -38,6 +38,13 @@ func TestCypressMatrixRunnerProvidesIsolatedLanes(t *testing.T) {
 		`"--listen", "0.0.0.0:17880"`,
 		`$args += "-ReuseServer"`,
 		`container_started = $containerStarted`,
+		`failure_stage = $failureStage`,
+		`error_message = $errorMessage`,
+		`$failureStage = "container_start"`,
+		`$failureStage = "runtime_health"`,
+		`$failureStage = "cypress"`,
+		`$errorMessage = $_.Exception.Message`,
+		`Cypress spec $spec failed with exit code $exitCode.`,
 		`"-BaseUrl", "http://127.0.0.1:$lanePort"`,
 		`data_dir = Join-Path $repoRoot ".tmp\cypress-runtime-$lanePort"`,
 		`profile = "e2e-cypress-$lanePort"`,
@@ -110,13 +117,13 @@ func TestCypressMatrixPlanSummaryExposesLaneCounts(t *testing.T) {
 	}
 
 	var summary struct {
-		SpecCount        int   `json:"spec_count"`
-		LaneCount        int   `json:"lane_count"`
-		MaxWorkers       int   `json:"max_workers"`
-		WorkerLimit      int   `json:"worker_limit"`
-		ActiveLaneCount  int   `json:"active_lane_count"`
-		EmptyLaneCount   int   `json:"empty_lane_count"`
-		SpecCountsByLane []int `json:"spec_counts_by_lane"`
+		SpecCount         int   `json:"spec_count"`
+		LaneCount         int   `json:"lane_count"`
+		MaxWorkers        int   `json:"max_workers"`
+		WorkerLimit       int   `json:"worker_limit"`
+		ActiveLaneCount   int   `json:"active_lane_count"`
+		EmptyLaneCount    int   `json:"empty_lane_count"`
+		SpecCountsByLane  []int `json:"spec_counts_by_lane"`
 		UseContainerImage bool  `json:"use_container_image"`
 		ContainerImage    any   `json:"container_image"`
 	}
@@ -188,15 +195,17 @@ func TestCypressMatrixPlanSummaryExposesContainerLaneMetadata(t *testing.T) {
 	}
 
 	var summary struct {
-		UseContainerImage        bool   `json:"use_container_image"`
-		ContainerImage           string `json:"container_image"`
-		ContainerStartupTimeout  int    `json:"container_startup_timeout_sec"`
-		KeepContainers           bool   `json:"keep_containers"`
-		Lanes                    []struct {
-			UseContainerImage bool   `json:"use_container_image"`
-			ContainerImage    string `json:"container_image"`
-			ContainerName     string `json:"container_name"`
-			ContainerVolume   string `json:"container_volume"`
+		UseContainerImage       bool   `json:"use_container_image"`
+		ContainerImage          string `json:"container_image"`
+		ContainerStartupTimeout int    `json:"container_startup_timeout_sec"`
+		KeepContainers          bool   `json:"keep_containers"`
+		Lanes                   []struct {
+			UseContainerImage bool    `json:"use_container_image"`
+			ContainerImage    string  `json:"container_image"`
+			ContainerName     string  `json:"container_name"`
+			ContainerVolume   string  `json:"container_volume"`
+			FailureStage      *string `json:"failure_stage"`
+			ErrorMessage      *string `json:"error_message"`
 		} `json:"lanes"`
 	}
 	if err := json.Unmarshal(raw, &summary); err != nil {
@@ -221,6 +230,9 @@ func TestCypressMatrixPlanSummaryExposesContainerLaneMetadata(t *testing.T) {
 		}
 		if lane.ContainerVolume != lane.ContainerName+"-data" {
 			t.Fatalf("lane %d has unexpected container volume %q for name %q", index+1, lane.ContainerVolume, lane.ContainerName)
+		}
+		if lane.FailureStage != nil || lane.ErrorMessage != nil {
+			t.Fatalf("lane %d plan should not report a failure: %+v", index+1, lane)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- record matrix lane failure_stage/error_message fields for container cleanup, container start, runtime health, and Cypress failures
- include those fields in plan and run lane summary objects
- extend CONT-UI-CAB-009 and focused Go coverage for the summary contract

## Validation
- openspec validate --all --strict --no-interactive
- go test ./tests -run CypressMatrix -count=1
- pwsh -NoLogo -NoProfile -File .\\scripts\\run-cypress-matrix.ps1 -PlanOnly -SpecGlob 'ui.web/cypress/e2e/general/ui-login-session/spec.cy.ts' -LaneCount 2 -MaxWorkers 2 -UseContainerImage -RunId 'lane-failure-summary-plan-postcommit' -LogRoot .work-agent\\logs\\1058-matrix-lane-failure-summary\\20260613-1220-cron\\cypress-matrix
- git diff --check origin/develop...HEAD
- git show --check --stat --oneline --no-renames HEAD

Evidence: .work-agent/logs/1058-matrix-lane-failure-summary/20260613-1220-cron/validation-summary-postcommit.json