### PR TITLE
#1425 Move Purchases actions into header

### DIFF
--- a/openspec/specs/commerce/reconciliation/spec.md
+++ b/openspec/specs/commerce/reconciliation/spec.md
@@ -56,7 +56,7 @@ Cabinet SHALL expose a first-class authenticated `/purchases` route, label the p
 - **THEN** Cabinet MUST show Purchases as the route title, expose a table shell with purchase/source/price/status/tracking/action columns, and provide a `+` add action that opens a creation/import dialog with New, CSV, and Email modes.
 - **AND** primary navigation and command navigation MUST expose the route with the user-facing `Purchases` label.
 - **AND** captured-review and purchase-source-match tooling MUST stay collapsed or hidden by default so the initial workspace is table-first instead of a stacked import/reconciliation toolbox.
-- **AND** users MUST be able to deliberately open captured purchase review and source-match tooling from explicit Purchases toolbar controls.
+- **AND** users MUST be able to deliberately open add/import, captured purchase review, and source-match tooling from explicit Purchases controls in the standard page header action area, without a duplicate in-body Purchases title or description block above the table.
 
 ### Requirement COMMERCE-RECONCILIATION-007: Purchases SHALL support table filtering and row state actions
 Cabinet SHALL let users narrow the Purchases table by purchase text/source/status signals and expose row-level controls for common review state markers before deeper edit/persistence workflows are completed.

--- a/tests/purchase_inbox_ui_contract_test.go
+++ b/tests/purchase_inbox_ui_contract_test.go
@@ -33,6 +33,7 @@ func TestPurchaseInboxUIContract(t *testing.T) {
 		"purchase-inbox-confirm-dialog",
 		"purchases-header-title",
 		"purchases-page-icon",
+		"purchases-global-header-actions",
 		"Load captured reviews",
 		"requires_confirmation",
 		"Confirmation required",
@@ -62,6 +63,7 @@ func TestPurchaseInboxUIContract(t *testing.T) {
 
 	requiredCypressSnippets := []string{
 		"COMMERCE-RECONCILIATION-006",
+		"purchases-global-header-actions",
 		"COMMERCE-RECONCILIATION-009",
 		"COMMERCE-RECONCILIATION-010",
 		"COMMERCE-RECONCILIATION-011",

--- a/ui.web/cypress/e2e/purchases/purchase-inbox/spec.cy.ts
+++ b/ui.web/cypress/e2e/purchases/purchase-inbox/spec.cy.ts
@@ -25,6 +25,10 @@ describe('purchases/purchase-inbox', () => {
       'Purchases'
     )
     cy.get('[data-testid="purchases-page-icon"]').should('be.visible')
+    cy.get('[data-testid="purchases-global-header-actions"]')
+      .parents('header')
+      .should('exist')
+    cy.get('main').find('h1').should('not.exist')
     cy.get('[data-testid="sidebar-nav-link-purchases"]')
       .should('contain', 'Purchases')
       .should('have.attr', 'href', '/purchases')

--- a/ui.web/src/features/purchases/index.tsx
+++ b/ui.web/src/features/purchases/index.tsx
@@ -1529,27 +1529,15 @@ export function Purchases() {
           iconTestId='purchases-page-icon'
         />
         <div
-          className='ms-auto flex items-center space-x-4'
+          className='ms-auto flex min-w-0 items-center gap-3'
           data-header-title-avoid='true'
         >
-          <LanguageSwitch />
-          <ThemeSwitch />
-          <ConfigDrawer />
-          <ProfileDropdown />
-        </div>
-      </Header>
-
-      <Main>
-        <div className='flex flex-wrap items-center justify-between gap-3'>
-          <div>
-            <h1 className='text-2xl font-bold tracking-tight'>Purchases</h1>
-            <p className='text-muted-foreground'>
-              Track purchases from eBay, Amazon, CSV, email, desktop imports,
-              and manual entries in one review-first workspace.
-            </p>
-          </div>
-          <div className='flex flex-wrap items-center gap-2'>
+          <div
+            className='flex min-w-0 flex-wrap items-center justify-end gap-2'
+            data-testid='purchases-global-header-actions'
+          >
             <Button
+              size='sm'
               data-testid='purchases-add-button'
               onClick={() => setAddDialogOpen(true)}
               aria-label='Add purchase'
@@ -1558,6 +1546,7 @@ export function Purchases() {
               Add
             </Button>
             <Button
+              size='sm'
               variant='outline'
               data-testid='purchases-source-matches-toggle'
               onClick={() => setSourceMatchesOpen((current) => !current)}
@@ -1567,6 +1556,7 @@ export function Purchases() {
               Source matches
             </Button>
             <Button
+              size='sm'
               variant='outline'
               data-testid='purchase-inbox-load-reviews'
               onClick={openCapturedReviews}
@@ -1581,10 +1571,24 @@ export function Purchases() {
               Load captured reviews
             </Button>
           </div>
+          <Separator
+            orientation='vertical'
+            className='h-6'
+            data-testid='purchases-header-action-separator'
+          />
+          <div className='flex items-center gap-4'>
+            <LanguageSwitch />
+            <ThemeSwitch />
+            <ConfigDrawer />
+            <ProfileDropdown />
+          </div>
         </div>
+      </Header>
+
+      <Main className='space-y-4'>
         {manualPurchaseResult ? (
           <div
-            className='mt-3 rounded-md border bg-muted/30 p-3 text-sm'
+            className='rounded-md border bg-muted/30 p-3 text-sm'
             data-testid='purchases-manual-draft-result'
           >
             {manualPurchaseResult}
@@ -1592,7 +1596,7 @@ export function Purchases() {
         ) : null}
 
         <div
-          className='mt-4 overflow-x-auto rounded-md border'
+          className='overflow-x-auto rounded-md border'
           data-testid='purchases-table-shell'
         >
           <div


### PR DESCRIPTION
## Summary
- Moves Purchases Add, Source matches, and Load captured reviews into the standard header action area.
- Removes the duplicate in-body Purchases title/description block so the table starts the page body.
- Updates COMMERCE-RECONCILIATION-006 and focused UI contract coverage for the header action placement.

## Validation
- openspec validate --all --strict --no-interactive (`.work-agent/logs/1425/20260622-1355-openspec.log`)
- go test ./tests -run TestPurchaseInboxUIContract -count=1 (`.work-agent/logs/1425/20260622-1355-go-test-purchase-contract-rerun.log`)
- npx eslint src/features/purchases/index.tsx cypress/e2e/purchases/purchase-inbox/spec.cy.ts (`.work-agent/logs/1425/20260622-1355-eslint-changed-files-rerun.log`)
- pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/purchases/purchase-inbox/spec.cy.ts -Browser chrome -RequireE2EHooks (`.work-agent/logs/1425/20260622-1355-cypress-purchase-inbox-rerun.log`) - 16 passing
- git diff --check (`.work-agent/logs/1425/20260622-1355-git-diff-check.log`)

Closes #1425