### PR TITLE
#1419 test(ui): align nav label contract

### DIFF
--- a/tests/ui_icon_only_navigation_test.go
+++ b/tests/ui_icon_only_navigation_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestPrimaryNavigationLinksAreIconOnlyAndAccessible(t *testing.T) {
+func TestPrimaryNavigationLinksExposeVisibleLabelsAndAccessibleCollapsedState(t *testing.T) {
 	root := repoRoot(t)
 	navGroupPath := filepath.Join(root, "ui.web", "src", "components", "layout", "nav-group.tsx")
 	sourceBytes, err := os.ReadFile(navGroupPath)
@@ -19,8 +19,11 @@ func TestPrimaryNavigationLinksAreIconOnlyAndAccessible(t *testing.T) {
 	if !strings.Contains(source, "aria-label={item.title}") {
 		t.Fatalf("primary nav links must expose item.title as a stable aria-label")
 	}
-	if strings.Contains(source, "data-testid={`sidebar-nav-label-${itemKey}`}") {
-		t.Fatalf("primary nav links must not render the visible sidebar-nav-label span")
+	if !strings.Contains(source, "data-testid={`sidebar-nav-label-${itemKey}`}") {
+		t.Fatalf("expanded primary nav links must render the visible sidebar-nav-label span")
+	}
+	if !strings.Contains(source, "!isIconOnly ?") {
+		t.Fatalf("primary nav links must still hide labels in collapsed desktop icon-only state")
 	}
 	if !strings.Contains(source, "justify-center") {
 		t.Fatalf("primary nav links must center icon-only controls in their row")


### PR DESCRIPTION
## Summary
- Aligns the stale Go navigation source contract with the visible-label navigation behavior restored by #1414.
- Keeps the accessibility/collapsed-state assertions: nav links still expose `aria-label={item.title}`, render expanded labels, hide labels behind `!isIconOnly`, and center collapsed icon-only controls.

## Validation
- RED captured first: `go test ./tests -run TestPrimaryNavigationLinksAreIconOnlyAndAccessible -count=1` failed on the stale no-label assertion.
- PASS: `go test ./tests -run "PrimaryNavigationLinks.*VisibleLabels|PrimaryNavigationLinks" -count=1`
- PASS: `git diff --check`
- PASS: `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/icon-only-navigation/spec.cy.ts -Browser chrome -RequireE2EHooks` (2 passing)
- PASS: `go test ./... -count=1` after the Cypress runtime stopped

## Logs
- `.work-agent/logs/issue-1419-nav-contract/20260621-0421/go-test-nav-contract-red.log`
- `.work-agent/logs/issue-1419-nav-contract/20260621-0421/go-test-nav-contract-final.log`
- `.work-agent/logs/issue-1419-nav-contract/20260621-0421/git-diff-check.log`
- `.work-agent/logs/issue-1419-nav-contract/20260621-0421/cypress-icon-only-navigation.log`
- `.work-agent/logs/issue-1419-nav-contract/20260621-0421/cypress-summary-copy.json`
- `.work-agent/logs/issue-1419-nav-contract/20260621-0421/go-test-all-rerun.log`

Closes #1419.