### PR TITLE
test(#1483): cover integration migration regressions

### DIFF
--- a/internal/app/integration_migration_regression_test.go
+++ b/internal/app/integration_migration_regression_test.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIntegrationMigrationRegistryKeepsLegacyProvidersVisibleAndRedacted(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	createProfile := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"IntegrationMigrationRegression"}`), map[string]string{"Content-Type": "application/json"})
+	if createProfile.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", createProfile.Code, createProfile.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createProfile.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	activate := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profile.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if activate.Code != http.StatusOK {
+		t.Fatalf("activate profile status=%d body=%s", activate.Code, activate.Body.String())
+	}
+
+	settings := doRequest(
+		t,
+		a,
+		http.MethodPut,
+		"/api/profiles/"+profile.ID+"/settings",
+		strings.NewReader(`{"settings":{"ebay_bearer_token":"secret-ebay-migration-token","ebay_marketplace":"EBAY_AU","ebay_base_url":"https://api.ebay.example","integration.au_webshops.domains":"bonzaslotcars.com.au,legacy.example.test","integration.au_webshop_legacy_example_test.enabled":"true","integration.au_webshop_legacy_example_test.token":"secret-legacy-provider-token","telegram.catalog_capture.sender_id":"12345","telegram.catalog_capture.chat_id":"-100987654321"}}`),
+		map[string]string{"Content-Type": "application/json"},
+	)
+	if settings.Code != http.StatusOK {
+		t.Fatalf("settings status=%d body=%s", settings.Code, settings.Body.String())
+	}
+	if _, err := a.db.Exec(`INSERT INTO app_state(key, value, updated_at) VALUES('provider.amazon.mode','disabled',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='disabled', updated_at=CURRENT_TIMESTAMP`); err != nil {
+		t.Fatalf("disable amazon migration mode: %v", err)
+	}
+
+	registry := doRequest(t, a, http.MethodGet, "/api/providers/registry", nil, nil)
+	if registry.Code != http.StatusOK {
+		t.Fatalf("registry status=%d body=%s", registry.Code, registry.Body.String())
+	}
+	raw := registry.Body.String()
+	for _, secret := range []string{"secret-ebay-migration-token", "secret-legacy-provider-token"} {
+		if strings.Contains(raw, secret) {
+			t.Fatalf("registry response must not leak migrated credential %q: %s", secret, raw)
+		}
+	}
+
+	var payload struct {
+		Providers []map[string]any `json:"providers"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("decode registry payload: %v", err)
+	}
+
+	for _, id := range []string{
+		"openai",
+		"telegram",
+		"ebay",
+		"amazon",
+		"au-webshop-bonzaslotcars-com-au",
+		"au-webshop-legacy-example-test",
+	} {
+		if provider := findRegistryProvider(payload.Providers, id); provider == nil {
+			t.Fatalf("migrated registry must keep provider id %q visible; providers=%+v", id, payload.Providers)
+		}
+	}
+
+	ebay := findRegistryProvider(payload.Providers, "ebay")
+	if ebay["has_token"] != true {
+		t.Fatalf("expected eBay token presence flag without token value, got %+v", ebay)
+	}
+	setup, ok := ebay["setup_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected eBay setup_status object, got %#v", ebay["setup_status"])
+	}
+	if got := fmt.Sprintf("%v", setup["token_state"]); got != "stored" {
+		t.Fatalf("expected migrated eBay token_state=stored, got setup=%+v", setup)
+	}
+
+	telegram := findRegistryProvider(payload.Providers, "telegram")
+	authMethods, ok := telegram["auth_methods"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Telegram auth methods after migration, got %+v", telegram)
+	}
+	senderChat, ok := authMethods["sender_chat"].(map[string]any)
+	if !ok || senderChat["connected"] != true {
+		t.Fatalf("expected migrated Telegram sender/chat authorization, got %+v", authMethods["sender_chat"])
+	}
+
+	amazon := findRegistryProvider(payload.Providers, "amazon")
+	if got := fmt.Sprintf("%v", amazon["state"]); got != "disabled" {
+		t.Fatalf("unsupported migrated Amazon provider must stay visible as disabled, got %+v", amazon)
+	}
+	if got := strings.TrimSpace(fmt.Sprintf("%v", amazon["setup_instructions"])); got == "" {
+		t.Fatalf("disabled Amazon provider needs visible setup/unsupported guidance, got %+v", amazon)
+	}
+
+	legacy := findRegistryProvider(payload.Providers, "au-webshop-legacy-example-test")
+	if got := fmt.Sprintf("%v", legacy["state"]); got != "ready" {
+		t.Fatalf("legacy AU webshop provider should migrate into ready registry entry, got %+v", legacy)
+	}
+	if legacy["has_token"] != true {
+		t.Fatalf("legacy provider should expose only token presence after migration, got %+v", legacy)
+	}
+}

--- a/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts
@@ -198,6 +198,124 @@ describe('ui-screen-integrations', () => {
       .and('contain', 'Items per page')
   })
 
+  it('#1483: renders migrated registry providers and keeps disabled providers addable with guidance', () => {
+    cy.intercept('GET', '/api/profiles/active', {
+      statusCode: 200,
+      body: { id: 'profile-e2e-001', name: 'E2E Local' },
+    }).as('activeProfile')
+    cy.intercept('GET', '/api/providers/registry', {
+      statusCode: 200,
+      body: {
+        providers: [
+          {
+            provider_id: 'ebay',
+            display_name: 'eBay',
+            base_domain: 'ebay.com',
+            integration_mode: 'official_api',
+            auth_mode: 'api_key',
+            state: 'ready',
+            has_token: true,
+            setup_instructions: 'Add eBay API token and marketplace.',
+            capabilities: {
+              search: true,
+              stock_observation: false,
+              pricing: true,
+              health: true,
+            },
+            health: { status: 'ok', last_checked_at: '2026-06-25T00:00:00Z' },
+            last_run: { status: 'success', finished_at: '2026-06-25T00:00:00Z' },
+          },
+          {
+            provider_id: 'openai',
+            display_name: 'OpenAI / ChatGPT',
+            base_domain: 'platform.openai.com',
+            integration_mode: 'assistant_workflows',
+            auth_mode: 'hybrid',
+            state: 'needs_config',
+            has_token: false,
+            setup_instructions: 'Configure OpenAI with Browser Auth or an API key.',
+            capabilities: {
+              search: false,
+              stock_observation: false,
+              pricing: false,
+              health: true,
+              assistant: true,
+            },
+            health: { status: 'unknown' },
+            last_run: { status: 'never' },
+          },
+          {
+            provider_id: 'amazon',
+            display_name: 'Amazon',
+            base_domain: 'amazon.com',
+            integration_mode: 'disabled',
+            auth_mode: 'hybrid',
+            state: 'disabled',
+            has_token: false,
+            setup_instructions:
+              'Program API eligibility controls availability before scans can run.',
+            capabilities: {
+              search: false,
+              stock_observation: false,
+              pricing: false,
+              health: true,
+            },
+            health: { status: 'unknown' },
+            last_run: { status: 'never' },
+          },
+          {
+            provider_id: 'au-webshop-legacy-example-test',
+            display_name: 'legacy.example.test',
+            base_domain: 'legacy.example.test',
+            integration_mode: 'web_ingestion',
+            auth_mode: 'none',
+            state: 'ready',
+            has_token: false,
+            setup_instructions: 'Webshop ingestion uses crawl parsing.',
+            capabilities: {
+              search: true,
+              stock_observation: true,
+              pricing: true,
+              health: true,
+            },
+            health: { status: 'unknown' },
+            last_run: { status: 'never' },
+          },
+        ],
+      },
+    }).as('registry')
+    cy.intercept('GET', '/api/profiles/*/settings', {
+      statusCode: 200,
+      body: { settings: { 'integration.ebay.enabled': 'true' } },
+    }).as('settings')
+
+    signIn()
+    cy.wait('@activeProfile')
+    cy.wait('@registry')
+    cy.wait('@settings')
+
+    cy.get('[data-testid="provider-row-ebay"]').should('be.visible')
+    cy.get('[data-testid="provider-row-openai"]').should('not.exist')
+    cy.get('[data-testid="provider-row-amazon"]').should('not.exist')
+    cy.get('[data-testid="provider-row-au-webshop-legacy-example-test"]').should(
+      'not.exist'
+    )
+
+    cy.get('[data-testid="integrations-header-add"]').click()
+    cy.get('[data-testid="integrations-provider-selector"]')
+      .should('be.visible')
+      .and('contain', 'OpenAI / ChatGPT')
+      .and('contain', 'Amazon')
+      .and('contain', 'legacy.example.test')
+
+    cy.get('[data-testid="integrations-provider-selector-option-amazon"]').click()
+    cy.get('[role="dialog"]')
+      .should('contain', 'Amazon')
+      .and('contain', 'Mode: disabled')
+      .and('contain', 'Program API eligibility controls availability')
+    cy.contains('secret').should('not.exist')
+  })
+
   it('UI-SCREEN-INTEGRATIONS-011 + #1112: paginates the full-page configured integrations table', () => {
     const providers = Array.from({ length: 12 }, (_, index) => {
       const number = index + 1


### PR DESCRIPTION
## Summary

- Adds #1483 API regression coverage for migrated provider registry visibility, stable provider IDs, credential redaction, Telegram sender/chat migration state, disabled Amazon visibility, and legacy AU webshop migration.
- Extends the integrations Cypress spec to prove Add Integration renders unconfigured migrated registry providers and disabled providers with setup guidance.

## Validation

- `go test ./internal/app -run TestIntegrationMigrationRegistryKeepsLegacyProvidersVisibleAndRedacted -count=1` passed.
- `npx prettier --check cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts` passed from `ui.web`.
- `git diff --check` passed after restoring validation-generated build artifacts.
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-integrations/spec.cy.ts -Browser chrome -BaseUrl http://127.0.0.1:17880 -StartupTimeoutSec 45 -LogDir .work-agent\logs\cypress -RequireE2EHooks -SkipDependencyPrep -LogName validate-issue-1483-ui-screen-integrations` passed.

Evidence logs: `.work-agent/logs/1483/20260626-0425-qa-cron/`
Cypress summary: `.work-agent/logs/cypress/20260626-043025-validate-issue-1483-ui-screen-integrations.summary.json`

Closes #1483.