### PR TITLE
#1438 persist dashboard error notification history

### DIFF
--- a/openspec/specs/chats/notification-inbox/spec.md
+++ b/openspec/specs/chats/notification-inbox/spec.md
@@ -72,7 +72,7 @@ The Notification Inbox MUST render a compact two-pane operating layout with filt
 - **AND** page actions such as refresh, mark all visible as read, clear all, and show hidden MUST be icon-only with accessible names/tooltips.
 
 ### Requirement UI-SCREEN-NOTIFICATION-INBOX-008: Notification-like UI events SHALL be preserved in Inbox history
-Cabinet notification-like UI events, including toast messages, promise-based success/failure feedback, shared confirmation or warning dialogs, and inline status/banner messages from operational settings, storage maintenance, runtime setup import operations, notification-preference settings, taxonomy settings, Collections workspace, and Integrations provider health surfaces, MUST be captured into the Notification Inbox history so immediate feedback is not the only record. Captured records MUST include a source label, event time, level/category metadata, title, and detail or lifecycle summary sufficient for later review from the Inbox route. Once Cabinet has an active profile, captured local notification history MUST be promoted into the server-backed Inbox store and deduplicated by local capture ID so the record survives local history loss or reload.
+Cabinet notification-like UI events, including toast messages, promise-based success/failure feedback, shared confirmation or warning dialogs, and inline status/banner messages from Dashboard/Home API failures, operational settings, storage maintenance, runtime setup import operations, notification-preference settings, taxonomy settings, Collections workspace, and Integrations provider health surfaces, MUST be captured into the Notification Inbox history so immediate feedback is not the only record. Captured records MUST include a source label, event time, level/category metadata, title, and detail or lifecycle summary sufficient for later review from the Inbox route. Once Cabinet has an active profile, captured local notification history MUST be promoted into the server-backed Inbox store and deduplicated by local capture ID so the record survives local history loss or reload.
 
 #### Scenario: Toast lifecycle events appear in Inbox
 - **GIVEN** a user triggers a promise-based UI feedback flow
@@ -87,7 +87,7 @@ Cabinet notification-like UI events, including toast messages, promise-based suc
 - **AND** the record MUST show source, time, level/category metadata, title, and detail sufficient to identify the dialog after it disappears.
 
 #### Scenario: Inline status banners appear in Inbox
-- **GIVEN** a user triggers an operational settings, storage maintenance, runtime setup import, notification-preference settings, taxonomy settings, Collections workspace, or Integrations provider health action that renders inline or toast-backed success or failure status copy
+- **GIVEN** a user triggers a Dashboard/Home API failure, operational settings, storage maintenance, runtime setup import, notification-preference settings, taxonomy settings, Collections workspace, or Integrations provider health action that renders inline or toast-backed success or failure status copy
 - **WHEN** the user later opens the Notification Inbox
 - **THEN** the Notification Inbox MUST include a captured status/banner history record
 - **AND** the record MUST show source, time, level/category metadata, title, and detail sufficient to identify the operational status after it disappears or is replaced.

--- a/openspec/specs/dashboard/ui-screen-home/spec.md
+++ b/openspec/specs/dashboard/ui-screen-home/spec.md
@@ -27,6 +27,7 @@ Home SHALL support loading, empty, error, and ready states for each major panel.
 - **GIVEN** an authenticated actor with the required role is operating an active local profile, required capability configuration is enabled, and scenario fixture data exists for execution
 - **WHEN** Home API fetch fails
 - **THEN** Home SHALL render actionable retry/error messaging without route crash
+- **AND** Home SHALL preserve the failure status in Notification Inbox history with source, level, category, title, and summary metadata
 
 ### Requirement UI-SCREEN-HOME-003: Home quick actions SHALL route to correct workflows
 Each quick action SHALL navigate to the correct destination with preserved context.

--- a/ui.web/cypress/e2e/dashboard/ui-screen-home/spec.cy.ts
+++ b/ui.web/cypress/e2e/dashboard/ui-screen-home/spec.cy.ts
@@ -207,9 +207,33 @@ describe("UI-SCREEN-HOME", () => {
       })
     }).as("dashboardRetry")
 
+    cy.clearLocalStorage("cabinet.toastHistory.v1")
     signInToHome()
     cy.wait("@dashboardRetry")
     cy.contains("Dashboard unavailable").should("be.visible")
+    cy.window()
+      .its("localStorage")
+      .invoke("getItem", "cabinet.toastHistory.v1")
+      .should("be.a", "string")
+      .then((raw) => {
+        const records = JSON.parse(raw as string) as Array<{
+          level: string
+          title: string
+          summary: string
+          source_label: string
+          category: string
+        }>
+        expect(
+          records.some(
+            (record) =>
+              record.level === "error" &&
+              record.title === "Dashboard unavailable" &&
+              record.summary === "dashboard_fetch_failed_500" &&
+              record.source_label === "Home" &&
+              record.category === "system"
+          )
+        ).to.eq(true)
+      })
     cy.contains("button", "Retry").click()
     cy.wait("@dashboardRetry")
     cy.contains("Dashboard unavailable").should("not.exist")

--- a/ui.web/src/features/dashboard/index.tsx
+++ b/ui.web/src/features/dashboard/index.tsx
@@ -25,6 +25,7 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import { recordNotificationHistory } from '@/lib/toast-history'
 
 type DashboardCard = {
   title: string
@@ -84,13 +85,24 @@ export function Dashboard() {
       const message =
         err instanceof Error ? err.message : 'dashboard_fetch_failed'
       setError(message)
+      recordNotificationHistory({
+        id: `dashboard-fetch-error-${message}`,
+        level: 'error',
+        title: 'Dashboard unavailable',
+        summary: message,
+        source_label: 'Home',
+        category: 'system',
+      })
     } finally {
       setLoading(false)
     }
   }, [])
 
   useEffect(() => {
-    void loadDashboard()
+    const timeoutID = window.setTimeout(() => {
+      void loadDashboard()
+    }, 0)
+    return () => window.clearTimeout(timeoutID)
   }, [loadDashboard])
 
   const metricCards = useMemo(() => {


### PR DESCRIPTION
## Summary
- Persist Dashboard/Home fetch-error retry-card feedback into shared Notification Inbox history.
- Bind the Dashboard error-state and Notification Inbox history requirements to this #1438 slice.
- Extend the existing dashboard Cypress retry test to prove the recorded Inbox-history metadata.

## Validation
- PASS: `openspec validate --all --strict --no-interactive` (`.work-agent/logs/issue-1438-dashboard-error-notification-history/20260625-2032/openspec-strict-committed.exit` = 0)
- PASS: `pnpm --dir ui.web exec eslint src/features/dashboard/index.tsx cypress/e2e/dashboard/ui-screen-home/spec.cy.ts` (`.work-agent/logs/issue-1438-dashboard-error-notification-history/20260625-2032/eslint-touched-committed-final.exit` = 0)
- PASS: `git diff --check origin/develop...HEAD` (`.work-agent/logs/issue-1438-dashboard-error-notification-history/20260625-2032/diff-check-committed.exit` = 0)
- PASS: `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/dashboard/ui-screen-home/spec.cy.ts -Browser chrome -RequireE2EHooks` (`.work-agent/logs/cypress/20260625-204559-spec.cy.summary.json`, source_commit `382c28361e30088e2b9d53b1f7985772833d2124`, runtime `app_version=rev-382c28361e30`, 8/8 passing)

## Notes
- This is one representative Dashboard/Home API failure status surface. Broader #1438 canonical notification persistence / emitter-audit scope remains open unless split or accepted separately.