### PR TITLE
#827 test(openapi): document eBay query scope preservation

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -523,7 +523,7 @@ paths:
     put:
       tags: [Scanner]
       summary: Update scanner query set
-      description: Updates saved-search filters, provider scope, pagination, schedule, enabled state, and rate-limit controls for an active-profile query set.
+      description: Updates saved-search filters, provider scope, pagination, schedule, enabled state, and rate-limit controls for an active-profile query set. When `provider_scope` is omitted from an update, the existing saved provider scope is preserved so eBay-only query edits do not widen to the default multi-provider scope.
       parameters:
         - in: path
           name: querySetID

--- a/internal/app/openapi_parity_test.go
+++ b/internal/app/openapi_parity_test.go
@@ -978,8 +978,13 @@ func TestOpenAPIDocumentsEbayQuerySetContract(t *testing.T) {
 	if !ok {
 		t.Fatalf("openapi missing /api/scanner/query-sets/{querySetID} path in %s", specPath)
 	}
-	if !strings.Contains(updateSection, "Updates saved-search filters, provider scope, pagination, schedule, enabled state, and rate-limit controls for an active-profile query set.") {
-		t.Fatalf("openapi /api/scanner/query-sets/{querySetID} section missing update description:\n%s", updateSection)
+	for _, token := range []string{
+		"Updates saved-search filters, provider scope, pagination, schedule, enabled state, and rate-limit controls for an active-profile query set.",
+		"When `provider_scope` is omitted from an update, the existing saved provider scope is preserved so eBay-only query edits do not widen to the default multi-provider scope.",
+	} {
+		if !strings.Contains(updateSection, token) {
+			t.Fatalf("openapi /api/scanner/query-sets/{querySetID} section missing update token %q:\n%s", token, updateSection)
+		}
 	}
 
 	inputSchema, ok := openAPIComponentSection(raw, "ScannerQuerySetInput")


### PR DESCRIPTION
## Summary
- Documents the scanner query-set update contract for omitted `provider_scope` values.
- Adds OpenAPI parity coverage proving clients can see that omitted `provider_scope` preserves the saved scope instead of widening eBay-only query edits to the default multi-provider scope.

## Validation
- RED captured: `go test ./internal/app -run TestOpenAPIDocumentsEbayQuerySetContract -count=1`
- PASS `go test ./internal/app -run "TestOpenAPIDocumentsEbayQuerySetContract|TestOpenAPIDocumentsRuntimeEndpoints" -count=1`
- PASS `go test ./internal/scanner -run "TestUpdateQuerySetPreservesProviderScopeWhenOmitted|TestRunScheduled" -count=1`
- PASS `go test ./tests -run "TestEbayProviderTraceabilityImplemented|TestEbayProviderSearchFailureTraceabilityImplemented" -count=1`
- PASS `openspec validate --all --strict --no-interactive`
- PASS `git diff --check`

## Logs
- `.work-agent/logs/issue-827-ebay-query-scope-openapi-parity/20260620-0231/`
