### PR TITLE
#1078 test(cypress): cover collections create query route

### DIFF
--- a/ui.web/cypress/e2e/collections/collections-create-query-state/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/collections-create-query-state/spec.cy.ts
@@ -1,0 +1,66 @@
+describe('collections-create-query-state', () => {
+  const collectionsSettingsKey = 'collections.workspace.v1'
+
+  function signInToCollectionsCreateQuery() {
+    cy.viewport(1512, 967)
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: { items: [] },
+    }).as('collectionsInventoryItems')
+    cy.intercept('GET', '/api/profiles/*/settings').as(
+      'loadCollectionSettings'
+    )
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: '/collections/',
+      })
+    })
+    cy.wait('@loadCollectionSettings')
+    cy.wait('@collectionsInventoryItems')
+    cy.visit('/collections/?create=collection')
+  }
+
+  it('opens create collection from direct route query state and persists the result', () => {
+    signInToCollectionsCreateQuery()
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as(
+      'saveCollectionSettings'
+    )
+
+    cy.get('[data-testid="collections-create-dialog"]').should('be.visible')
+    cy.location('pathname', { timeout: 15000 }).should(
+      'match',
+      /^\/collections\/?$/
+    )
+    cy.location('search').should('not.contain', 'create=collection')
+
+    cy.get('[data-testid="collections-create-input"]').type('Route Query Shelf')
+    cy.get('[data-testid="collections-create-submit"]').click()
+    cy.wait('@saveCollectionSettings').then(({ request }) => {
+      const settings = (request.body.settings ?? {}) as Record<string, string>
+      const persisted = JSON.parse(settings[collectionsSettingsKey] ?? '{}') as {
+        collections?: string[]
+        activeCollection?: string
+      }
+
+      expect(persisted.collections).to.include('Route Query Shelf')
+      expect(persisted.activeCollection).to.equal('Route Query Shelf')
+    })
+
+    cy.get('[data-testid="collections-create-dialog"]').should('not.exist')
+    cy.get('[data-testid="collections-row-route-query-shelf"]')
+      .scrollIntoView()
+      .should('be.visible')
+    cy.get('[data-testid="collections-active-context"]').should(
+      'contain.text',
+      'Route Query Shelf'
+    )
+
+    cy.reload()
+    cy.get('[data-testid="collections-create-dialog"]').should('not.exist')
+    cy.get('[data-testid="collections-row-route-query-shelf"]')
+      .scrollIntoView()
+      .should('be.visible')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a focused Cypress spec for the collections create route query state.
- Proves authenticated direct `/collections/?create=collection` entry opens the create collection dialog, removes the transient query, persists the created collection to profile settings, and keeps it after reload.

## Validation
- `npx eslint cypress/e2e/collections/collections-create-query-state/spec.cy.ts` -> passed.
- `git diff --check` -> passed.
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/collections/collections-create-query-state/spec.cy.ts" -Browser electron -RequireE2EHooks -SkipRuntimeBuild -LogDir ".work-agent\logs\1078-collections-create-query" -LogName "focused-collections-create-query-isolated-rerun" -StartupTimeoutSec 60` -> passed, 1/1.

## Evidence
- `.work-agent/logs/1078-collections-create-query/20260615-042814-focused-collections-create-query-isolated-rerun.log`
- `.work-agent/logs/1078-collections-create-query/20260615-042814-focused-collections-create-query-isolated-rerun.summary.json`

## Notes
- A broader run of the existing `ui-screen-collections` spec failed before reaching this slice at `UI-SCREEN-COLLECTIONS-010`; saved for traceability at `.work-agent/logs/1078-collections-create-query/20260615-042208-focused-collections-create-query.log` and `.summary.json`.

Refs #1078