### PR TITLE
#827 test(cypress): cover eBay observed currency output

### DIFF
--- a/ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts
@@ -674,7 +674,7 @@ describe('integrations/ui-screen-market-watch', () => {
       .and('not.contain', 'Sign in again')
   })
 
-  it('INTEGRATION-005 + #827 surfaces eBay provider run pagination metadata', () => {
+  it('INTEGRATION-005 + #827 surfaces eBay provider run pagination metadata and observed-currency output', () => {
     cy.intercept('GET', '/api/scanner/query-sets', {
       statusCode: 200,
       body: {
@@ -710,6 +710,7 @@ describe('integrations/ui-screen-market-watch', () => {
               title: 'Aurora HO slot car lot',
               source: 'ebay',
               price: 42,
+              shipping: 7.5,
               observed_currency: 'AUD',
               url: 'https://www.ebay.example/itm/ebay-ho-1',
               stock_state: 'in_stock',
@@ -722,6 +723,7 @@ describe('integrations/ui-screen-market-watch', () => {
               title: 'Tyco HO track bundle',
               source: 'ebay',
               price: 64,
+              shipping: 0,
               observed_currency: 'AUD',
               url: 'https://www.ebay.example/itm/ebay-ho-2',
               stock_state: 'low_stock',
@@ -763,6 +765,12 @@ describe('integrations/ui-screen-market-watch', () => {
       cy.contains('24').should('be.visible')
       cy.contains('Aurora HO slot car lot').should('be.visible')
       cy.contains('ebay').should('be.visible')
+      cy.get('[data-testid="market-watch-output-results-table"]').within(() => {
+        cy.contains('td', '42.00 AUD').should('be.visible')
+        cy.contains('td', '7.50 AUD').should('be.visible')
+        cy.contains('td', '64.00 AUD').should('be.visible')
+        cy.contains('td', '0.00 AUD').should('be.visible')
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
- Extends the existing Market Watch eBay provider-run pagination Cypress case to assert output-detail price and shipping cells render with persisted observed_currency.
- Keeps this slice non-credentialed and UI-only; no product behavior changes.

## Validation
- PASS: pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts -Browser chrome -RequireE2EHooks (21/21 passing)
- PASS: go test ./tests -run "EbayProviderTraceability|EbayProviderSearchFailureTraceability" -count=1
- PASS: openspec validate --all --strict --no-interactive
- PASS: npx eslint cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts
- PASS: git diff --check

Logs: .work-agent/logs/issue-827-ebay-observed-currency-output/20260619-1020/

Issue: #827