### PR TITLE
#1414 Fix sidebar navigation labels

### DIFF
--- a/ui.web/cypress/e2e/general/icon-only-navigation/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/icon-only-navigation/spec.cy.ts
@@ -11,11 +11,11 @@ describe('general/icon-only-navigation', () => {
     cy.clearLocalStorage()
   })
 
-  it('UI-FOUNDATION-SHELL-NAVIGATION-018 renders primary navigation as icon-only accessible controls', () => {
+  it('UI-FOUNDATION-SHELL-NAVIGATION-018 renders expanded primary navigation with readable labels', () => {
     signInTo('/inventory/')
     cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
 
-    const iconOnlyLinks = [
+    const navLinks = [
       ['dashboard', 'Dashboard'],
       ['inventory', 'Inventory'],
       ['media', 'Media'],
@@ -30,14 +30,16 @@ describe('general/icon-only-navigation', () => {
       ['reports', 'Reports'],
     ] as const
 
-    iconOnlyLinks.forEach(([key, label]) => {
+    navLinks.forEach(([key, label]) => {
       cy.get(`[data-testid="sidebar-nav-link-${key}"]`)
         .scrollIntoView()
         .should('be.visible')
         .and('have.attr', 'aria-label', label)
         .within(() => {
           cy.get('svg').should('be.visible')
-          cy.get(`[data-testid="sidebar-nav-label-${key}"]`).should('not.exist')
+          cy.get(`[data-testid="sidebar-nav-label-${key}"]`)
+            .should('be.visible')
+            .and('have.text', label)
         })
     })
 
@@ -45,5 +47,43 @@ describe('general/icon-only-navigation', () => {
       .should('have.attr', 'data-active', 'true')
       .focus()
       .should('be.focused')
+  })
+
+  it('UI-FOUNDATION-SHELL-NAVIGATION-019 expands the sidebar when Navigation is selected', () => {
+    signInTo('/inventory/')
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/inventory\/?$/)
+
+    cy.get('[data-slot="sidebar-trigger"]').first().click()
+    cy.get('[data-slot="sidebar"]')
+      .first()
+      .should('have.attr', 'data-state', 'expanded')
+
+    const navLinks = [
+      ['dashboard', 'Dashboard'],
+      ['inventory', 'Inventory'],
+      ['media', 'Media'],
+      ['collections', 'Collections'],
+      ['wishlist', 'Wishlist'],
+      ['discoveries', 'Discoveries'],
+      ['market-watch', 'Market Watch'],
+      ['purchases', 'Purchases'],
+      ['integrations', 'Integrations'],
+      ['chats', 'Chats'],
+      ['users', 'Users'],
+      ['reports', 'Reports'],
+    ] as const
+
+    navLinks.forEach(([key, label]) => {
+      cy.get(`[data-testid="sidebar-nav-link-${key}"]`)
+        .scrollIntoView()
+        .should('be.visible')
+        .and('have.attr', 'aria-label', label)
+        .within(() => {
+          cy.get('svg').should('be.visible')
+          cy.get(`[data-testid="sidebar-nav-label-${key}"]`)
+            .should('be.visible')
+            .and('have.text', label)
+        })
+    })
   })
 })

--- a/ui.web/src/components/layout/app-sidebar.tsx
+++ b/ui.web/src/components/layout/app-sidebar.tsx
@@ -71,7 +71,7 @@ function moveKeyToIndex(order: string[], key: string, targetIndex: number) {
 
 export function AppSidebar() {
   const { collapsible, variant } = useLayout()
-  const { state: sidebarState, isMobile } = useSidebar()
+  const { state: sidebarState, isMobile, setOpen } = useSidebar()
   const { t } = useTranslation('nav')
   const { activeWorkspace, setActiveWorkspace } = useShellWorkspace()
   const isCollapsedSidebar = sidebarState === 'collapsed' && !isMobile
@@ -142,6 +142,16 @@ export function AppSidebar() {
       cancelled = true
     }
   }, [])
+
+  useEffect(() => {
+    if (
+      activeWorkspace === 'navigation' &&
+      sidebarState === 'collapsed' &&
+      !isMobile
+    ) {
+      setOpen(true)
+    }
+  }, [activeWorkspace, isMobile, setOpen, sidebarState])
 
   useEffect(() => {
     const profileScope = authUser?.email || authUser?.accountNo || 'local'

--- a/ui.web/src/components/layout/nav-group.tsx
+++ b/ui.web/src/components/layout/nav-group.tsx
@@ -81,8 +81,9 @@ function NavBadge({
 }
 
 function SidebarMenuLink({ item, href }: { item: NavLink; href: string }) {
-  const { setOpenMobile } = useSidebar()
+  const { state, isMobile, setOpenMobile } = useSidebar()
   const itemKey = navTestKey(item.testIdKey || item.title)
+  const isIconOnly = state === 'collapsed' && !isMobile
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
@@ -91,7 +92,15 @@ function SidebarMenuLink({ item, href }: { item: NavLink; href: string }) {
         isActive={checkIsActive(href, item)}
         tooltip={item.title}
         size='sm'
-        className={item.badge ? 'justify-center pe-9' : 'justify-center'}
+        className={
+          isIconOnly
+            ? item.badge
+              ? 'justify-center pe-9'
+              : 'justify-center'
+            : item.badge
+              ? 'pe-9'
+              : undefined
+        }
       >
         <Link
           to={item.url}
@@ -100,6 +109,11 @@ function SidebarMenuLink({ item, href }: { item: NavLink; href: string }) {
           onClick={() => setOpenMobile(false)}
         >
           {item.icon && <item.icon />}
+          {!isIconOnly ? (
+            <span data-testid={`sidebar-nav-label-${itemKey}`}>
+              {item.title}
+            </span>
+          ) : null}
           {item.badge && <NavBadge itemKey={itemKey}>{item.badge}</NavBadge>}
         </Link>
       </SidebarMenuButton>
@@ -114,8 +128,9 @@ function SidebarMenuCollapsible({
   item: NavCollapsible
   href: string
 }) {
-  const { setOpenMobile } = useSidebar()
+  const { state, isMobile, setOpenMobile } = useSidebar()
   const itemKey = navTestKey(item.testIdKey || item.title)
+  const isIconOnly = state === 'collapsed' && !isMobile
   return (
     <Collapsible
       asChild
@@ -128,9 +143,12 @@ function SidebarMenuCollapsible({
             aria-label={item.title}
             tooltip={item.title}
             size='sm'
-            className={item.badge ? 'justify-center pe-9' : 'justify-center'}
+            className={item.badge ? 'pe-9' : undefined}
           >
             {item.icon && <item.icon />}
+            <span data-testid={`sidebar-nav-label-${itemKey}`}>
+              {item.title}
+            </span>
             {item.badge && <NavBadge itemKey={itemKey}>{item.badge}</NavBadge>}
             <ChevronRight className='ms-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90 rtl:rotate-180' />
           </SidebarMenuButton>
@@ -144,7 +162,7 @@ function SidebarMenuCollapsible({
                   <SidebarMenuSubButton
                     asChild
                     isActive={checkIsActive(href, subItem)}
-                    className='justify-center'
+                    className={isIconOnly ? 'justify-center' : undefined}
                   >
                     <Link
                       to={subItem.url}
@@ -153,6 +171,11 @@ function SidebarMenuCollapsible({
                       onClick={() => setOpenMobile(false)}
                     >
                       {subItem.icon && <subItem.icon />}
+                      {!isIconOnly ? (
+                        <span data-testid={`sidebar-nav-label-${subItemKey}`}>
+                          {subItem.title}
+                        </span>
+                      ) : null}
                       {subItem.badge && (
                         <NavBadge itemKey={subItemKey}>
                           {subItem.badge}


### PR DESCRIPTION
## Summary
- Restores readable labels for primary sidebar navigation links and settings subitems when the Navigation workspace is active.
- Forces the desktop sidebar open whenever Navigation is selected, preventing a persisted collapsed cookie/session from showing Nav as icon-only under General/Other.
- Updates focused Cypress coverage for expanded labels and the Navigation-active expansion guard.

## Validation
- `npm ci` (restored incomplete local ui.web dependencies)
- `npx prettier --check src/components/layout/app-sidebar.tsx src/components/layout/nav-group.tsx cypress/e2e/general/icon-only-navigation/spec.cy.ts`
- `npm run build`
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/icon-only-navigation/spec.cy.ts -Browser electron -LogName issue-1414-nav-labels-focused`
- pre-push: OpenSpec validation passed
- pre-push: fast API docs smoke passed (`go test github.com/collectors-tech/cabinet/internal/app`)

## Notes
Demo2 deployment and LAN/screenshot proof will be added after merge to `develop`.

Closes #1414