### PR TITLE
#1411 Show local storage label in setup wizard

### DIFF
--- a/openspec/specs/general/setup-wizard-first-run/spec.md
+++ b/openspec/specs/general/setup-wizard-first-run/spec.md
@@ -163,7 +163,8 @@ Storage form step MUST expose default exe-local storage, optional custom data pa
 #### Scenario: Exe-local default storage
 - **GIVEN** setup wizard storage step is active
 - **WHEN** step first renders
-- **THEN** storage mode MUST default to `exe_local`
+- **THEN** storage mode MUST default to runtime value `exe_local`
+- **AND** the user-facing storage mode label MUST read `local`
 - **AND** data directory preview MUST resolve to `<exe_dir>/data`
 - **AND** portable mode toggle MUST be visible and off by default
 

--- a/ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts
@@ -152,6 +152,10 @@ describe('SETUP-WIZ', () => {
 
       cy.get('[data-testid="setup-step-indicator"]').should('contain.text', 'STEP 2 OF 6');
       cy.get('[data-testid="setup-storage-mode"]').should('have.value', 'exe_local');
+      cy.get('[data-testid="setup-storage-mode"] option:selected').should(
+        'have.text',
+        'local'
+      );
       cy.get('[data-testid="setup-storage-data-dir-preview"]')
         .should('be.visible')
         .and('contain.text', statusResponse.body.default_storage_data_dir);

--- a/ui.web/src/features/auth/sign-in/index.tsx
+++ b/ui.web/src/features/auth/sign-in/index.tsx
@@ -682,7 +682,7 @@ export function SignIn() {
                     }
                     data-testid='setup-storage-mode'
                   >
-                    <option value='exe_local'>exe_local</option>
+                    <option value='exe_local'>local</option>
                     <option value='custom'>custom</option>
                   </select>
                 </label>


### PR DESCRIPTION
## Summary
- Updates SETUP-WIZ-013 to require the user-facing default storage mode label `local` while preserving runtime value `exe_local`.
- Changes the setup wizard Storage Mode option text from `exe_local` to `local`.
- Extends setup wizard Cypress coverage to assert selected option value remains `exe_local` and selected text is `local`.

## Validation
- PASS: `openspec validate --all --strict --no-interactive` (log: `.work-agent/logs/1411/20260622-1845-openspec-validate.log`)
- PASS: changed-file ESLint for `src/features/auth/sign-in/index.tsx` and `cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` (log: `.work-agent/logs/1411/20260622-1845-eslint-changed-files.log`)
- PASS: `npx prettier --check src/features/auth/sign-in/index.tsx cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` (log: `.work-agent/logs/1411/20260622-1845-prettier-check-changed-files.log`)
- PASS: `npm run build` from `ui.web` (log: `.work-agent/logs/1411/20260622-1845-ui-build.log`)
- FAIL/BLOCKED: `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/general/setup-wizard-first-run/spec.cy.ts -Browser chrome -RequireE2EHooks` reached Vite build success, then failed in `scripts/build-ui-static.ps1` after a Windows libuv assertion (`Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)`) with exit code `-1073740791`; wrapper exit 1 (log: `.work-agent/logs/1411/20260622-1845-cypress-setup-wizard-first-run.log`).

## Issue
Closes #1411