### PR TITLE
#1401 preserve Cypress matrix fixture stages

### DIFF
--- a/scripts/run-cypress-matrix.ps1
+++ b/scripts/run-cypress-matrix.ps1
@@ -124,6 +124,19 @@ function Test-TcpPortOpen([int]$port) {
   }
 }
 
+function ConvertFrom-JobString($value) {
+  if ($null -eq $value) {
+    return $null
+  }
+  if ($value -is [string]) {
+    return $value
+  }
+  if ($value.PSObject.Properties.Name -contains "Value") {
+    return [string]$value.Value
+  }
+  return [string]$value
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $sourceCommit = Get-SourceCommit $repoRoot
 $runStartedAt = Get-Date
@@ -394,8 +407,11 @@ if ($UseContainerImage) {
     exit 1
   }
 
+  $skipImagePreflightForFixture = $FailureFixtureStage -eq "container_start" -or $FailureFixtureStage -eq "runtime_health"
   $imagePreflightError = $null
-  if ($FailureFixtureStage -eq "container_image") {
+  if ($skipImagePreflightForFixture) {
+    Write-Host "[cypress-matrix] Skipping container image preflight for forced $FailureFixtureStage fixture."
+  } elseif ($FailureFixtureStage -eq "container_image") {
     $imagePreflightError = "Failure fixture forced container_image failure for image $ContainerImage."
   } elseif (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
     $imagePreflightError = "Docker CLI is unavailable. Install Docker or make docker available on PATH before running container-backed lanes."
@@ -835,11 +851,11 @@ $cleanLaneResults = @(
       container_command = $_.container_command
       container_started = $_.container_started
       container_kept = $_.container_kept
-      source_commit = $_.source_commit
-      cypress_fixture_mode = $_.cypress_fixture_mode
-      failure_stage = $_.failure_stage
-      error_message = $_.error_message
-      log_dir = $_.log_dir
+      source_commit = ConvertFrom-JobString ($_.source_commit)
+      cypress_fixture_mode = ConvertFrom-JobString ($_.cypress_fixture_mode)
+      failure_stage = ConvertFrom-JobString ($_.failure_stage)
+      error_message = ConvertFrom-JobString ($_.error_message)
+      log_dir = ConvertFrom-JobString ($_.log_dir)
       results = $_.results
       exit_code = $_.exit_code
     }


### PR DESCRIPTION
## Summary
- Fixes the Cypress matrix failure fixture contract so forced container_start/runtime_health stages bypass only the container image preflight.
- Normalizes nullable diagnostic strings returned from PowerShell background jobs before writing matrix.summary.json.

## Validation
- PASS: go test ./tests -run "CypressMatrixFailureFixturesWriteLaneDiagnostics" -count=1
- PASS: go test ./... -count=1
- PASS: git diff --check

Logs: .work-agent/logs/1401-cypress-matrix-fixture-stage/20260620-0824-qa-cron/

Closes #1401
