### PR TITLE
#1435 Integrations Add opens provider selection first

### DIFF
--- a/openspec/specs/integrations/ui-screen-integrations/spec.md
+++ b/openspec/specs/integrations/ui-screen-integrations/spec.md
@@ -57,6 +57,24 @@ Integrations table rows SHALL provide distinct single-click, double-click, and r
 - **THEN** the provider configuration dialog MUST open
 - **AND** row details/edit dialogs MUST NOT open from the nested action click
 
+### Requirement UI-SCREEN-INTEGRATIONS-015: Add Integration SHALL use icon-only header action and provider selection first
+Integrations screen SHALL expose the page header Add Integration action as an icon-only control with tooltip and accessible label, and SHALL require explicit provider selection before opening provider-specific setup.
+
+#### Scenario: Header Add Integration action is icon-only
+- **GIVEN** integrations route is loaded
+- **WHEN** the page header action area renders
+- **THEN** the Add Integration action MUST render without visible button text
+- **AND** the action MUST preserve an accessible label and tooltip for `Add integration`
+
+#### Scenario: Add Integration opens provider selector before provider setup
+- **GIVEN** integrations route is loaded with a provider registry containing configured and catalog providers
+- **WHEN** user activates the header Add Integration action
+- **THEN** the screen MUST show provider selection/catalog UI first
+- **AND** provider-specific setup fields such as Base URL or Items per page MUST NOT render until the user selects a provider
+- **WHEN** the user selects a provider from the selector
+- **THEN** the provider-specific setup dialog MUST open for that selected provider
+- **AND** the flow MUST NOT default straight into `acercmodels.com` or any other first registry provider without selection
+
 ### Requirement UI-SCREEN-INTEGRATIONS-011: Integrations screen SHALL use a paginated full-height configured integrations table as the primary provider list
 Integrations screen SHALL render the primary configured integrations list as a scan-friendly full-height table with pagination and stable operational columns.
 
@@ -235,3 +253,4 @@ Integrations provider configuration dialogs MUST render stable visible labels as
 | UC-INT-UI-18 | Use row interaction surfaces | Table row single-click opens details, double-click opens edit, selected context is URL-backed, and nested row actions do not trigger row dialogs | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-014 + UC-INT-UI-18: separates row details edit and action dialogs` |
 | UC-INT-UI-19 | Hydrate direct route empty filter state | Shared `/integrations/` URL with no matching providers shows deterministic no-match table state, stable zero-result pagination, and preserved query context | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-013 + UC-INT-UI-19: shows deterministic empty state for direct route filters` |
 | UC-INT-UI-20 | Hydrate direct route empty cards state | Shared `/integrations/` URL with no matching providers in cards view shows explicit no-match feedback and preserved query context | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-013 + UC-INT-UI-20: shows deterministic empty state for direct route filters in cards view` |
+| UC-INT-UI-21 | Add Integration provider-selection-first flow | Header action is icon-only/no visible text, opens provider selector first, and only opens selected provider setup after selection | `cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` `UI-SCREEN-INTEGRATIONS-015 + #1435: Add Integration is icon-only and opens provider selection first` |

--- a/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
@@ -96,7 +96,8 @@ describe('ui-screen-integrations', () => {
     )
     cy.get('[data-testid="integrations-header-add"]')
       .should('be.visible')
-      .and('contain', 'Add Integration')
+      .and('have.attr', 'aria-label', 'Add integration')
+      .and('not.contain.text', 'Add Integration')
 
     cy.get('input[placeholder="Filter providers..."]').clear().type('bonza')
     cy.get('[data-testid="provider-row-au-webshop-bonzaslotcars-com-au"]').should(
@@ -113,6 +114,88 @@ describe('ui-screen-integrations', () => {
     )
     cy.contains('button', 'Rows').click()
     cy.get('table').should('be.visible')
+  })
+
+  it('UI-SCREEN-INTEGRATIONS-015 + #1435: Add Integration is icon-only and opens provider selection first', () => {
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: { id: 'profile-e2e-001', name: 'E2E Local' },
+    }).as('activeProfile')
+    cy.intercept('GET', '/api/providers/registry', {
+      statusCode: 200,
+      body: {
+        providers: [
+          {
+            provider_id: 'ebay',
+            display_name: 'eBay',
+            base_domain: 'ebay.com',
+            integration_mode: 'official_api',
+            auth_mode: 'api_key',
+            state: 'ready',
+            has_token: true,
+            setup_instructions: 'Configure eBay token and marketplace.',
+            capabilities: {
+              search: true,
+              stock_observation: false,
+              pricing: true,
+              health: true,
+            },
+            health: { status: 'ok', last_checked_at: '2026-03-01T00:00:00Z' },
+            last_run: { status: 'success', finished_at: '2026-03-01T00:00:00Z' },
+          },
+          {
+            provider_id: 'au-webshop-acercmodels-com',
+            display_name: 'acercmodels.com',
+            base_domain: 'acercmodels.com',
+            integration_mode: 'web_ingestion',
+            auth_mode: 'none',
+            state: 'ready',
+            has_token: false,
+            setup_instructions: 'Configure Acerc Models catalog ingestion.',
+            capabilities: {
+              search: true,
+              stock_observation: true,
+              pricing: true,
+              health: true,
+            },
+            health: { status: 'unknown', last_checked_at: null },
+            last_run: { status: 'never', finished_at: null },
+          },
+        ],
+      },
+    }).as('registry')
+    cy.intercept('GET', '/api/profiles/*/settings', {
+      statusCode: 200,
+      body: { settings: { 'integration.ebay.enabled': 'true' } },
+    }).as('settings')
+
+    signIn()
+    cy.wait('@activeProfile')
+    cy.wait('@registry')
+    cy.wait('@settings')
+
+    cy.get('[data-testid="integrations-header-add"]')
+      .should('be.visible')
+      .and('have.attr', 'aria-label', 'Add integration')
+      .and('not.contain.text', 'Add Integration')
+      .click()
+
+    cy.get('[data-testid="integrations-provider-selector"]')
+      .should('be.visible')
+      .and('contain', 'Add Integration')
+      .and('contain', 'Choose a provider')
+      .and('contain', 'acercmodels.com')
+      .and('not.contain', 'Base URL')
+    cy.get('[role="dialog"]').should('not.contain', 'Items per page')
+
+    cy.get(
+      '[data-testid="integrations-provider-selector-option-au-webshop-acercmodels-com"]'
+    ).click()
+    cy.get('[data-testid="integrations-provider-selector"]').should('not.exist')
+    cy.get('[role="dialog"]')
+      .should('contain', 'acercmodels.com')
+      .and('contain', 'Base URL')
+      .and('contain', 'Items per page')
   })
 
   it('UI-SCREEN-INTEGRATIONS-011 + #1112: paginates the full-page configured integrations table', () => {

--- a/ui.web/src/features/apps/index.tsx
+++ b/ui.web/src/features/apps/index.tsx
@@ -44,6 +44,11 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { LanguageSwitch } from '@/components/language-switch'
 import { Header, HeaderTitle } from '@/components/layout/header'
@@ -485,10 +490,7 @@ function providerSettingsKeys(providerID: string) {
 function providerSettingAliases(providerID: string) {
   const keys = providerSettingsKeys(providerID)
   return {
-    enabledKeys: [
-      keys.enabledKey,
-      `integration.${providerID}.enabled`,
-    ],
+    enabledKeys: [keys.enabledKey, `integration.${providerID}.enabled`],
     baseURLKeys: [keys.baseURLKey, `integration.${providerID}.base_url`],
     tokenKeys: [keys.tokenKey, `integration.${providerID}.token`],
     marketplaceKeys: [
@@ -618,6 +620,7 @@ export function Apps({
   const [editingProviderID, setEditingProviderID] = useState<string | null>(
     null
   )
+  const [providerSelectorOpen, setProviderSelectorOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [validating, setValidating] = useState(false)
   const [actionMessage, setActionMessage] = useState<string | null>(null)
@@ -795,7 +798,9 @@ export function Apps({
     filteredProviders.length,
     tableStart + paginatedProviders.length
   )
-  const addIntegrationTarget = addableProviders[0] ?? sortedProviders[0] ?? null
+  const providerCatalogProviders = addableProviders.length
+    ? addableProviders
+    : sortedProviders
 
   useEffect(() => {
     setTablePage((page) => Math.min(page, tablePageCount))
@@ -1663,20 +1668,22 @@ export function Apps({
           className='ms-auto flex items-center gap-4'
           data-header-title-avoid='true'
         >
-          <Button
-            type='button'
-            size='sm'
-            data-testid='integrations-header-add'
-            disabled={!addIntegrationTarget}
-            onClick={() => {
-              if (addIntegrationTarget) {
-                openIntegration(addIntegrationTarget)
-              }
-            }}
-          >
-            <Plus className='size-4' />
-            <span className='hidden sm:inline'>Add Integration</span>
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type='button'
+                size='icon'
+                data-testid='integrations-header-add'
+                aria-label='Add integration'
+                title='Add integration'
+                disabled={!sortedProviders.length}
+                onClick={() => setProviderSelectorOpen(true)}
+              >
+                <Plus className='size-4' aria-hidden='true' />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Add integration</TooltipContent>
+          </Tooltip>
           <LanguageSwitch />
           <ThemeSwitch />
           <ConfigDrawer />
@@ -2086,6 +2093,44 @@ export function Apps({
           </ul>
         ) : null}
       </Main>
+
+      <Dialog
+        open={providerSelectorOpen}
+        onOpenChange={setProviderSelectorOpen}
+      >
+        <DialogContent data-testid='integrations-provider-selector'>
+          <DialogHeader>
+            <DialogTitle>Add Integration</DialogTitle>
+            <DialogDescription>
+              Choose a provider before opening provider-specific setup.
+            </DialogDescription>
+          </DialogHeader>
+          <div className='grid gap-2'>
+            {providerCatalogProviders.map((provider) => (
+              <Button
+                key={provider.provider_id}
+                type='button'
+                variant='outline'
+                className='h-auto justify-start px-3 py-2 text-left'
+                data-testid={`integrations-provider-selector-option-${provider.provider_id}`}
+                onClick={() => {
+                  setProviderSelectorOpen(false)
+                  openIntegration(provider)
+                }}
+              >
+                <span className='flex min-w-0 flex-col items-start'>
+                  <span className='truncate font-medium'>
+                    {provider.display_name}
+                  </span>
+                  <span className='truncate text-xs text-muted-foreground'>
+                    {provider.base_domain}
+                  </span>
+                </span>
+              </Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={editingProvider !== null}


### PR DESCRIPTION
## Summary
- Makes the Integrations header Add action icon-only with accessible label/title and tooltip.
- Changes Add Integration to open a provider selector/catalog first instead of defaulting into the first provider setup dialog.
- Binds the new UI contract in OpenSpec and covers the behavior in the Integrations Cypress spec.

## Validation
- PASS `openspec validate --all --strict --no-interactive` (`.work-agent/logs/1435/openspec-validate-all.log`)
- PASS `npx eslint src/features/apps/index.tsx cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` (`.work-agent/logs/1435/eslint-changed-files.log`)
- PASS `npx prettier --check src/features/apps/index.tsx cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts ../openspec/specs/integrations/ui-screen-integrations/spec.md` (`.work-agent/logs/1435/prettier-check-changed-files.log`)
- PASS `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts -Browser chrome -RequireE2EHooks` (`.work-agent/logs/1435/cypress-integrations-spec.log`; summary `.work-agent/logs/cypress/20260622-191458-spec.cy.summary.json`, 25/25 passing)
- PASS pre-push OpenSpec hook and fast API docs smoke test.

Closes #1435