### PR TITLE
#1075 test(inventory): cover table controls and bulk selection

### DIFF
--- a/openspec/specs/inventory/ui-screen-inventory-items/spec.md
+++ b/openspec/specs/inventory/ui-screen-inventory-items/spec.md
@@ -10,6 +10,12 @@ Inventory Items SHALL support row-details behavior, selection mode, and filter/s
 - **WHEN** user clicks non-interactive row area
 - **THEN** item details drawer SHALL open for selected row
 
+#### Scenario: Checkbox bulk selection mode
+- **GIVEN** an authenticated actor with the required role is operating an active local profile, required capability configuration is enabled, and scenario fixture data exists for execution
+- **WHEN** user selects one or more inventory rows using row checkboxes or the select-all checkbox
+- **THEN** the bulk actions toolbar SHALL appear without opening the item editor
+- **AND** clearing selection by keyboard or clear action SHALL remove the toolbar and selected row state
+
 ### Requirement UI-SCREEN-INVENTORY-ITEMS-002: Inventory Items SHALL support deterministic state handling
 Inventory Items SHALL support loading, empty, error, and ready states.
 
@@ -120,9 +126,9 @@ Inventory rows view SHALL preserve readable Part #, Title, Condition, Item type,
 | UC-INV-02 | Empty filtered results | Empty state appears | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `renders empty inventory state without global 500 fallback` |
 | UC-INV-03 | API failure on load | Error state + retry, no 500 route | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-002 shows inline error state and recovers on retry` |
 | UC-INV-04 | Row click open details | Details drawer opens selected item | planned: `cypress/e2e/ui/inventory.cy.ts` `inventory-row-opens-details` |
-| UC-INV-05 | Checkbox bulk select | Selection mode appears, no row-open side effect | planned: `cypress/e2e/ui/inventory.cy.ts` `inventory-bulk-checkbox-mode` |
+| UC-INV-05 | Checkbox bulk select | Selection mode appears, no row-open side effect | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-001/008 covers search, filters, sort, reset, and bulk selection` |
 | UC-INV-06 | Click Add Item | Create-item workflow opens from toolbar | planned: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `inventory-add-item-opens-create-flow` |
 | UC-INV-07 | Click Add Folder | Folder creation workflow opens from toolbar | planned: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `inventory-add-folder-opens-create-flow` |
-| UC-INV-08 | Toggle Rows/Cards view | View mode changes deterministically | planned: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `inventory-view-mode-toggle` |
-| UC-INV-09 | Open Status/Priority/View controls | Browser controls render and open without errors | planned: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `inventory-browser-controls-available` |
+| UC-INV-08 | Toggle Rows/Cards view | View mode changes deterministically | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `renders inventory workspace, supports view toggle and filtering, and avoids 500`; existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-001/008 covers search, filters, sort, reset, and bulk selection` |
+| UC-INV-09 | Open Status/Priority/View controls | Browser controls render and open without errors | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-001/008 covers search, filters, sort, reset, and bulk selection`; existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-011 scopes condition choices by item type and restores compact filters` |
 | UC-INV-10 | Review dense inventory rows at desktop width | Right-side columns remain readable and actions are reachable via table scroll | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-012 keeps dense row columns readable` |

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -812,4 +812,126 @@ describe("inventory-management", () => {
     });
   });
 
+  it("UI-SCREEN-INVENTORY-ITEMS-001/008 covers search, filters, sort, reset, and bulk selection", () => {
+    cy.intercept("GET", "/api/items", {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            id: "item-table-1",
+            part_number: "PN-TABLE-001",
+            title: "Road Alpha",
+            status: "used",
+            category: "Cars",
+            item_type: "Slot Cars",
+            packaging_grade_type: "Carded",
+          },
+          {
+            id: "item-table-2",
+            part_number: "PN-TABLE-002",
+            title: "Road Zeta",
+            status: "used",
+            category: "Cars",
+            item_type: "Slot Cars",
+            packaging_grade_type: "Loose",
+          },
+          {
+            id: "item-table-3",
+            part_number: "PN-TABLE-003",
+            title: "Road Bravo",
+            status: "active",
+            category: "Cars",
+            item_type: "Slot Cars",
+            packaging_grade_type: "Carded",
+          },
+          {
+            id: "item-table-4",
+            part_number: "PN-TABLE-004",
+            title: "Plane Delta",
+            status: "used",
+            category: "Planes",
+            item_type: "Model Planes",
+            packaging_grade_type: "Boxed",
+          },
+        ],
+      },
+    }).as("itemsTableControls");
+
+    signIn();
+    cy.wait("@itemsTableControls");
+
+    cy.get('button[aria-label="Switch to rows view"]')
+      .click({ force: true })
+      .should("have.attr", "aria-pressed", "true");
+
+    cy.get('[data-testid="inventory-table-search-input"]').type("Road");
+    cy.contains("Road Alpha").should("be.visible");
+    cy.contains("Road Zeta").should("be.visible");
+    cy.contains("Road Bravo").should("be.visible");
+    cy.contains("Plane Delta").should("not.exist");
+
+    cy.get('[data-testid="inventory-table-toolbar"]')
+      .contains("button", "Condition")
+      .click();
+    cy.contains('[role="option"]', "used").click();
+    cy.get("body").type("{esc}");
+    cy.contains("Road Alpha").should("be.visible");
+    cy.contains("Road Zeta").should("be.visible");
+    cy.contains("Road Bravo").should("not.exist");
+
+    cy.get('[data-testid="inventory-table-toolbar"]')
+      .contains("button", "Category")
+      .click();
+    cy.contains('[role="option"]', "Cars").click();
+    cy.get("body").type("{esc}");
+    cy.contains("Road Alpha").should("be.visible");
+    cy.contains("Road Zeta").should("be.visible");
+    cy.contains("Plane Delta").should("not.exist");
+
+    cy.contains("th", "Title").find("button").click();
+    cy.contains('[role="menuitem"]', "Desc").click();
+    cy.get("table tbody tr").first().should("contain", "PN-TABLE-002");
+
+    cy.contains("button", "Reset").click();
+    cy.get('[data-testid="inventory-table-search-input"]').should("have.value", "");
+    cy.contains("Road Bravo").should("be.visible");
+    cy.contains("Plane Delta").should("be.visible");
+
+    cy.get('[data-testid="inventory-item-row-item-table-1"]')
+      .find('button[role="checkbox"][aria-label="Select row"]')
+      .click();
+    cy.get('[data-testid="inventory-item-editor-dialog"]').should("not.exist");
+    cy.get('[data-testid="inventory-item-row-item-table-1"]').should(
+      "have.attr",
+      "data-state",
+      "selected"
+    );
+    cy.get('[role="toolbar"][aria-label^="Bulk actions for 1 selected"]')
+      .should("be.visible")
+      .within(() => {
+        cy.contains("selected").should("be.visible");
+        cy.get('button[aria-label="Update status"]').should("be.visible");
+        cy.get('button[aria-label="Update priority"]').should("be.visible");
+        cy.get('button[aria-label="Export tasks"]').should("be.visible");
+        cy.get('button[aria-label="Delete selected tasks"]').should("be.visible");
+      });
+
+    cy.get('[role="toolbar"][aria-label^="Bulk actions for 1 selected"]')
+      .focus()
+      .type("{esc}");
+    cy.get('[role="toolbar"][aria-label^="Bulk actions"]').should("not.exist");
+    cy.get('[data-testid="inventory-item-row-item-table-1"]').should(
+      "not.have.attr",
+      "data-state",
+      "selected"
+    );
+
+    cy.get('button[role="checkbox"][aria-label="Select all"]').click();
+    cy.get('[role="toolbar"][aria-label^="Bulk actions for 4 selected"]').should(
+      "be.visible"
+    );
+    cy.get('button[aria-label="Clear selection"]').click();
+    cy.get('[role="toolbar"][aria-label^="Bulk actions"]').should("not.exist");
+  });
+
 });


### PR DESCRIPTION
## Summary
- Adds Cypress coverage for inventory table search, condition/category filters, descending title sort, reset behavior, row checkbox bulk selection, select-all, and selection clear flows.
- Extends `UI-SCREEN-INVENTORY-ITEMS-001` with checkbox bulk selection behavior and updates UC mappings for #1075 from planned to existing coverage.

## Validation
- `openspec validate --all --strict --no-interactive` PASS (`.work-agent/logs/issue-1075/openspec-validate.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser chrome -RequireE2EHooks -LogDir .work-agent\logs\issue-1075\cypress-wrapper` PASS, 15/15 (`.work-agent/logs/issue-1075/cypress-ui-screen-inventory-items.log`)
- `npm exec eslint -- cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` PASS (`.work-agent/logs/issue-1075/eslint-changed-files.log`)
- `git diff --check` PASS (`.work-agent/logs/issue-1075/git-diff-check.log`)

Issue: #1075