### PR TITLE
#1501 test: cover Bonza category listing fixture

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9917,6 +9917,11 @@ func runBonzaSearch(ctx context.Context, client *http.Client, baseURL string, qs
 				"listing_id":  listingID,
 				"title":       strings.TrimSpace(product.Name),
 				"url":         permalink,
+				"price":       parseWooCommerceMinorUnitPrice(product.Prices.Price),
+				"currency":    strings.TrimSpace(product.Prices.CurrencyCode),
+				"image":       firstBonzaImageURL(product.Images),
+				"category":    firstBonzaCategoryName(product.Categories),
+				"categories":  bonzaCategoryNames(product.Categories),
 				"source":      "bonzaslotcars",
 				"seller":      "bonzaslotcars.com.au",
 				"stock_state": stockState,
@@ -10327,7 +10332,9 @@ func providerCandidatesForScanner(candidates []map[string]any, defaultSource str
 			ListingID:  listingID,
 			Title:      title,
 			Price:      numericCandidateValue(candidate["price"]),
+			Currency:   stringCandidateValue(candidate["currency"]),
 			URL:        sourceURL,
+			Image:      stringCandidateValue(candidate["image"]),
 			Seller:     stringCandidateValue(candidate["seller"]),
 			Source:     firstNonEmptyString(stringCandidateValue(candidate["source"]), defaultSource),
 			StockState: stringCandidateValue(candidate["stock_state"]),
@@ -10335,6 +10342,33 @@ func providerCandidatesForScanner(candidates []map[string]any, defaultSource str
 		})
 	}
 	return out
+}
+
+func firstBonzaCategoryName(categories []bonzaProductName) string {
+	names := bonzaCategoryNames(categories)
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
+}
+
+func bonzaCategoryNames(categories []bonzaProductName) []string {
+	out := make([]string, 0, len(categories))
+	for _, category := range categories {
+		if value := strings.TrimSpace(category.Name); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func firstBonzaImageURL(images []bonzaProductImage) string {
+	for _, image := range images {
+		if src := strings.TrimSpace(image.Src); src != "" {
+			return src
+		}
+	}
+	return ""
 }
 
 func normalizeScannerReviewApplyTarget(raw string) string {

--- a/internal/app/shopping_provider_fixture_contract_test.go
+++ b/internal/app/shopping_provider_fixture_contract_test.go
@@ -164,6 +164,65 @@ func TestShoppingProviderFixturesPreserveAvailabilitySignals(t *testing.T) {
 	}
 }
 
+func TestShoppingProviderFixturesCoverBonzaCategoryListingShape(t *testing.T) {
+	t.Parallel()
+
+	server := shoppingFixtureServer(t)
+	result, err := runBonzaSearch(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		scanner.QuerySet{Name: "AFX", Keywords: []string{"AFX"}},
+		24,
+	)
+	if err != nil {
+		t.Fatalf("runBonzaSearch() category fixture error = %v", err)
+	}
+	if result.PageCount != 1 {
+		t.Fatalf("expected one Bonza fixture page, got %d", result.PageCount)
+	}
+	if result.ObservedPageSize != 1 || result.ItemsPerPageUsed != 24 {
+		t.Fatalf("unexpected Bonza fixture paging metadata: %+v", result)
+	}
+	if len(result.Candidates) != 1 {
+		t.Fatalf("expected one Bonza category/listing candidate, got %+v", result.Candidates)
+	}
+	raw := result.Candidates[0]
+	for key, want := range map[string]string{
+		"listing_id": "bonza-2001",
+		"title":      "AFX Mega-G+ Ford GT",
+		"url":        server.URL + "/product/afx-mega-g-ford-gt/",
+		"currency":   "AUD",
+		"image":      "https://bonzaslotcars.com.au/wp-content/uploads/afx-mega-g-ford-gt.jpg",
+		"category":   "HO Slot Cars",
+		"source":     "bonzaslotcars",
+		"seller":     "bonzaslotcars.com.au",
+	} {
+		if got := stringCandidateValue(raw[key]); got != want {
+			t.Fatalf("Bonza raw candidate %s got %q want %q; candidate=%+v", key, got, want, raw)
+		}
+	}
+	if got := numericCandidateValue(raw["price"]); got != 64.95 {
+		t.Fatalf("Bonza raw candidate price got %.2f want 64.95; candidate=%+v", got, raw)
+	}
+	if got := raw["categories"]; !hasStringValue(got, "HO Slot Cars") || !hasStringValue(got, "AFX") {
+		t.Fatalf("Bonza raw candidate categories missing fixture values: %+v", raw)
+	}
+
+	normalized := bonzaCandidatesForScanner(result.Candidates)
+	if len(normalized) != 1 {
+		t.Fatalf("expected one normalized Bonza candidate, got %+v", normalized)
+	}
+	candidate := normalized[0]
+	assertSharedShoppingCandidateShape(t, "bonzaslotcars", candidate)
+	if candidate.Currency != "AUD" {
+		t.Fatalf("expected normalized Bonza currency AUD, got %+v", candidate)
+	}
+	if candidate.Image == "" {
+		t.Fatalf("expected normalized Bonza image URL, got %+v", candidate)
+	}
+}
+
 func TestShoppingProviderFixturesRejectUnsupportedManualFallbackResponse(t *testing.T) {
 	t.Parallel()
 
@@ -192,12 +251,13 @@ func shoppingFixtureServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	fixtures := map[string]string{
-		"/hobbytech/search":            readShoppingFixture(t, "hobbytech_success.json"),
-		"/bigcommerce/products/search": readShoppingFixture(t, "bigcommerce_storefront_success.json"),
-		"/bigcommerce/graphql":         readShoppingFixture(t, "bigcommerce_graphql_stock_success.json"),
-		"/doofinder/search":            readShoppingFixture(t, "doofinder_success.json"),
-		"/missing-fields/search":       readShoppingFixture(t, "missing_required_fields.json"),
-		"/unsupported/manual-fallback": readShoppingFixture(t, "unsupported_manual_fallback.json"),
+		"/hobbytech/search":             readShoppingFixture(t, "hobbytech_success.json"),
+		"/bigcommerce/products/search":  readShoppingFixture(t, "bigcommerce_storefront_success.json"),
+		"/bigcommerce/graphql":          readShoppingFixture(t, "bigcommerce_graphql_stock_success.json"),
+		"/doofinder/search":             readShoppingFixture(t, "doofinder_success.json"),
+		"/missing-fields/search":        readShoppingFixture(t, "missing_required_fields.json"),
+		"/wp-json/wc/store/v1/products": readShoppingFixture(t, "bonza_category_listing_success.json"),
+		"/unsupported/manual-fallback":  readShoppingFixture(t, "unsupported_manual_fallback.json"),
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, ok := fixtures[r.URL.Path]
@@ -253,4 +313,17 @@ func assertSharedShoppingCandidateShape(t *testing.T, providerID string, candida
 	if candidate.Price <= 0 {
 		t.Fatalf("price must be normalized to a positive value: %+v", candidate)
 	}
+}
+
+func hasStringValue(raw any, want string) bool {
+	values, ok := raw.([]string)
+	if !ok {
+		return false
+	}
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/app/testdata/shopping_provider_fixtures/bonza_category_listing_success.json
+++ b/internal/app/testdata/shopping_provider_fixtures/bonza_category_listing_success.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": 2001,
+    "name": "AFX Mega-G+ Ford GT",
+    "slug": "afx-mega-g-ford-gt",
+    "permalink": "/product/afx-mega-g-ford-gt/",
+    "description": "<p>HO scale slot car listing fixture.</p>",
+    "prices": {
+      "currency_code": "AUD",
+      "price": "6495"
+    },
+    "is_in_stock": true,
+    "low_stock_remaining": 3,
+    "categories": [
+      {
+        "name": "HO Slot Cars"
+      },
+      {
+        "name": "AFX"
+      }
+    ],
+    "images": [
+      {
+        "src": "https://bonzaslotcars.com.au/wp-content/uploads/afx-mega-g-ford-gt.jpg"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add a shared Bonza/WooCommerce shopping fixture for category/listing metadata
- assert raw adapter category, category list, price, currency, image, seller, and listing URL shape
- carry parsed provider currency and image through shared scanner candidate normalization

## Validation
- PASS git diff --check; .work-agent/logs/issue-1501-bonza-category-fixture/20260626-1820/diff-check.log
- PASS go test ./internal/app -run 'TestShoppingProviderFixtures' -count=1; .work-agent/logs/issue-1501-bonza-category-fixture/20260626-1820/go-test-shopping-provider-fixtures.log
- PASS go test ./internal/app -run 'TestBonzaRunAggregatesPagesAndEnrichesWatchedStock' -count=1; .work-agent/logs/issue-1501-bonza-category-fixture/20260626-1820/go-test-bonza-provider-run.log

Refs #1501