### PR TITLE
#1074 Bind Reports use cases to current coverage

### DIFF
--- a/openspec/specs/dashboard/ui-screen-reports/spec.md
+++ b/openspec/specs/dashboard/ui-screen-reports/spec.md
@@ -59,10 +59,10 @@ Reports SHALL support loading, empty, error, and ready states.
 ## Use-Case IDs and E2E Mapping
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |
-| UC-REP-01 | Load reports | Summary panels render | planned: `cypress/e2e/ui/reports.cy.ts` `reports-ready` |
-| UC-REP-02 | Export data | Export output generated | planned: `cypress/e2e/ui/reports.cy.ts` `reports-export` |
-| UC-REP-03 | No report data | Empty state guidance appears | planned: `cypress/e2e/ui/reports.cy.ts` `reports-empty-state` |
-| UC-REP-04 | Reports API failure | Error + retry appears | planned: `cypress/e2e/ui/reports.cy.ts` `reports-error-state` |
+| UC-REP-01 | Load reports | Summary panels render | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` `UI-SCREEN-REPORTS-001 renders wishlist and pricing summary metrics` |
+| UC-REP-02 | Export data | Export output generated | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` `UI-SCREEN-REPORTS-002 exports report output deterministically` |
+| UC-REP-03 | No report data | Empty state guidance appears | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` `UI-SCREEN-REPORTS-003 handles loading/empty/error states deterministically` |
+| UC-REP-04 | Reports API failure | Error + retry appears | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` `UI-SCREEN-REPORTS-003 handles loading/empty/error states deterministically` |
 | UC-REP-05 | Refresh reports toolbar action | `Refresh Reports` re-fetches analytics without route change | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` `UI-SCREEN-REPORTS-004 refreshes reports without route transition` |
 | UC-REP-06 | Export CSV toolbar action | `Export CSV` triggers export with deterministic feedback | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` `UI-SCREEN-REPORTS-002 exports report output deterministically`, `UI-SCREEN-REPORTS-004 reports export failures deterministically` |
 | UC-REP-07 | Unavailable reports state | `Export CSV` stays disabled while report context is unavailable | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` `UI-SCREEN-REPORTS-004 disables export while reports are unavailable` |


### PR DESCRIPTION
## Summary
- Binds Reports UC-REP-01 through UC-REP-04 to the current executable Reports Cypress coverage.
- Replaces stale planned `cypress/e2e/ui/reports.cy.ts` mappings with `ui.web/cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` test names.

## Validation
- `openspec validate --all --strict --no-interactive` -> passed (`.work-agent/logs/1074-reports-mapping-closure/openspec.log`)
- `cd ui.web; npx eslint cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts` -> passed (`.work-agent/logs/1074-reports-mapping-closure/eslint-reports-spec.log`)
- `git diff --check` -> passed (`.work-agent/logs/1074-reports-mapping-closure/diff-check.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/dashboard/ui-screen-reports/spec.cy.ts -Browser electron -RequireE2EHooks -LogDir .work-agent/logs/1074-reports-mapping-closure -LogName focused-reports-mapping-closure -StartupTimeoutSec 60` -> passed 6/6 (`.work-agent/logs/1074-reports-mapping-closure/20260615-220248-focused-reports-mapping-closure.summary.json`)
- Pre-push OpenSpec hook -> passed
- Pre-push fast API docs smoke test -> passed

## Demo
No deployment claimed because this PR is open and unmerged. Demo2 remains pending merge follow-through for this slice.

Issue: #1074