### PR TITLE
#1503 wire Chat to deterministic app-control planner

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5116,28 +5116,32 @@ func New(cfg config.Config) (*App, error) {
 			response := map[string]any{"message": message}
 			if strings.EqualFold(strings.TrimSpace(req.Role), "user") {
 				if assistantContext, ok := req.Context["assistant"].(map[string]any); ok && len(assistantContext) > 0 {
-					inboxItem, inboxErr := chatSvc.CreateInboxItem(r.Context(), chat.InboxItem{
-						ProfileID: req.ProfileID,
-						ThreadID:  req.ThreadID,
-						Source:    "assistant_handoff",
-						Status:    "queued",
-						Title:     "Assistant handoff queued",
-						Summary:   strings.TrimSpace(req.Content),
-						Metadata: map[string]any{
-							"assistant": assistantContext,
-							"route":     req.Context["route"],
-							"selection": req.Context["selection"],
-						},
-					})
-					if inboxErr == nil {
-						assistantMessage, assistantErr := chatSvc.CreateMessage(r.Context(), req.ProfileID, req.ThreadID, "assistant", "Assistant handoff queued in Inbox.", map[string]any{
-							"assistant_handoff": map[string]any{
-								"status":        "queued",
-								"inbox_item_id": inboxItem.ID,
+					if appControl, handled := dispatchChatMessageAppControl(r.Context(), chatSvc, req.ProfileID, req.ThreadID, req.Content, req.Context, message.ID); handled {
+						response["app_control"] = appControl
+					} else {
+						inboxItem, inboxErr := chatSvc.CreateInboxItem(r.Context(), chat.InboxItem{
+							ProfileID: req.ProfileID,
+							ThreadID:  req.ThreadID,
+							Source:    "assistant_handoff",
+							Status:    "queued",
+							Title:     "Assistant handoff queued",
+							Summary:   strings.TrimSpace(req.Content),
+							Metadata: map[string]any{
+								"assistant": assistantContext,
+								"route":     req.Context["route"],
+								"selection": req.Context["selection"],
 							},
 						})
-						if assistantErr == nil {
-							response["assistant_handoff"] = map[string]any{"thread_message": assistantMessage, "inbox_item": inboxItem}
+						if inboxErr == nil {
+							assistantMessage, assistantErr := chatSvc.CreateMessage(r.Context(), req.ProfileID, req.ThreadID, "assistant", "Assistant handoff queued in Inbox.", map[string]any{
+								"assistant_handoff": map[string]any{
+									"status":        "queued",
+									"inbox_item_id": inboxItem.ID,
+								},
+							})
+							if assistantErr == nil {
+								response["assistant_handoff"] = map[string]any{"thread_message": assistantMessage, "inbox_item": inboxItem}
+							}
 						}
 					}
 				}

--- a/internal/app/chat_api_test.go
+++ b/internal/app/chat_api_test.go
@@ -537,6 +537,101 @@ func TestCabinetAgentAppControlCapabilitiesAndOpenItemTitleMutation(t *testing.T
 	}
 }
 
+func TestChatMessageAppControlPlannerDispatchesDeterministicActions(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	create := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"Chat Planner Profile"}`), map[string]string{"Content-Type": "application/json"})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", create.Code, create.Body.String())
+	}
+	var p struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(create.Body).Decode(&p); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	if activate := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+p.ID+`"}`), map[string]string{"Content-Type": "application/json"}); activate.Code != http.StatusOK {
+		t.Fatalf("activate profile status=%d body=%s", activate.Code, activate.Body.String())
+	}
+
+	threadResp := doRequest(t, a, http.MethodPost, "/api/chat/threads", strings.NewReader(`{"profile_id":"`+p.ID+`","title":"Planner Thread"}`), map[string]string{"Content-Type": "application/json"})
+	if threadResp.Code != http.StatusCreated {
+		t.Fatalf("create thread status=%d body=%s", threadResp.Code, threadResp.Body.String())
+	}
+	var thread struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(threadResp.Body).Decode(&thread); err != nil {
+		t.Fatalf("decode thread: %v", err)
+	}
+
+	routeResp := doRequest(t, a, http.MethodPost, "/api/chat/messages", strings.NewReader(`{"profile_id":"`+p.ID+`","thread_id":"`+thread.ID+`","role":"user","content":"open media","context":{"route":{"pathname":"/chats"},"assistant":{"provider":"openai","model":"gpt-4o-mini"}}}`), map[string]string{"Content-Type": "application/json"})
+	if routeResp.Code != http.StatusCreated {
+		t.Fatalf("route app-control status=%d body=%s", routeResp.Code, routeResp.Body.String())
+	}
+	routeBody := routeResp.Body.String()
+	if strings.Contains(routeBody, `"assistant_handoff"`) {
+		t.Fatalf("handled app-control route must not create default inbox handoff, body=%s", routeBody)
+	}
+	if !strings.Contains(routeBody, `"capability_id":"navigate.open_surface"`) || !strings.Contains(routeBody, `"route":"/media"`) || !strings.Contains(routeBody, `"confirmation_state":"not_required"`) {
+		t.Fatalf("expected navigate.open_surface app-control route result, body=%s", routeBody)
+	}
+
+	createResp := doRequest(t, a, http.MethodPost, "/api/chat/messages", strings.NewReader(`{"profile_id":"`+p.ID+`","thread_id":"`+thread.ID+`","role":"user","content":"create an inventory item AFX-001 Test Car","context":{"route":{"pathname":"/chats"},"assistant":{"provider":"openai","model":"gpt-4o-mini"}}}`), map[string]string{"Content-Type": "application/json"})
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create preview app-control status=%d body=%s", createResp.Code, createResp.Body.String())
+	}
+	createBody := createResp.Body.String()
+	if strings.Contains(createBody, `"assistant_handoff"`) {
+		t.Fatalf("handled app-control create must not create default inbox handoff, body=%s", createBody)
+	}
+	if !strings.Contains(createBody, `"capability_id":"inventory.item.create"`) || !strings.Contains(createBody, `"action":"create_inventory_item"`) || !strings.Contains(createBody, `"confirmation_state":"pending"`) || !strings.Contains(createBody, `"part_number":"AFX-001"`) {
+		t.Fatalf("expected create_inventory_item preview result, body=%s", createBody)
+	}
+	itemsBeforeConfirm := doRequest(t, a, http.MethodGet, "/api/items?profile_id="+p.ID, nil, nil)
+	if itemsBeforeConfirm.Code != http.StatusOK {
+		t.Fatalf("items status=%d body=%s", itemsBeforeConfirm.Code, itemsBeforeConfirm.Body.String())
+	}
+	if strings.Contains(itemsBeforeConfirm.Body.String(), "AFX-001") {
+		t.Fatalf("planner preview must not mutate inventory before confirmation, body=%s", itemsBeforeConfirm.Body.String())
+	}
+
+	itemResp := doRequest(t, a, http.MethodPost, "/api/items", strings.NewReader(`{"part_number":"REN-001","title":"Original Planner Title","brand":"AFX","category":"Slot Cars"}`), map[string]string{"Content-Type": "application/json"})
+	if itemResp.Code != http.StatusCreated {
+		t.Fatalf("create item status=%d body=%s", itemResp.Code, itemResp.Body.String())
+	}
+	var item struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(itemResp.Body).Decode(&item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	renameResp := doRequest(t, a, http.MethodPost, "/api/chat/messages", strings.NewReader(`{"profile_id":"`+p.ID+`","thread_id":"`+thread.ID+`","role":"user","content":"rename this item to Planner Updated Title","context":{"route":{"pathname":"/inventory/`+item.ID+`"},"assistant":{"provider":"openai","model":"gpt-4o-mini"}}}`), map[string]string{"Content-Type": "application/json"})
+	if renameResp.Code != http.StatusCreated {
+		t.Fatalf("rename preview app-control status=%d body=%s", renameResp.Code, renameResp.Body.String())
+	}
+	renameBody := renameResp.Body.String()
+	if !strings.Contains(renameBody, `"capability_id":"update_open_item_title"`) || !strings.Contains(renameBody, `"action":"update_open_item_title"`) || !strings.Contains(renameBody, `"item_id":"`+item.ID+`"`) || !strings.Contains(renameBody, `"title":"Planner Updated Title"`) {
+		t.Fatalf("expected open item rename preview result, body=%s", renameBody)
+	}
+	itemsAfterRenamePreview := doRequest(t, a, http.MethodGet, "/api/items?profile_id="+p.ID, nil, nil)
+	if itemsAfterRenamePreview.Code != http.StatusOK {
+		t.Fatalf("items after rename preview status=%d body=%s", itemsAfterRenamePreview.Code, itemsAfterRenamePreview.Body.String())
+	}
+	if strings.Contains(itemsAfterRenamePreview.Body.String(), "Planner Updated Title") {
+		t.Fatalf("rename preview must not mutate inventory before confirmation, body=%s", itemsAfterRenamePreview.Body.String())
+	}
+
+	runs := doRequest(t, a, http.MethodGet, "/api/chat/workflow-runs?profile_id="+p.ID+"&thread_id="+thread.ID, nil, nil)
+	if runs.Code != http.StatusOK {
+		t.Fatalf("workflow runs status=%d body=%s", runs.Code, runs.Body.String())
+	}
+	if !strings.Contains(runs.Body.String(), `"workflow_id":"chat.app_control.dispatch"`) || !strings.Contains(runs.Body.String(), `"capability_id":"navigate.open_surface"`) || !strings.Contains(runs.Body.String(), `"capability_id":"inventory.item.create"`) || !strings.Contains(runs.Body.String(), `"capability_id":"update_open_item_title"`) {
+		t.Fatalf("expected durable app-control workflow audit runs, body=%s", runs.Body.String())
+	}
+}
+
 func TestAssistantContentListingGenerationRunsStayPreviewFirst(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/chat_app_control.go
+++ b/internal/app/chat_app_control.go
@@ -1,0 +1,288 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/collectors-tech/cabinet/internal/chat"
+)
+
+type chatAppControlIntent struct {
+	CapabilityID      string
+	Action            string
+	Payload           map[string]any
+	Route             string
+	ConfirmationState string
+	Message           string
+	SetupNeeded       bool
+}
+
+func dispatchChatMessageAppControl(ctx context.Context, chatSvc *chat.Service, profileID, threadID, content string, envelope map[string]any, sourceMessageID string) (map[string]any, bool) {
+	intent, ok := planChatMessageAppControl(content, envelope)
+	if !ok {
+		return nil, false
+	}
+	result := map[string]any{
+		"capability_id": intent.CapabilityID,
+		"policy":        "preview-before-apply",
+	}
+	if intent.Route != "" {
+		result["route"] = intent.Route
+	}
+	if intent.SetupNeeded {
+		result["setup_needed"] = true
+	}
+
+	run, runErr := chatSvc.CreateWorkflowRun(ctx, chat.CreateWorkflowRunInput{
+		ProfileID:         profileID,
+		WorkflowID:        "chat.app_control.dispatch",
+		CapabilityID:      intent.CapabilityID,
+		SourceChannel:     "in_app_chat",
+		SourceThreadID:    threadID,
+		SourceMessageID:   sourceMessageID,
+		Input:             map[string]any{"content": content, "route": envelope["route"], "selection": envelope["selection"]},
+		ProviderTrace:     map[string]any{"mode": "deterministic_app_control_planner", "live_provider": false},
+		ConfirmationState: intent.ConfirmationState,
+	})
+	if runErr == nil {
+		result["workflow_run"] = run
+	}
+
+	if intent.Action != "" {
+		preview, previewErr := chatSvc.PreviewAction(ctx, chat.PreviewActionInput{
+			ProfileID: profileID,
+			ThreadID:  threadID,
+			Action:    intent.Action,
+			Payload:   intent.Payload,
+		})
+		if previewErr != nil {
+			result["error"] = map[string]any{"code": "app_control_preview_failed", "message": previewErr.Error()}
+			intent.Message = "I found the app-control request, but Cabinet could not create a safe preview."
+		} else {
+			result["preview"] = preview
+			if runErr == nil {
+				updated, updateErr := chatSvc.UpdateWorkflowRun(ctx, chat.UpdateWorkflowRunInput{
+					ProfileID:         profileID,
+					RunID:             run.ID,
+					Status:            "completed",
+					ProviderTrace:     map[string]any{"mode": "deterministic_app_control_planner", "live_provider": false},
+					Result:            map[string]any{"preview_id": preview.ID, "action": preview.Action, "confirmation_required": true},
+					ConfirmationState: "pending",
+				})
+				if updateErr == nil {
+					result["workflow_run"] = updated
+				}
+			}
+		}
+	} else if runErr == nil {
+		updated, updateErr := chatSvc.UpdateWorkflowRun(ctx, chat.UpdateWorkflowRunInput{
+			ProfileID:         profileID,
+			RunID:             run.ID,
+			Status:            "completed",
+			ProviderTrace:     map[string]any{"mode": "deterministic_app_control_planner", "live_provider": false},
+			Result:            map[string]any{"route": intent.Route, "setup_needed": intent.SetupNeeded},
+			ConfirmationState: intent.ConfirmationState,
+		})
+		if updateErr == nil {
+			result["workflow_run"] = updated
+		}
+	}
+
+	assistantMessage, assistantErr := chatSvc.CreateMessage(ctx, profileID, threadID, "assistant", intent.Message, map[string]any{
+		"app_control": result,
+	})
+	if assistantErr == nil {
+		result["thread_message"] = assistantMessage
+	}
+	return result, true
+}
+
+func planChatMessageAppControl(content string, envelope map[string]any) (chatAppControlIntent, bool) {
+	normalized := normalizePlannerText(content)
+	if normalized == "" {
+		return chatAppControlIntent{}, false
+	}
+	if route, label, ok := plannedOpenSurface(normalized); ok {
+		return chatAppControlIntent{
+			CapabilityID:      "navigate.open_surface",
+			Route:             route,
+			ConfirmationState: "not_required",
+			Message:           fmt.Sprintf("I can open %s from this thread without changing Cabinet data.", label),
+		}, true
+	}
+	if partNumber, title, ok := plannedCreateInventoryItem(content); ok {
+		return chatAppControlIntent{
+			CapabilityID:      "inventory.item.create",
+			Action:            "create_inventory_item",
+			Payload:           map[string]any{"part_number": partNumber, "title": title, "brand": "Unknown", "category": "General", "source": "chat_app_control"},
+			ConfirmationState: "pending",
+			Message:           fmt.Sprintf("I prepared a preview to create %s. Confirm before Cabinet saves anything.", partNumber),
+		}, true
+	}
+	if title, ok := plannedRenameTitle(content); ok {
+		itemID := selectedItemID(envelope)
+		if itemID == "" {
+			return chatAppControlIntent{
+				CapabilityID:      "update_open_item_title",
+				ConfirmationState: "not_required",
+				Message:           "I can rename an item after you open or select the target inventory item.",
+				SetupNeeded:       true,
+			}, true
+		}
+		return chatAppControlIntent{
+			CapabilityID:      "update_open_item_title",
+			Action:            "update_open_item_title",
+			Payload:           map[string]any{"item_id": itemID, "title": title, "source_route": routePath(envelope)},
+			ConfirmationState: "pending",
+			Message:           "I prepared a title-change preview for the open item. Confirm before Cabinet applies it.",
+		}, true
+	}
+	if mentionsProviderBackedCapability(normalized) {
+		return chatAppControlIntent{
+			CapabilityID:      "content_generate",
+			ConfirmationState: "not_required",
+			Message:           "That assistant action needs provider setup before Cabinet can run it.",
+			SetupNeeded:       true,
+		}, true
+	}
+	return chatAppControlIntent{}, false
+}
+
+func normalizePlannerText(content string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(content))), " ")
+}
+
+func plannedOpenSurface(normalized string) (string, string, bool) {
+	if !strings.Contains(normalized, "open ") && !strings.Contains(normalized, "go to ") && !strings.Contains(normalized, "show ") {
+		return "", "", false
+	}
+	surfaces := []struct {
+		aliases []string
+		route   string
+		label   string
+	}{
+		{[]string{"media", "photos", "images"}, "/media", "Media"},
+		{[]string{"inventory", "items"}, "/inventory", "Inventory"},
+		{[]string{"wishlist", "wish list"}, "/wishlist", "Wishlist"},
+		{[]string{"collections"}, "/collections", "Collections"},
+		{[]string{"integrations", "apps"}, "/integrations", "Integrations"},
+		{[]string{"settings"}, "/settings", "Settings"},
+		{[]string{"chats", "chat"}, "/chats", "Chats"},
+	}
+	for _, surface := range surfaces {
+		for _, alias := range surface.aliases {
+			if strings.Contains(normalized, alias) {
+				return surface.route, surface.label, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func plannedCreateInventoryItem(content string) (string, string, bool) {
+	normalized := normalizePlannerText(content)
+	if !strings.Contains(normalized, "create") || (!strings.Contains(normalized, "inventory item") && !strings.Contains(normalized, "item")) {
+		return "", "", false
+	}
+	parts := strings.Fields(strings.TrimSpace(content))
+	for i, part := range parts {
+		clean := strings.Trim(part, ".,:;")
+		if looksLikePartNumber(clean) && i+1 < len(parts) {
+			title := strings.TrimSpace(strings.Join(parts[i+1:], " "))
+			title = strings.Trim(title, ".,")
+			if title != "" {
+				return clean, title, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func plannedRenameTitle(content string) (string, bool) {
+	normalized := normalizePlannerText(content)
+	if !strings.Contains(normalized, "rename") && !strings.Contains(normalized, "title") {
+		return "", false
+	}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\brename\b.+?\bto\s+(.+)$`),
+		regexp.MustCompile(`(?i)\btitle\b.+?\bto\s+(.+)$`),
+	}
+	for _, pattern := range patterns {
+		matches := pattern.FindStringSubmatch(strings.TrimSpace(content))
+		if len(matches) == 2 {
+			title := strings.Trim(strings.TrimSpace(matches[1]), ` "'.,`)
+			if title != "" {
+				return title, true
+			}
+		}
+	}
+	return "", false
+}
+
+func mentionsProviderBackedCapability(normalized string) bool {
+	return strings.Contains(normalized, "generate listing") ||
+		strings.Contains(normalized, "catalog content") ||
+		strings.Contains(normalized, "analyze image") ||
+		strings.Contains(normalized, "process image") ||
+		strings.Contains(normalized, "provider")
+}
+
+func looksLikePartNumber(value string) bool {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return false
+	}
+	hasDigit := false
+	hasLetter := false
+	for _, r := range value {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z':
+			hasLetter = true
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
+	return hasDigit && hasLetter
+}
+
+func selectedItemID(envelope map[string]any) string {
+	if id := stringFromNestedMap(envelope, "selection", "item_id"); id != "" {
+		return id
+	}
+	if id := stringFromNestedMap(envelope, "selection", "active_item_id"); id != "" {
+		return id
+	}
+	pathname := routePath(envelope)
+	if strings.HasPrefix(pathname, "/inventory/") {
+		return strings.Trim(strings.TrimPrefix(pathname, "/inventory/"), "/")
+	}
+	if rawSearch := stringFromNestedMap(envelope, "route", "search"); rawSearch != "" {
+		values, err := url.ParseQuery(strings.TrimPrefix(rawSearch, "?"))
+		if err == nil {
+			return strings.TrimSpace(values.Get("item"))
+		}
+	}
+	return ""
+}
+
+func routePath(envelope map[string]any) string {
+	if path := stringFromNestedMap(envelope, "route", "pathname"); path != "" {
+		return path
+	}
+	return "/"
+}
+
+func stringFromNestedMap(envelope map[string]any, parent, key string) string {
+	rawParent, _ := envelope[parent].(map[string]any)
+	if rawParent == nil {
+		return ""
+	}
+	rawValue, _ := rawParent[key].(string)
+	return strings.TrimSpace(rawValue)
+}

--- a/ui.web/cypress/e2e/chats/assistant-workspace/spec.cy.ts
+++ b/ui.web/cypress/e2e/chats/assistant-workspace/spec.cy.ts
@@ -62,6 +62,67 @@ describe('chats/assistant-workspace', () => {
     cy.contains('[data-testid="shell-assistant-message-list"]', 'what should I do with this inventory route?').should('exist')
   })
 
+  it('ASSISTANT-WORKSPACE-008/#1503 renders app-control route and preview cards from assistant thread context', () => {
+    bootstrapInventory()
+    cy.intercept('POST', '/api/chat/messages').as('assistantMessage')
+    openAssistantWorkspace()
+
+    cy.get('[data-testid="shell-assistant-compose-input"]').type('open media')
+    cy.get('[data-testid="shell-assistant-send-button"]').click()
+    cy.wait('@assistantMessage').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body.app_control.capability_id).to.eq(
+        'navigate.open_surface'
+      )
+      expect(response?.body.app_control.route).to.eq('/media')
+    })
+    cy.get('[data-testid="shell-assistant-navigation-action"]')
+      .should('be.visible')
+      .and('contain', 'Open Media')
+    cy.get('[data-testid="shell-assistant-navigation-reason"]').should(
+      'contain',
+      'read-only navigation action'
+    )
+    cy.get('[data-testid="shell-assistant-navigation-action-open"]').click()
+    cy.location('pathname', { timeout: 15000 }).should('match', /^\/media\/?$/)
+
+    cy.get('[data-testid="shell-assistant-compose-input"]').type(
+      'create an inventory item APP-1503 Thread Preview'
+    )
+    cy.get('[data-testid="shell-assistant-send-button"]').click()
+    cy.wait('@assistantMessage').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body.app_control.capability_id).to.eq(
+        'inventory.item.create'
+      )
+      expect(response?.body.app_control.preview.action).to.eq(
+        'create_inventory_item'
+      )
+      expect(response?.body.app_control.preview.payload.part_number).to.eq(
+        'APP-1503'
+      )
+      expect(response?.body.app_control.preview.payload.title).to.eq(
+        'Thread Preview'
+      )
+    })
+    cy.get('[data-testid="shell-assistant-permission-guidance"]').should(
+      'contain',
+      'Confirm before any mutation is applied'
+    )
+    cy.get('[data-testid="shell-assistant-action-preview"]')
+      .should('contain', 'create_inventory_item')
+      .and('contain', 'APP-1503')
+      .and('contain', 'Thread Preview')
+    cy.get('[data-testid="shell-assistant-apply-action"]').should(
+      'not.be.disabled'
+    )
+    cy.request('/api/items?profile_id=e2e-profile-001')
+      .its('body')
+      .should((items) => {
+        expect(JSON.stringify(items)).not.to.include('APP-1503')
+      })
+  })
+
   it('ASSISTANT-WORKSPACE-003 changes provider/model with deterministic forked-thread semantics', () => {
     bootstrapInventory()
     let originalThreadId = ''

--- a/ui.web/src/components/layout/assistant-workspace-panel.tsx
+++ b/ui.web/src/components/layout/assistant-workspace-panel.tsx
@@ -64,6 +64,7 @@ type Message = {
     selection?: { active_workspace_collection?: string }
     assistant?: { provider?: string; model?: string }
     assistant_handoff?: { status?: string; inbox_item_id?: string }
+    app_control?: AppControlContext
   }
 }
 
@@ -71,7 +72,20 @@ type ActionPreview = {
   id: string
   action: string
   status: string
-  payload?: { part_number?: string; title?: string }
+  payload?: { part_number?: string; title?: string; item_id?: string }
+}
+
+type AppControlContext = {
+  capability_id?: string
+  policy?: string
+  route?: string
+  setup_needed?: boolean
+  preview?: ActionPreview
+  workflow_run?: {
+    id?: string
+    status?: string
+    confirmation_state?: string
+  }
 }
 
 type ApplyActionResult = {
@@ -156,6 +170,41 @@ function resultLink(result: ApplyActionResult | null) {
   return null
 }
 
+function labelForRoute(route: string) {
+  const normalized = route.replace(/^\/+/, '').replace(/\/+$/, '')
+  if (!normalized) {
+    return 'Open Cabinet'
+  }
+  return `Open ${normalized
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' / ')}`
+}
+
+function navigationActionFromAppControl(
+  appControl: AppControlContext | undefined
+): NavigationAction | null {
+  const route = appControl?.route?.trim()
+  if (!route) {
+    return null
+  }
+  return {
+    id: appControl?.capability_id || 'navigate.open_surface',
+    label: labelForRoute(route),
+    target: route,
+    reason:
+      appControl?.policy === 'preview-before-apply'
+        ? 'Cabinet planned this as a read-only navigation action from the assistant thread.'
+        : 'Cabinet planned this route action from the assistant thread.',
+  }
+}
+
+function latestAppControl(messages: Message[]) {
+  return [...messages].reverse().find((message) => message.context?.app_control)
+    ?.context?.app_control
+}
+
 async function loadAssistantDefaultSettings(profileId: string) {
   const response = await fetch(`/api/profiles/${profileId}/settings`)
   if (!response.ok) {
@@ -235,6 +284,12 @@ export function AssistantWorkspacePanel() {
         ?.models || [],
     [provider]
   )
+  const appControl = useMemo(() => latestAppControl(messages), [messages])
+  const backendNavigationAction = useMemo(
+    () => navigationActionFromAppControl(appControl),
+    [appControl]
+  )
+  const displayedNavigationAction = navigationAction ?? backendNavigationAction
 
   const selectedThreadTitle = useMemo(
     () =>
@@ -357,6 +412,19 @@ export function AssistantWorkspacePanel() {
     return nextThreads
   }
 
+  useEffect(() => {
+    const preview = appControl?.preview
+    if (!preview?.id || actionPreview?.id === preview.id) {
+      return
+    }
+    setActionPreview(preview)
+    setApplyResult(null)
+    setExecutionState('running')
+    setPermissionGuidance(
+      'Cabinet created this preview from the assistant thread. Confirm before any mutation is applied.'
+    )
+  }, [actionPreview?.id, appControl?.preview])
+
   async function handleSelectThread(nextThreadId: string) {
     if (!activeProfileId || !nextThreadId || nextThreadId === threadId) return
     const selected = threads.find((thread) => thread.id === nextThreadId)
@@ -365,6 +433,7 @@ export function AssistantWorkspacePanel() {
     setThreadMetadata(selected?.metadata ?? {})
     if (selected?.metadata?.provider) setProvider(selected.metadata.provider)
     if (selected?.metadata?.model) setModel(selected.metadata.model)
+    setMessages([])
     setActionPreview(null)
     setApplyResult(null)
     setExecutionState('idle')
@@ -590,6 +659,7 @@ export function AssistantWorkspacePanel() {
       setActionPreview(null)
       setApplyResult(null)
       setNavigationAction(null)
+      setMessages([])
       setExecutionState('idle')
       await loadMessages(activeProfileId, newThreadId)
     } catch (err) {
@@ -744,10 +814,7 @@ export function AssistantWorkspacePanel() {
   const applyLink = resultLink(applyResult)
 
   return (
-    <div
-      className='px-2 py-2'
-      data-testid='shell-assistant-workspace'
-    >
+    <div className='px-2 py-2' data-testid='shell-assistant-workspace'>
       <AssistantRuntimeProvider runtime={assistantRuntime}>
         <AssistantModalPrimitive.Root
           defaultOpen
@@ -923,9 +990,7 @@ export function AssistantWorkspacePanel() {
 
                 <div className='mt-3 grid grid-cols-2 gap-2 text-xs'>
                   <label className='space-y-1'>
-                    <span className='font-medium text-slate-300'>
-                      Provider
-                    </span>
+                    <span className='font-medium text-slate-300'>Provider</span>
                     <select
                       data-testid='shell-assistant-provider-select'
                       className='w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-100'
@@ -983,7 +1048,7 @@ export function AssistantWorkspacePanel() {
                     reset creates a clean thread for the current profile.
                   </span>
                 </div>
-                {navigationAction ? (
+                {displayedNavigationAction ? (
                   <div
                     className='mt-3 rounded-md border border-slate-800 bg-slate-900 p-3 text-sm'
                     data-testid='shell-assistant-navigation-action'
@@ -991,12 +1056,14 @@ export function AssistantWorkspacePanel() {
                     <div className='flex items-start gap-2'>
                       <ExternalLink className='mt-0.5 h-4 w-4 text-primary' />
                       <div className='min-w-0 flex-1'>
-                        <p className='font-medium'>{navigationAction.label}</p>
+                        <p className='font-medium'>
+                          {displayedNavigationAction.label}
+                        </p>
                         <p
                           className='mt-1 text-xs text-muted-foreground'
                           data-testid='shell-assistant-navigation-reason'
                         >
-                          {navigationAction.reason}
+                          {displayedNavigationAction.reason}
                         </p>
                         <Button
                           type='button'
@@ -1005,7 +1072,9 @@ export function AssistantWorkspacePanel() {
                           className='mt-2 border-slate-700 bg-slate-950 text-slate-100 hover:bg-slate-800'
                           data-testid='shell-assistant-navigation-action-open'
                           onClick={() =>
-                            void navigate({ to: navigationAction.target })
+                            void navigate({
+                              to: displayedNavigationAction.target,
+                            })
                           }
                         >
                           <ExternalLink className='h-3.5 w-3.5' />
@@ -1023,9 +1092,9 @@ export function AssistantWorkspacePanel() {
                   data-testid='shell-assistant-message-list'
                 >
                   {loading ? (
-                      <p className='text-sm text-slate-400'>
-                        Loading assistant workspace...
-                      </p>
+                    <p className='text-sm text-slate-400'>
+                      Loading assistant workspace...
+                    </p>
                   ) : null}
                   {!loading && messages.length === 0 ? (
                     <div className='rounded-lg border border-dashed border-slate-700 bg-slate-900/60 p-3 text-sm text-slate-400'>


### PR DESCRIPTION
## Summary

Implements a bounded #1503 backend/API slice that routes normal assistant-context chat messages through deterministic app-control planning before falling back to the old Inbox handoff.

Changes:
- Adds deterministic app-control planning for `open media`/known surface route requests.
- Adds chat-text preview creation for `create_inventory_item` requests such as `create an inventory item AFX-001 Test Car`.
- Adds chat-text preview creation for open-item rename requests such as `rename this item to ...` using route/selection context.
- Adds provider-backed setup-needed guidance for unavailable assistant/provider actions.
- Persists accepted app-control requests as `chat.app_control.dispatch` workflow runs and assistant thread messages.
- Keeps unknown ordinary assistant messages on the existing assistant Inbox handoff path.

## Validation

- PASS `go test ./internal/app -run 'TestChatMessageAppControlPlannerDispatchesDeterministicActions|TestChatAPIsThreadMessageAttachmentAndPreviewApply|TestCabinetAgentAppControlCapabilitiesAndOpenItemTitleMutation' -count=1`
  - `.work-agent/logs/issue-1503-chat-app-control-planner/20260626-1501/go-test-internal-app-chat-planner.log`
- PASS `git diff --check`
  - `.work-agent/logs/issue-1503-chat-app-control-planner/20260626-1501/diff-check.log`
- PASS `openspec validate --all --strict --no-interactive`
  - `.work-agent/logs/issue-1503-chat-app-control-planner/20260626-1501/openspec-validate.log`
- PASS pre-push OpenSpec hook and fast API docs smoke test during `git push`.

## Notes

This is not a full #1503 closure yet. It establishes the deterministic planner/dispatcher path and backend proof. Follow-up work remains for UI consumption of route cards, broader capability-registry binding, and full main/shell E2E coverage.