### PR TITLE
#1438 persist settings notifications feedback history

### DIFF
--- a/openspec/specs/chats/notification-inbox/spec.md
+++ b/openspec/specs/chats/notification-inbox/spec.md
@@ -72,7 +72,7 @@ The Notification Inbox MUST render a compact two-pane operating layout with filt
 - **AND** page actions such as refresh, mark all visible as read, clear all, and show hidden MUST be icon-only with accessible names/tooltips.
 
 ### Requirement UI-SCREEN-NOTIFICATION-INBOX-008: Notification-like UI events SHALL be preserved in Inbox history
-Cabinet notification-like UI events, including toast messages, promise-based success/failure feedback, shared confirmation or warning dialogs, and inline status/banner messages from operational settings, storage maintenance, taxonomy settings, Collections workspace, and Integrations provider health surfaces, MUST be captured into the Notification Inbox history so immediate feedback is not the only record. Captured records MUST include a source label, event time, level/category metadata, title, and detail or lifecycle summary sufficient for later review from the Inbox route. Once Cabinet has an active profile, captured local notification history MUST be promoted into the server-backed Inbox store and deduplicated by local capture ID so the record survives local history loss or reload.
+Cabinet notification-like UI events, including toast messages, promise-based success/failure feedback, shared confirmation or warning dialogs, and inline status/banner messages from operational settings, storage maintenance, notification-preference settings, taxonomy settings, Collections workspace, and Integrations provider health surfaces, MUST be captured into the Notification Inbox history so immediate feedback is not the only record. Captured records MUST include a source label, event time, level/category metadata, title, and detail or lifecycle summary sufficient for later review from the Inbox route. Once Cabinet has an active profile, captured local notification history MUST be promoted into the server-backed Inbox store and deduplicated by local capture ID so the record survives local history loss or reload.
 
 #### Scenario: Toast lifecycle events appear in Inbox
 - **GIVEN** a user triggers a promise-based UI feedback flow
@@ -87,7 +87,7 @@ Cabinet notification-like UI events, including toast messages, promise-based suc
 - **AND** the record MUST show source, time, level/category metadata, title, and detail sufficient to identify the dialog after it disappears.
 
 #### Scenario: Inline status banners appear in Inbox
-- **GIVEN** a user triggers an operational settings, storage maintenance, taxonomy settings, Collections workspace, or Integrations provider health action that renders inline or toast-backed success or failure status copy
+- **GIVEN** a user triggers an operational settings, storage maintenance, notification-preference settings, taxonomy settings, Collections workspace, or Integrations provider health action that renders inline or toast-backed success or failure status copy
 - **WHEN** the user later opens the Notification Inbox
 - **THEN** the Notification Inbox MUST include a captured status/banner history record
 - **AND** the record MUST show source, time, level/category metadata, title, and detail sufficient to identify the operational status after it disappears or is replaced.

--- a/openspec/specs/settings/notifications/spec.md
+++ b/openspec/specs/settings/notifications/spec.md
@@ -27,6 +27,7 @@ Define Notifications settings screen behavior.
 - **GIVEN** notifications form is loaded with editable controls
 - **WHEN** user clicks `Update notifications`
 - **THEN** runtime MUST persist notification preferences and show deterministic success feedback
+- **AND** the success feedback MUST be preserved in Notification Inbox history with source, level, category, title, and detail metadata.
 
 ### Requirement UI-SCREEN-SETTINGS-NOTIFICATIONS-004: Notifications screen SHALL preserve editable controls on save failure
 
@@ -49,6 +50,6 @@ Define Notifications settings screen behavior.
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |
 | UC-SET-NOTIF-01 | Retry notifications load failure | `Retry` re-attempts notifications fetch deterministically | `ui.web/cypress/e2e/settings/notifications/spec.cy.ts` (`UI-SCREEN-SETTINGS-NOTIFICATIONS-003 retries notifications settings load failure without route reload`) |
-| UC-SET-NOTIF-02 | Update notifications action | `Update notifications` persists notification settings | `ui.web/cypress/e2e/settings/notifications/spec.cy.ts` (`UI-SCREEN-SETTINGS-NOTIFICATIONS-003 updates notifications with deterministic success feedback`) |
+| UC-SET-NOTIF-02 | Update notifications action | `Update notifications` persists notification settings and records the success event in Notification Inbox history | `ui.web/cypress/e2e/settings/notifications/spec.cy.ts` (`UI-SCREEN-SETTINGS-NOTIFICATIONS-003 updates notifications with deterministic success feedback`) |
 | UC-SET-NOTIF-03 | Notifications save failure | Failed save shows error feedback and preserves edited notification choices | `ui.web/cypress/e2e/settings/notifications/spec.cy.ts` (`UI-SCREEN-SETTINGS-NOTIFICATIONS-004 preserves edited notification choices when save fails`) |
 | UC-SET-NOTIF-04 | Missing active profile blocker | Profile-context blocker hides editable notification controls and exposes recovery actions | `ui.web/cypress/e2e/settings/notifications/spec.cy.ts` (`UI-SCREEN-SETTINGS-NOTIFICATIONS-005 blocks notification edits when active profile is missing`) |

--- a/ui.web/cypress/e2e/settings/notifications/spec.cy.ts
+++ b/ui.web/cypress/e2e/settings/notifications/spec.cy.ts
@@ -56,6 +56,30 @@ describe('settings/notifications', () => {
         'notifications.security_emails': 'true',
       })
     cy.contains('Notification settings saved.').should('be.visible')
+    cy.window()
+      .its('localStorage')
+      .invoke('getItem', 'cabinet.toastHistory.v1')
+      .then((rawHistory) => {
+        expect(rawHistory).to.be.a('string')
+        const history = JSON.parse(rawHistory as string) as Array<{
+          title?: string
+          level?: string
+          source_label?: string
+          category?: string
+          summary?: string
+        }>
+        const savedNotification = history.find(
+          (record) => record.title === 'Notification settings saved.'
+        )
+        expect(savedNotification).to.deep.include({
+          title: 'Notification settings saved.',
+          level: 'success',
+          source_label: 'Settings Notifications',
+          category: 'settings',
+          summary:
+            'Settings Notifications preferences were persisted and preserved in Inbox history.',
+        })
+      })
   })
 
   it('UI-SCREEN-SETTINGS-NOTIFICATIONS-003 retries notifications settings load failure without route reload', () => {

--- a/ui.web/src/features/settings/notifications/notifications-form.tsx
+++ b/ui.web/src/features/settings/notifications/notifications-form.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/form'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Switch } from '@/components/ui/switch'
+import { recordNotificationHistory } from '@/lib/toast-history'
 import { ProfileContextBlocked } from '../components/profile-context-blocked'
 import { useProfileSettings } from '../use-profile-settings'
 
@@ -99,6 +100,14 @@ export function NotificationsForm() {
         'notifications.security_emails': String(data.security_emails),
       })
       setSaveMessage('Notification settings saved.')
+      recordNotificationHistory({
+        level: 'success',
+        title: 'Notification settings saved.',
+        summary:
+          'Settings Notifications preferences were persisted and preserved in Inbox history.',
+        source_label: 'Settings Notifications',
+        category: 'settings',
+      })
     } catch (err) {
       setSaveError(
         err instanceof Error ? err.message : 'failed_to_save_notifications'


### PR DESCRIPTION
## Summary
- Routes `/settings/notifications` successful save feedback through the shared Notification Inbox history capture path.
- Binds #1438 to notification-preference settings in the Notification Inbox and Settings Notifications specs.
- Adds focused Cypress proof that the save success record is preserved in `cabinet.toastHistory.v1` with source, level, category, title, and summary metadata.

## Validation
- PASS: `openspec validate --all --strict --no-interactive`  
  `.work-agent/logs/issue-1438-settings-notifications-history/20260625-1933/openspec-strict-final.log`, `.exit` = 0
- PASS: touched-file ESLint  
  `.work-agent/logs/issue-1438-settings-notifications-history/20260625-1933/eslint-touched-final.log`, `.exit` = 0
- PASS: `git diff --check`  
  `.work-agent/logs/issue-1438-settings-notifications-history/20260625-1933/diff-check-final.log`, `.exit` = 0
- PASS: `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/settings/notifications/spec.cy.ts -Browser chrome -RequireE2EHooks`  
  `.work-agent/logs/issue-1438-settings-notifications-history/20260625-1933/cypress-settings-notifications-committed.log`, `.exit` = 0  
  Summary: `.work-agent/logs/cypress/20260625-193936-spec.cy.summary.json`, source commit `8ba886344909664e86d4476211a2950c1f5efca3`, runtime `app_version=rev-8ba886344909`, 6/6 passing.

## Demo
Not deployed for this PR head. Current demo2 remains on `develop` at `a30081fc81ee2a7df96b0f9e653b0e95bd250cbb`; deployment is pending merge gates and demo2 recycle from clean `develop` after merge.

Closes focused slice of #1438; #1438 remains open for broader canonical notification persistence / emitter-audit scope unless split or accepted separately.