### PR TITLE
#1408 Add password-manager sign-in markup

### DIFF
--- a/ui.web/cypress/e2e/general/ui-login-password-manager/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/ui-login-password-manager/spec.cy.ts
@@ -1,0 +1,32 @@
+describe("ui-login-password-manager", () => {
+  beforeEach(() => {
+    cy.e2eReset();
+    cy.request("POST", "/api/test/runtime/setup-status", { state: "present" })
+      .its("status")
+      .should("eq", 200);
+    cy.e2eEnsureSignedOut();
+  });
+
+  it("UI-LOGIN-PASSWORD-MANAGER-001 exposes standard sign-in autofill markup", () => {
+    cy.visit("/sign-in");
+
+    cy.get("form").within(() => {
+      cy.get('input[name="email"]')
+        .should("have.attr", "id", "email")
+        .and("have.attr", "type", "email")
+        .and("have.attr", "autocomplete", "username")
+        .and("be.visible");
+
+      cy.get('label[for="email"]').should("contain", "Email");
+
+      cy.get('input[name="password"]')
+        .should("have.attr", "id", "password")
+        .and("have.attr", "type", "password")
+        .and("have.attr", "autocomplete", "current-password")
+        .and("be.visible");
+
+      cy.get('label[for="password"]').should("contain", "Password");
+      cy.contains("button[type='submit']", "Sign in").should("be.visible");
+    });
+  });
+});

--- a/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
+++ b/ui.web/src/features/auth/sign-in/components/user-auth-form.tsx
@@ -203,6 +203,7 @@ export function UserAuthForm({
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
+        noValidate
         className={cn('grid gap-3', className)}
         {...props}
       >
@@ -211,9 +212,15 @@ export function UserAuthForm({
           name='email'
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Email</FormLabel>
+              <FormLabel htmlFor='email'>Email</FormLabel>
               <FormControl>
-                <Input placeholder='name@example.com' {...field} />
+                <Input
+                  id='email'
+                  type='email'
+                  autoComplete='username'
+                  placeholder='name@example.com'
+                  {...field}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -224,9 +231,11 @@ export function UserAuthForm({
           name='password'
           render={({ field }) => (
             <FormItem className='relative'>
-              <FormLabel>Password</FormLabel>
+              <FormLabel htmlFor='password'>Password</FormLabel>
               <FormControl>
                 <PasswordInput
+                  id='password'
+                  autoComplete='current-password'
                   placeholder='********'
                   toggleTestId='sign-in-password-toggle'
                   {...field}
@@ -243,7 +252,7 @@ export function UserAuthForm({
             </FormItem>
           )}
         />
-        <Button className='mt-2' disabled={isLoading}>
+        <Button className='mt-2' type='submit' disabled={isLoading}>
           {isLoading ? <Loader2 className='animate-spin' /> : <LogIn />}
           Sign in
         </Button>


### PR DESCRIPTION
## Summary
- Add password-manager friendly sign-in markup: stable `id`/`name`, `type="email"`, `autocomplete="username"`, `autocomplete="current-password"`, explicit submit button, and associated labels.
- Keep Cabinet inline validation behavior by marking the sign-in form `noValidate`.
- Add a focused Cypress spec for standard sign-in autofill markup.

## Validation
- PASS `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/ui-login-password-manager/spec.cy.ts -Browser chrome -RequireE2EHooks` (1 passing). Log: `.work-agent/logs/issue-1408-password-manager-markup/20260620-1622/cypress-password-manager-final.log`; summary: `.work-agent/logs/issue-1408-password-manager-markup/20260620-1622/cypress-password-manager-summary.json`.
- PASS `git diff --check`. Log: `.work-agent/logs/issue-1408-password-manager-markup/20260620-1622/git-diff-check-final-2.log`.
- PASS `git diff --check origin/develop...HEAD`. Log: `.work-agent/logs/issue-1408-password-manager-markup/20260620-1622/git-diff-check-origin-develop.log`.

## Notes
- A full `ui-login-session` spec run is not used as the PR gate because the broader spec still has an unrelated existing failure in `UI-LOGIN-SESSION-003` around the Integrations nav link after profile switching. The new password-manager assertion passed in that run and is now isolated in its own focused spec.

Closes #1408