### PR TITLE
#1423 Keep wishlist edit panel open across navigation

### DIFF
--- a/openspec/specs/wishlist/ui-screen-wishlist/spec.md
+++ b/openspec/specs/wishlist/ui-screen-wishlist/spec.md
@@ -189,6 +189,22 @@ Wishlist create SHALL accept a draft with only `Title` populated, create the bac
 - **AND** the create panel MUST close after persistence succeeds
 - **AND** the UI MUST NOT show generic `Wishlist save failed` copy for this valid title-only draft
 
+### Requirement UI-SCREEN-WISHLIST-022: Wishlist edit panel navigation SHALL update in place
+
+Wishlist edit side panel Previous/Next navigation SHALL keep the active side
+panel open while replacing the form data and highlighted row with the newly
+selected wishlist entry.
+
+#### Scenario: Navigate wishlist edit panel entries
+
+- **GIVEN** wishlist rows view is loaded with at least two visible wishlist entries
+- **AND** the user opens the `Edit Wishlist Entry` side panel for one row
+- **WHEN** the user clicks `Previous` or `Next` in the side panel
+- **THEN** the same side panel instance MUST remain open without closing and reopening
+- **AND** the form fields MUST update to the newly selected wishlist entry
+- **AND** the highlighted wishlist row MUST move to the entry currently shown in the side panel
+- **AND** existing close and save behavior MUST remain available
+
 ## Use-Case IDs and E2E Mapping
 
 | UC ID     | Flow                             | Expected Result                                                                                                        | E2E Mapping                                                                                                                                            |
@@ -200,3 +216,4 @@ Wishlist create SHALL accept a draft with only `Title` populated, create the bac
 | UC-WSH-17 | Edit wishlist Cost and Quantity  | Inline numeric fields support keyboard entry plus accessible fixed-width stepper controls with lower-bound constraints | implemented: `ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` `UI-SCREEN-WISHLIST-017 edits cost and quantity with stable stepper controls` |
 | UC-WSH-18 | Show row thumbnails              | Rows render stable decorative thumbnails with deterministic fallback styling                                            | implemented: `ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` `UI-SCREEN-WISHLIST-018 renders compact deterministic row thumbnails`        |
 | UC-WSH-19 | Create title-only wishlist entry | Title-only drafts persist with generated metadata and no generic failure copy                                           | implemented: `ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` `UI-SCREEN-WISHLIST-019 creates a title-only wishlist entry`                  |
+| UC-WSH-22 | Navigate edit panel entries      | Previous/Next updates the side-panel form in place and moves the active row highlight                                  | implemented: `ui.web/cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts` `opens a right-side edit panel on double click and navigates visible records` |

--- a/ui.web/cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts
@@ -179,11 +179,15 @@ describe("wishlist-row-side-panel", () => {
   it("opens a right-side edit panel on double click and navigates visible records", () => {
     signInToWishlistWithRows();
 
-    cy.contains("tr", "Panel Wishlist Alpha").click();
+    cy.contains("tr", "Panel Wishlist Alpha")
+      .scrollIntoView()
+      .click({ force: true });
     cy.get('[data-testid="wishlist-edit-panel"]').should("not.exist");
     cy.get('[data-testid="row-edit-modal"]').should("not.exist");
 
-    cy.contains("tr", "Panel Wishlist Alpha").dblclick();
+    cy.contains("tr", "Panel Wishlist Alpha")
+      .scrollIntoView()
+      .dblclick({ force: true });
     cy.get('[data-testid="wishlist-edit-panel"]')
       .should("be.visible")
       .should("have.attr", "data-side", "right");
@@ -195,6 +199,14 @@ describe("wishlist-row-side-panel", () => {
     cy.get('[data-testid="wishlist-edit-entry-id"]').should(
       "contain.text",
       "wish-panel-1"
+    );
+    cy.get('[data-testid="inventory-item-row-item-panel-1"]').should(
+      "have.class",
+      "bg-primary/5"
+    );
+    cy.get('[data-testid="inventory-item-row-item-panel-2"]').should(
+      "not.have.class",
+      "bg-primary/5"
     );
     cy.get('input[name="partNumber"]').should("have.value", "PANEL-001");
     cy.get('input[name="category"]').should("have.value", "Cards");
@@ -226,10 +238,36 @@ describe("wishlist-row-side-panel", () => {
     cy.get('input[name="purchaseDate"]').should("have.value", "2026-04-20");
     cy.get('input[name="purchaseCondition"]').should("have.value", "Boxed");
 
-    cy.get('[data-testid="wishlist-edit-next"]').click();
+    cy.get('[data-testid="wishlist-edit-panel"]').then(($panel) => {
+      cy.get('[data-testid="wishlist-edit-next"]').click();
+      cy.get('[data-testid="wishlist-edit-panel"]').should(($nextPanel) => {
+        expect($nextPanel[0]).to.equal($panel[0]);
+      });
+    });
     cy.get('input[name="title"]').should("have.value", "Panel Wishlist Beta");
-    cy.get('[data-testid="wishlist-edit-previous"]').click();
+    cy.get('[data-testid="inventory-item-row-item-panel-1"]').should(
+      "not.have.class",
+      "bg-primary/5"
+    );
+    cy.get('[data-testid="inventory-item-row-item-panel-2"]').should(
+      "have.class",
+      "bg-primary/5"
+    );
+    cy.get('[data-testid="wishlist-edit-panel"]').then(($panel) => {
+      cy.get('[data-testid="wishlist-edit-previous"]').click();
+      cy.get('[data-testid="wishlist-edit-panel"]').should(($nextPanel) => {
+        expect($nextPanel[0]).to.equal($panel[0]);
+      });
+    });
     cy.get('input[name="title"]').should("have.value", "Panel Wishlist Alpha");
+    cy.get('[data-testid="inventory-item-row-item-panel-1"]').should(
+      "have.class",
+      "bg-primary/5"
+    );
+    cy.get('[data-testid="inventory-item-row-item-panel-2"]').should(
+      "not.have.class",
+      "bg-primary/5"
+    );
     cy.get('[data-testid="wishlist-edit-next"]').click();
 
     cy.get('input[name="title"]').clear().type("Panel Wishlist Beta Updated");

--- a/ui.web/src/features/tasks/components/tasks-dialogs.tsx
+++ b/ui.web/src/features/tasks/components/tasks-dialogs.tsx
@@ -126,7 +126,11 @@ export function TasksDialogs({
       {currentRow && (
         <>
           <TasksMutateDrawer
-            key={`task-update-${currentRow.id}`}
+            key={
+              isWishlistRoute
+                ? 'wishlist-update-panel'
+                : `task-update-${currentRow.id}`
+            }
             open={open === 'update'}
             onOpenChange={(isOpen) => {
               if (isOpen) {

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -2029,6 +2029,11 @@ export function Tasks({
           <TasksTable
             data={displayedData}
             routePath={routePath}
+            currentRecordID={
+              isWishlistRoute && dialogOpen === 'update'
+                ? (currentDialogRow?.itemID ?? currentDialogRow?.id)
+                : undefined
+            }
             onEditRow={(task, navigationRows) => {
               setDialogNavigationRows(navigationRows ?? displayedData)
               setCurrentDialogRow(task)


### PR DESCRIPTION
## Summary
- Keeps the wishlist update drawer mounted during Previous/Next navigation so the side panel updates in place instead of closing/reopening.
- Passes the active wishlist edit row into the table so the highlighted row follows the entry shown in the panel.
- Adds `UI-SCREEN-WISHLIST-022` and Cypress assertions for in-place panel navigation plus row highlight movement.

## Validation
- `openspec validate --all --strict --no-interactive` PASS (`.work-agent/logs/issue-1423/openspec-validate.log`)
- `npx eslint src/features/tasks/components/tasks-dialogs.tsx src/features/tasks/index.tsx cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts` PASS (`.work-agent/logs/issue-1423/eslint-targeted-rerun.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/wishlist-row-side-panel/spec.cy.ts -Browser chrome -RequireE2EHooks` PASS (`.work-agent/logs/issue-1423/cypress-wishlist-row-side-panel-final.log`)
- Push hook: OpenSpec PASS and fast API docs smoke test PASS

Closes #1423