### PR TITLE
#1078 test(cypress): cover duplicate collection side-panel rename

### DIFF
--- a/ui.web/cypress/e2e/collections/collections-row-side-panel/spec.cy.ts
+++ b/ui.web/cypress/e2e/collections/collections-row-side-panel/spec.cy.ts
@@ -65,4 +65,46 @@ describe('collections-row-side-panel', () => {
       'Store 2 Panel'
     )
   })
+
+  it('keeps the side panel open and skips persistence on duplicate rename', () => {
+    signInToCollections()
+
+    cy.get('@saveCollectionSettings.all').should('have.length', 0)
+    cy.get('[data-testid="collections-active-context"]').should(
+      'contain.text',
+      'All Items'
+    )
+
+    cy.get('[data-testid="collections-row-edit-store-1"]')
+      .scrollIntoView()
+      .click({ force: true })
+    cy.get('[data-testid="collections-edit-panel"]')
+      .should('be.visible')
+      .should('have.attr', 'data-side', 'right')
+    cy.get('[data-testid="collections-edit-input"]')
+      .should('have.value', 'Store 1')
+      .clear()
+      .type('Store 2')
+
+    cy.get('[data-testid="collections-edit-submit"]').click()
+
+    cy.get('[data-testid="collections-edit-panel"]').should('be.visible')
+    cy.get('[data-testid="collections-edit-input"]').should(
+      'have.value',
+      'Store 2'
+    )
+    cy.get('@saveCollectionSettings.all').should('have.length', 0)
+    cy.get('[data-testid="collections-row-name-store-1"]').should(
+      'contain.text',
+      'Store 1'
+    )
+    cy.get('[data-testid="collections-row-name-store-2"]').should(
+      'contain.text',
+      'Store 2'
+    )
+    cy.get('[data-testid="collections-active-context"]').should(
+      'contain.text',
+      'Store 1'
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- adds focused Cypress coverage for duplicate-name rename attempts in the collection edit side panel
- asserts the side panel stays open, no profile-settings PUT is sent, existing rows remain unchanged, and the selected context stays on the edited row
- records a UI feedback gap for the missing duplicate-rename visible toast/error observed during the first focused run

## Validation
- PASS: `npx eslint cypress/e2e/collections/collections-row-side-panel/spec.cy.ts`
  - `.work-agent/logs/1078-edit-panel-duplicate-rename/20260615-0826-eslint-row-side-panel.log`
- PASS: `git diff --check`
  - `.work-agent/logs/1078-edit-panel-duplicate-rename/20260615-0826-git-diff-check.log`
- PASS: `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec "cypress/e2e/collections/collections-row-side-panel/spec.cy.ts" -Browser electron -RequireE2EHooks -SkipRuntimeBuild -LogDir ".work-agent\logs\1078-edit-panel-duplicate-rename" -LogName "focused-edit-panel-duplicate-rename-final" -StartupTimeoutSec 60`
  - 2/2 passing
  - `.work-agent/logs/1078-edit-panel-duplicate-rename/20260615-082629-focused-edit-panel-duplicate-rename-final.log`
  - `.work-agent/logs/1078-edit-panel-duplicate-rename/20260615-082629-focused-edit-panel-duplicate-rename-final.summary.json`

## Gap recorded
- `.work-agent/logs/1078-edit-panel-duplicate-rename/20260615-0824-ui-feedback-gap.txt`
- Initial assertion expected visible duplicate-name feedback; served UI prevented mutation but did not show visible feedback before timeout.
