### PR TITLE
#1071 test(cypress): assert profile context across sections

### DIFF
--- a/ui.web/cypress/e2e/general/profile-switcher-existing-profile-context/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/profile-switcher-existing-profile-context/spec.cy.ts
@@ -20,9 +20,12 @@ describe('general/profile-switcher-existing-profile-context', () => {
       'contain',
       expectedStatus
     )
+    cy.request('GET', '/api/profiles/active')
+      .its('body.name')
+      .should('eq', expectedName)
   }
 
-  it('PROFILES-005 selects an existing database profile across app sections', () => {
+  it('UI-FOUNDATION-SHELL-NAVIGATION-016 selects an existing database profile across app sections', () => {
     cy.request('POST', '/api/test/reset', {})
     cy.request('POST', '/api/profiles', { name: 'Primary DB' }).then((primaryResp) => {
       expect(primaryResp.status).to.eq(201)


### PR DESCRIPTION
## Summary
- Strengthens the existing profile-switcher Cypress coverage for `UI-FOUNDATION-SHELL-NAVIGATION-016`.
- Verifies the selected Showcase DB remains the visible shell context and the active profile API context across Inventory, Wishlist, Collections, Settings, Chats, and Integrations.

## Validation
- `npx eslint cypress/e2e/general/profile-switcher-existing-profile-context/spec.cy.ts` -> passed. Log: `.work-agent/logs/1071-profile-selection-route-persistence/eslint-profile-selection-route-persistence-head.log`
- `git diff --check` -> passed. Log: `.work-agent/logs/1071-profile-selection-route-persistence/git-diff-check-head.log`
- `git diff --check origin/develop...HEAD` -> passed. Log: `.work-agent/logs/1071-profile-selection-route-persistence/git-diff-check-origin-develop.log`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/general/profile-switcher-existing-profile-context/spec.cy.ts" -Browser electron -RequireE2EHooks -SkipRuntimeBuild -LogDir ".work-agent\logs\1071-profile-selection-route-persistence" -LogName "focused-profile-selection-route-persistence-head" -StartupTimeoutSec 60` -> passed, 1/1. Log: `.work-agent/logs/1071-profile-selection-route-persistence/20260614-102408-focused-profile-selection-route-persistence-head.log`; summary: `.work-agent/logs/1071-profile-selection-route-persistence/20260614-102408-focused-profile-selection-route-persistence-head.summary.json`

Issue: #1071