### PR TITLE
#1078 test(cypress): cover protected All Items row

### DIFF
--- a/ui.web/cypress/e2e/collections/collections-protected-all-items/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/collections-protected-all-items/spec.cy.ts
@@ -1,0 +1,66 @@
+describe('collections-protected-all-items', () => {
+  function signInToCollections() {
+    cy.viewport(1512, 967)
+    cy.e2eReset()
+    cy.e2eSetSetupState('present')
+    cy.intercept('GET', '/api/items', {
+      statusCode: 200,
+      body: { items: [] },
+    }).as('collectionsInventoryItems')
+    cy.intercept('GET', '/api/profiles/*/settings').as(
+      'loadCollectionSettings'
+    )
+    cy.e2eBootstrap().then(({ profile_id, profile_name }) => {
+      cy.useBootstrappedProfile(profile_id, profile_name, {
+        path: '/collections/',
+      })
+    })
+    cy.wait('@loadCollectionSettings')
+    cy.wait('@collectionsInventoryItems')
+  }
+
+  it('keeps All Items protected from row rename and delete actions', () => {
+    signInToCollections()
+    cy.intercept('PUT', '/api/profiles/e2e-profile-001/settings').as(
+      'saveCollectionSettings'
+    )
+
+    cy.get('[data-testid="collections-row-all-items"]').should(
+      'have.attr',
+      'data-state',
+      'selected'
+    )
+    cy.get('[data-testid="collections-active-context"]').should(
+      'contain.text',
+      'All Items'
+    )
+
+    cy.get('[data-testid="collections-row-edit-all-items"]').click()
+    cy.get('[data-testid="collections-edit-panel"]').should('be.visible')
+    cy.get('[data-testid="collections-edit-input"]')
+      .should('have.value', 'All Items')
+      .clear()
+      .type('Everything Else')
+    cy.get('[data-testid="collections-edit-submit"]').click({ force: true })
+    cy.get('@saveCollectionSettings.all').should('have.length', 0)
+    cy.get('[data-testid="collections-edit-panel"]').should('be.visible')
+    cy.get('[data-testid="collections-row-all-items"]').should('be.visible')
+    cy.get('[data-testid="collections-row-everything-else"]').should(
+      'not.exist'
+    )
+    cy.get('[data-testid="collections-edit-panel"]').within(() => {
+      cy.contains('button', 'Cancel').click()
+    })
+
+    cy.get('[data-testid="collections-row-delete-all-items"]').click()
+    cy.get('[data-testid="collections-delete-dialog"]').should('be.visible')
+    cy.get('[data-testid="collections-delete-submit"]').click()
+    cy.get('@saveCollectionSettings.all').should('have.length', 0)
+    cy.get('[data-testid="collections-delete-dialog"]').should('be.visible')
+    cy.get('[data-testid="collections-row-all-items"]').should('be.visible')
+    cy.get('[data-testid="collections-active-context"]').should(
+      'contain.text',
+      'All Items'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a focused Cypress spec for the protected default `All Items` collection row.
- Covers attempted row rename/delete actions and verifies they perform no profile-settings write, do not create a renamed row, do not remove `All Items`, and keep the active context on `All Items`.

## Validation
- `npx eslint cypress/e2e/collections/collections-protected-all-items/spec.cy.ts` -> PASS
  - `.work-agent/logs/1078-protected-all-items/20260615-0625-eslint-protected-all-items.log`
- `git diff --check` -> PASS
  - `.work-agent/logs/1078-protected-all-items/20260615-0625-git-diff-check.log`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/collections/collections-protected-all-items/spec.cy.ts" -Browser electron -RequireE2EHooks -SkipRuntimeBuild -LogDir ".work-agent\logs\1078-protected-all-items" -LogName "focused-protected-all-items-rerun" -StartupTimeoutSec 60` -> PASS, 1/1
  - `.work-agent/logs/1078-protected-all-items/20260615-062449-focused-protected-all-items-rerun.log`
  - `.work-agent/logs/1078-protected-all-items/20260615-062449-focused-protected-all-items-rerun.summary.json`

## QA Notes
- Initial authoring attempted to assert visible rename feedback for the protected row; the served UI prevented mutation but no visible rename toast appeared before timeout.
- Gap note: `.work-agent/logs/1078-protected-all-items/20260615-0626-ui-feedback-gap.txt`

Refs #1078