### PR TITLE
#1074 test(cypress): prove discover action payloads

### DIFF
--- a/openspec/specs/dashboard/ui-screen-discover/spec.md
+++ b/openspec/specs/dashboard/ui-screen-discover/spec.md
@@ -90,11 +90,11 @@ has already been purchased or delivered.
 ## Use-Case IDs and E2E Mapping
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |
-| UC-DIS-01 | Filter discover list | Filtered candidates displayed | planned: `cypress/e2e/ui/discover.cy.ts` `discover-filtering` |
-| UC-DIS-02 | Ignore action | Candidate state updates to ignored | planned: `cypress/e2e/ui/discover.cy.ts` `discover-ignore` |
-| UC-DIS-03 | Add to wishlist action | Wishlist linkage created | planned: `cypress/e2e/ui/discover.cy.ts` `discover-wishlist` |
-| UC-DIS-04 | Track/create action | Pricing track or item create executes | planned: `cypress/e2e/ui/discover.cy.ts` `discover-track-create` |
-| UC-DIS-05 | Discover API failure | Error + retry appears | planned: `cypress/e2e/ui/discover.cy.ts` `discover-error-state` |
+| UC-DIS-01 | Filter discover list | Filtered candidates displayed | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-001 renders filterable candidate triage list` |
+| UC-DIS-02 | Ignore action | Candidate state updates to ignored | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-002 + UC-DIS-02..04 submits ignore wishlist track and create action payloads` |
+| UC-DIS-03 | Add to wishlist action | Wishlist linkage created | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-002 + UC-DIS-02..04 submits ignore wishlist track and create action payloads`; `UI-SCREEN-DISCOVER-006 promotes a candidate to Wishlist without purchased state` |
+| UC-DIS-04 | Track/create action | Pricing track or item create executes | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-002 + UC-DIS-02..04 submits ignore wishlist track and create action payloads` |
+| UC-DIS-05 | Discover API failure | Error + retry appears | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-003 shows retryable error state when discover API fails` |
 | UC-DIS-06 | Apply Filters action | `Apply Filters` triggers deterministic filtered-query refresh | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-001 + UC-DIS-06 applies query price and date filters without route transition` |
 | UC-DIS-07 | Boundary enforcement | Discoveries shows triage actions only; no provider query/run controls | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-004 keeps Discoveries as triage-only and excludes Market Watch query/run controls` |
 | UC-DIS-08 | Market Watch handoff | Discoveries can route to Market Watch handoff without losing context | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-004 provides explicit handoff action to Market Watch with preserved context` |

--- a/ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts
+++ b/ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts
@@ -90,7 +90,7 @@ describe('dashboard/ui-screen-discover', () => {
       .and('contain', 'A$88.50')
   })
 
-  it('UI-SCREEN-DISCOVER-002 executes ignore/wishlist/track/create actions deterministically', () => {
+  it('UI-SCREEN-DISCOVER-002 + UC-DIS-02..04 submits ignore wishlist track and create action payloads', () => {
     cy.intercept('GET', '/api/discovery/not-in-collection*', {
       statusCode: 200,
       body: {
@@ -108,9 +108,16 @@ describe('dashboard/ui-screen-discover', () => {
       },
     }).as('discoverList')
 
-    cy.intercept('POST', '/api/discovery/action', { statusCode: 200, body: { ok: true } }).as(
-      'discoverAction'
-    )
+    const expectedActions = ['ignore', 'add_to_wishlist', 'track_price', 'create_item']
+    cy.intercept('POST', '/api/discovery/action', (req) => {
+      const expectedAction = expectedActions.shift()
+      expect(req.body).to.deep.equal({
+        candidate_id: 'cand-002',
+        type: expectedAction,
+        payload: {},
+      })
+      req.reply({ statusCode: 200, body: { ok: true } })
+    }).as('discoverAction')
 
     signInToDiscoveries()
     cy.wait('@discoverList')
@@ -130,6 +137,7 @@ describe('dashboard/ui-screen-discover', () => {
     cy.get('[data-testid="discover-action-create-cand-002"]').click()
     cy.wait('@discoverAction')
     cy.get('[data-testid="discover-action-status"]').should('contain', 'create_item:cand-002')
+    cy.wrap(expectedActions).should('be.empty')
   })
 
   it('UI-SCREEN-DISCOVER-003 shows retryable error state when discover API fails', () => {


### PR DESCRIPTION
## Summary
- Strengthens #1074 Discoveries Cypress coverage for UI-SCREEN-DISCOVER-002 / UC-DIS-02..04.
- Verifies ignore, wishlist, track-price, and create-item buttons submit the exact `/api/discovery/action` request payloads.
- Updates Discoveries OpenSpec use-case mapping so UC-DIS-01..05 point to current executable Cypress specs instead of stale planned paths.

## Validation
- `openspec validate --all --strict --no-interactive` -> PASS (`.work-agent/logs/1074-discover-action-payloads/20260615-2020-qa-cron/openspec.log`)
- `cd ui.web; npx eslint cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` -> PASS (`.work-agent/logs/1074-discover-action-payloads/20260615-2020-qa-cron/eslint-discover-spec.log`)
- `git diff --check` -> PASS (`.work-agent/logs/1074-discover-action-payloads/20260615-2020-qa-cron/diff-check.log`, `diff-check-precommit.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec 'cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts' -Browser electron -RequireE2EHooks -LogDir '.work-agent\logs\1074-discover-action-payloads\20260615-2020-qa-cron' -LogName 'focused-discover-action-payloads' -StartupTimeoutSec 90` -> PASS, 9/9 (`.work-agent/logs/1074-discover-action-payloads/20260615-2020-qa-cron/20260615-202245-focused-discover-action-payloads.log`, `.summary.json`)
- `git show --check --stat --oneline --no-renames HEAD` -> PASS (`.work-agent/logs/1074-discover-action-payloads/20260615-2020-qa-cron/git-show-check-head.log`)

## Demo2
No deployment claimed; this PR is open and not merged to `develop`.