### PR TITLE
#1501 Add shopping provider fixture contracts

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10298,14 +10298,16 @@ func providerCandidatesForScanner(candidates []map[string]any, defaultSource str
 	out := make([]scanner.CandidateInput, 0, len(candidates))
 	for _, candidate := range candidates {
 		listingID := strings.TrimSpace(fmt.Sprint(candidate["listing_id"]))
-		if listingID == "" {
+		title := stringCandidateValue(candidate["title"])
+		sourceURL := stringCandidateValue(candidate["url"])
+		if listingID == "" || title == "" || sourceURL == "" {
 			continue
 		}
 		out = append(out, scanner.CandidateInput{
 			ListingID:  listingID,
-			Title:      stringCandidateValue(candidate["title"]),
+			Title:      title,
 			Price:      numericCandidateValue(candidate["price"]),
-			URL:        stringCandidateValue(candidate["url"]),
+			URL:        sourceURL,
 			Seller:     stringCandidateValue(candidate["seller"]),
 			Source:     firstNonEmptyString(stringCandidateValue(candidate["source"]), defaultSource),
 			StockState: stringCandidateValue(candidate["stock_state"]),

--- a/internal/app/shopping_provider_fixture_contract_test.go
+++ b/internal/app/shopping_provider_fixture_contract_test.go
@@ -1,0 +1,195 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/collectors-tech/cabinet/internal/scanner"
+)
+
+func TestShoppingProviderFixturesNormalizeSharedCandidateShape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		providerID string
+		run        func(t *testing.T, serverURL string, client *http.Client) []scanner.CandidateInput
+	}{
+		{
+			name:       "hobbytech boost product fixture",
+			providerID: "hobbytechtoys",
+			run: func(t *testing.T, serverURL string, client *http.Client) []scanner.CandidateInput {
+				t.Helper()
+				candidates, pageCount, err := runHobbytechSearch(
+					context.Background(),
+					client,
+					scanner.QuerySet{Name: "AFX", Keywords: []string{"AFX"}},
+					hobbytechBoostConfig{
+						Shop:      "hobbytechtoys.com.au",
+						SID:       "fixture-sid",
+						Template:  "search",
+						Widget:    "main",
+						SearchURL: serverURL + "/hobbytech/search",
+					},
+					24,
+				)
+				if err != nil {
+					t.Fatalf("runHobbytechSearch() error = %v", err)
+				}
+				if pageCount != 1 {
+					t.Fatalf("expected one fixture page, got %d", pageCount)
+				}
+				return hobbytechCandidatesForScanner(candidates)
+			},
+		},
+		{
+			name:       "bigcommerce storefront product fixture",
+			providerID: "voglers.com.au",
+			run: func(t *testing.T, serverURL string, client *http.Client) []scanner.CandidateInput {
+				t.Helper()
+				candidates, err := runBigCommerceStorefrontSearch(
+					context.Background(),
+					client,
+					serverURL+"/bigcommerce/products/search",
+					"Scalextric",
+					1,
+					24,
+					"voglers.com.au",
+				)
+				if err != nil {
+					t.Fatalf("runBigCommerceStorefrontSearch() error = %v", err)
+				}
+				return bigCommerceCandidatesForScanner(candidates, "voglers.com.au")
+			},
+		},
+		{
+			name:       "doofinder product fixture",
+			providerID: "mrtoys.com.au",
+			run: func(t *testing.T, serverURL string, client *http.Client) []scanner.CandidateInput {
+				t.Helper()
+				candidates, total, err := runDoofinderSearch(
+					context.Background(),
+					client,
+					serverURL+"/doofinder/search",
+					"Carrera",
+					1,
+					24,
+					"fixture-hashid",
+					"https://www.mrtoys.com.au",
+					"mrtoys.com.au",
+				)
+				if err != nil {
+					t.Fatalf("runDoofinderSearch() error = %v", err)
+				}
+				if total != 1 {
+					t.Fatalf("expected total=1 from fixture, got %d", total)
+				}
+				return doofinderCandidatesForScanner(candidates, "mrtoys.com.au")
+			},
+		},
+	}
+
+	server := shoppingFixtureServer(t)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			candidates := tt.run(t, server.URL, server.Client())
+			if len(candidates) != 1 {
+				t.Fatalf("expected one normalized candidate, got %+v", candidates)
+			}
+			assertSharedShoppingCandidateShape(t, tt.providerID, candidates[0])
+		})
+	}
+}
+
+func TestShoppingProviderFixturesRejectMissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	server := shoppingFixtureServer(t)
+	candidates, pageCount, err := runHobbytechSearch(
+		context.Background(),
+		server.Client(),
+		scanner.QuerySet{Name: "Missing fields", Keywords: []string{"missing"}},
+		hobbytechBoostConfig{
+			Shop:      "hobbytechtoys.com.au",
+			SID:       "fixture-sid",
+			SearchURL: server.URL + "/missing-fields/search",
+		},
+		24,
+	)
+	if err != nil {
+		t.Fatalf("runHobbytechSearch() missing-field fixture error = %v", err)
+	}
+	if pageCount != 1 {
+		t.Fatalf("expected one missing-field fixture page, got %d", pageCount)
+	}
+	if normalized := hobbytechCandidatesForScanner(candidates); len(normalized) != 0 {
+		t.Fatalf("expected missing title/url records to be rejected, got %+v", normalized)
+	}
+}
+
+func shoppingFixtureServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	fixtures := map[string]string{
+		"/hobbytech/search":            readShoppingFixture(t, "hobbytech_success.json"),
+		"/bigcommerce/products/search": readShoppingFixture(t, "bigcommerce_storefront_success.json"),
+		"/doofinder/search":            readShoppingFixture(t, "doofinder_success.json"),
+		"/missing-fields/search":       readShoppingFixture(t, "missing_required_fields.json"),
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := fixtures[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		if strings.Contains(r.URL.Path, "doofinder") && strings.TrimSpace(r.Header.Get("Origin")) == "" {
+			http.Error(w, `{"error":"missing_origin"}`, http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func readShoppingFixture(t *testing.T, name string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("testdata", "shopping_provider_fixtures", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return string(raw)
+}
+
+func assertSharedShoppingCandidateShape(t *testing.T, providerID string, candidate scanner.CandidateInput) {
+	t.Helper()
+
+	if strings.TrimSpace(candidate.ListingID) == "" {
+		t.Fatalf("listing_id is required: %+v", candidate)
+	}
+	if strings.TrimSpace(candidate.Title) == "" {
+		t.Fatalf("title is required: %+v", candidate)
+	}
+	if strings.TrimSpace(candidate.URL) == "" {
+		t.Fatalf("source URL is required: %+v", candidate)
+	}
+	if strings.TrimSpace(candidate.Source) != providerID {
+		t.Fatalf("expected provider source %q, got %+v", providerID, candidate)
+	}
+	if strings.TrimSpace(candidate.Seller) == "" {
+		t.Fatalf("seller/provider domain is required: %+v", candidate)
+	}
+	if candidate.Price <= 0 {
+		t.Fatalf("price must be normalized to a positive value: %+v", candidate)
+	}
+}

--- a/internal/app/testdata/shopping_provider_fixtures/bigcommerce_storefront_success.json
+++ b/internal/app/testdata/shopping_provider_fixtures/bigcommerce_storefront_success.json
@@ -1,0 +1,14 @@
+{
+  "products": [
+    {
+      "id": "bc-fixture-1",
+      "name": "Scalextric Bathurst Mustang",
+      "url": "https://voglers.com.au/products/scalextric-bathurst-mustang",
+      "price": "59.95",
+      "image": "https://voglers.com.au/images/scalextric-bathurst-mustang.jpg"
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/internal/app/testdata/shopping_provider_fixtures/doofinder_success.json
+++ b/internal/app/testdata/shopping_provider_fixtures/doofinder_success.json
@@ -1,0 +1,14 @@
+{
+  "results": [
+    {
+      "id": "df-fixture-1",
+      "title": "Carrera Digital 132 Porsche",
+      "link": "https://www.mrtoys.com.au/products/carrera-digital-132-porsche",
+      "price": "72.50",
+      "image_link": "https://cdn.mrtoys.com.au/products/carrera-digital-132-porsche.jpg"
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/internal/app/testdata/shopping_provider_fixtures/hobbytech_success.json
+++ b/internal/app/testdata/shopping_provider_fixtures/hobbytech_success.json
@@ -1,0 +1,14 @@
+{
+  "products": [
+    {
+      "id": "hb-fixture-1",
+      "title": "AFX Mega G+ Camaro",
+      "url": "https://hobbytechtoys.com.au/products/afx-mega-g-camaro",
+      "price": "24.95",
+      "image": "https://hobbytechtoys.com.au/cdn/afx-mega-g-camaro.jpg"
+    }
+  ],
+  "pagination": {
+    "total_pages": 1
+  }
+}

--- a/internal/app/testdata/shopping_provider_fixtures/missing_required_fields.json
+++ b/internal/app/testdata/shopping_provider_fixtures/missing_required_fields.json
@@ -1,0 +1,17 @@
+{
+  "products": [
+    {
+      "id": "missing-title",
+      "url": "https://example.test/products/missing-title",
+      "price": "19.95"
+    },
+    {
+      "id": "missing-url",
+      "title": "Incomplete source record",
+      "price": "21.95"
+    }
+  ],
+  "pagination": {
+    "total_pages": 1
+  }
+}


### PR DESCRIPTION
## Summary\n- adds shared fixture-backed provider parser/normalization coverage for Hobbytech Boost, BigCommerce storefront, and Doofinder\n- adds missing-field fixture coverage so parser output missing title or source URL is rejected before scanner persistence\n- tightens shared provider candidate conversion to require listing ID, title, and source URL\n\n## Validation\n- PASS go test ./internal/app -run 'TestShoppingProviderFixtures|TestHobbytechRun|TestBigCommerceRun|TestDoofinderRun|TestProviderFamily' -count=1\n- PASS go test ./internal/scanner -run 'TestQuerySetAndRunNowLifecycle|TestRunNowPersistsObservedCurrency|TestFailureSnapshotsAreProfileScoped' -count=1\n- PASS git diff --check\n- CAVEAT go test ./internal/app -count=1 currently fails on the pre-existing docs migration guard for docs/backlog/reviews/chat-app-control-issue-plan-2026-06-25.md and docs/backlog/reviews/chat-application-control-review-2026-06-25.md, unrelated to this PR\n\nLog evidence: .work-agent/logs/issue-1501-shopping-provider-fixtures/20260626-1221/\n\nRefs #1501