### PR TITLE
#1076 fix(inventory): stabilize row delete actions

### DIFF
--- a/openspec/specs/inventory/ui-screen-inventory-items/spec.md
+++ b/openspec/specs/inventory/ui-screen-inventory-items/spec.md
@@ -107,6 +107,12 @@ Inventory rows view SHALL preserve readable Part #, Title, Condition, Item type,
 - **AND** action controls SHALL remain reachable without covering data columns
 - **AND** the table MAY expose horizontal scrolling instead of compressing columns into unreadable text
 
+#### Scenario: Horizontally scrolled row actions remain deterministic
+- **GIVEN** `/api/items` returns representative inventory records and the row table is horizontally scrolled to the right-side action column
+- **WHEN** user opens a specific row action menu and chooses `Delete`
+- **THEN** the Delete confirmation SHALL open for that same row
+- **AND** canceling the confirmation SHALL close the dialog without changing the selected inventory context
+
 ## Acceptance Criteria
 - UC IDs cover browse, edit, selection, and state transitions.
 - E2E mapping includes non-500 regression behavior.
@@ -132,3 +138,4 @@ Inventory rows view SHALL preserve readable Part #, Title, Condition, Item type,
 | UC-INV-08 | Toggle Rows/Cards view | View mode changes deterministically | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `renders inventory workspace, supports view toggle and filtering, and avoids 500`; existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-001/008 covers search, filters, sort, reset, and bulk selection` |
 | UC-INV-09 | Open Status/Priority/View controls | Browser controls render and open without errors | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-001/008 covers search, filters, sort, reset, and bulk selection`; existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-011 scopes condition choices by item type and restores compact filters` |
 | UC-INV-10 | Review dense inventory rows at desktop width | Right-side columns remain readable and actions are reachable via table scroll | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-012 keeps dense row columns readable` |
+| UC-INV-11 | Open Delete from a horizontally scrolled inventory row action menu | Delete confirmation opens for the same row; cancel preserves selected item context | existing: `ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` `UI-SCREEN-INVENTORY-ITEMS-009 persists create-edit save flow and keeps media attach usable` |

--- a/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts
@@ -540,6 +540,28 @@ describe("inventory-management", () => {
     scrollInventoryTable("left");
     cy.contains("Created Inventory Item Updated").should("be.visible");
     cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
+
+    scrollInventoryTable("right");
+    cy.get(
+      '[data-testid="inventory-item-row-item-created-1"] [data-testid="task-row-actions-trigger"][data-row-id="item-created-1"]'
+    ).click();
+    cy.get(
+      '[data-testid="task-row-actions-menu"][data-row-id="item-created-1"]'
+    )
+      .filter(":visible")
+      .should("have.length", 1)
+      .within(() => {
+        cy.get('[data-testid="task-row-action-delete"]')
+          .should("be.visible")
+          .click();
+      });
+    cy.get('[data-testid="task-delete-dialog"]')
+      .should("be.visible")
+      .and("contain", "Delete this task: PN-CREATE-1 ?");
+    cy.get('[data-testid="task-delete-cancel"]').click();
+    cy.get('[data-testid="task-delete-dialog"]').should("not.exist");
+    cy.get('[data-testid="collection-selected-item"]').should("contain", "PN-CREATE-1");
+
     scrollInventoryTable("right");
     cy.get(
       '[data-testid="inventory-item-row-item-created-1"] [data-testid="inventory-row-photos-action"]'

--- a/ui.web/src/components/confirm-dialog.tsx
+++ b/ui.web/src/components/confirm-dialog.tsx
@@ -22,6 +22,9 @@ type ConfirmDialogProps = {
   handleConfirm: () => void
   isLoading?: boolean
   className?: string
+  contentTestId?: string
+  cancelTestId?: string
+  confirmTestId?: string
   children?: React.ReactNode
 }
 
@@ -37,11 +40,17 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     isLoading,
     disabled = false,
     handleConfirm,
+    contentTestId,
+    cancelTestId,
+    confirmTestId,
     ...actions
   } = props
   return (
     <AlertDialog {...actions}>
-      <AlertDialogContent className={cn(className && className)}>
+      <AlertDialogContent
+        className={cn(className && className)}
+        data-testid={contentTestId}
+      >
         <AlertDialogHeader className='text-start'>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription asChild>
@@ -50,13 +59,14 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
         </AlertDialogHeader>
         {children}
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isLoading}>
+          <AlertDialogCancel disabled={isLoading} data-testid={cancelTestId}>
             {cancelBtnText ?? 'Cancel'}
           </AlertDialogCancel>
           <Button
             variant={destructive ? 'destructive' : 'default'}
             onClick={handleConfirm}
             disabled={disabled || isLoading}
+            data-testid={confirmTestId}
           >
             {confirmText ?? 'Continue'}
           </Button>

--- a/ui.web/src/features/collection/index.tsx
+++ b/ui.web/src/features/collection/index.tsx
@@ -5445,6 +5445,10 @@ export function Collection({
                   const matchedItem = resolveInventoryItemFromTask(task)
                   openInventoryAssignCollectionForItem(matchedItem)
                 }}
+                onDeleteRow={(task) => {
+                  setTasksDialogRow(task)
+                  setTasksDialogOpen('delete')
+                }}
               />
               {isInventoryRoute ? (
                 <>

--- a/ui.web/src/features/tasks/components/data-table-row-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-row-actions.tsx
@@ -29,6 +29,10 @@ export function DataTableRowActions<TData>({
   const task = taskSchema.parse(row.original)
   const isWishlistRoute = routePath === '/_authenticated/wishlist/'
   const [open, setOpen] = useState(false)
+  const rowActionId = task.itemID?.trim() || task.id
+  const handleDeleteRow = () => {
+    onDeleteRow?.(task)
+  }
 
   return (
     <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
@@ -38,6 +42,8 @@ export function DataTableRowActions<TData>({
           variant='ghost'
           className='flex h-8 w-8 p-0 data-[state=open]:bg-muted'
           data-testid='task-row-actions-trigger'
+          data-row-id={rowActionId}
+          aria-label={`Open actions for ${task.title}`}
           onPointerDown={(event) => {
             event.stopPropagation()
           }}
@@ -53,11 +59,18 @@ export function DataTableRowActions<TData>({
       <DropdownMenuContent
         align='end'
         className='w-[160px]'
+        data-testid='task-row-actions-menu'
+        data-row-id={rowActionId}
+        onPointerDown={(event) => {
+          event.stopPropagation()
+        }}
         onClick={(event) => {
           event.stopPropagation()
         }}
       >
         <DropdownMenuItem
+          data-testid='task-row-action-edit'
+          data-row-id={rowActionId}
           onSelect={(event) => {
             event.stopPropagation()
             onEditRow?.(task)
@@ -73,9 +86,15 @@ export function DataTableRowActions<TData>({
           </>
         ) : null}
         <DropdownMenuItem
+          data-testid='task-row-action-delete'
+          data-row-id={rowActionId}
+          onClick={(event) => {
+            event.stopPropagation()
+            handleDeleteRow()
+          }}
           onSelect={(event) => {
             event.stopPropagation()
-            onDeleteRow?.(task)
+            handleDeleteRow()
           }}
         >
           Delete

--- a/ui.web/src/features/tasks/components/tasks-dialogs.tsx
+++ b/ui.web/src/features/tasks/components/tasks-dialogs.tsx
@@ -180,6 +180,9 @@ export function TasksDialogs({
             }}
             isLoading={isWishlistMutating}
             className='max-w-md'
+            contentTestId='task-delete-dialog'
+            cancelTestId='task-delete-cancel'
+            confirmTestId='task-delete-confirm'
             title={
               isWishlistRoute
                 ? `Delete this wishlist entry: ${currentRow.title} ?`


### PR DESCRIPTION
## Summary
- Wire `/inventory` row Delete actions into the existing task delete dialog state.
- Add item-scoped row action/menu hooks and delete confirmation test hooks.
- Cover the horizontally scrolled inventory row Delete confirmation cancel path in the focused inventory Cypress spec.
- Extend the inventory screen OpenSpec contract and UC mapping for deterministic row actions.

## Validation
- `openspec validate --all --strict --no-interactive` PASS; log `.work-agent/logs/1076-row-actions-stability/openspec-validate-all.log`.
- `npm exec eslint -- src/components/confirm-dialog.tsx src/features/tasks/components/data-table-row-actions.tsx src/features/tasks/components/tasks-dialogs.tsx src/features/collection/index.tsx cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts` PASS; log `.work-agent/logs/1076-row-actions-stability/eslint-targeted-collection-delete.log`.
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/inventory/ui-screen-inventory-items/spec.cy.ts -Browser electron -RequireE2EHooks -LogDir .work-agent\logs\1076-row-actions-stability -LogName cypress-ui-screen-inventory-items-wired-delete` PASS, 15 passing / 0 failing; summary `.work-agent/logs/1076-row-actions-stability/20260615-010528-cypress-ui-screen-inventory-items-wired-delete.summary.json`.
- Push hook also passed OpenSpec and fast API docs smoke (`go test github.com/collectors-tech/cabinet/internal/app`).

## Notes
Earlier failed Cypress iterations are retained in `.work-agent/logs/1076-row-actions-stability/` and document the blocker progression before the missing `/inventory` delete callback was wired.