### PR TITLE
#1501 test: scope provider health failures

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8709,6 +8709,10 @@ func (p amazonContractProvider) Search(context.Context, scanner.QuerySet) ([]sca
 	return p.candidates, nil
 }
 
+func (p amazonContractProvider) ProviderID() string {
+	return "amazon"
+}
+
 func buildAmazonCandidateContract(qs scanner.QuerySet) []scanner.CandidateInput {
 	keyword := "collectible"
 	if len(qs.Keywords) > 0 && strings.TrimSpace(qs.Keywords[0]) != "" {

--- a/internal/ebay/provider.go
+++ b/internal/ebay/provider.go
@@ -71,6 +71,10 @@ func NewProvider(cfg ProviderConfig) *Provider {
 	}
 }
 
+func (p *Provider) ProviderID() string {
+	return "ebay"
+}
+
 func (p *Provider) Search(ctx context.Context, q scanner.QuerySet) ([]scanner.CandidateInput, error) {
 	if p.bearerToken == "" {
 		return nil, &ProviderError{StatusCode: http.StatusUnauthorized, ErrorCode: "PROVIDER_AUTH_MISSING", Message: "missing ebay bearer token"}

--- a/internal/scanner/providers.go
+++ b/internal/scanner/providers.go
@@ -32,6 +32,10 @@ type DisabledProvider struct {
 	name string
 }
 
+func (p DisabledProvider) ProviderID() string {
+	return p.name
+}
+
 func (p DisabledProvider) Search(context.Context, QuerySet) ([]CandidateInput, error) {
 	return nil, fmt.Errorf("%s provider is disabled", p.name)
 }

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -113,6 +113,10 @@ type Provider interface {
 	Search(ctx context.Context, q QuerySet) ([]CandidateInput, error)
 }
 
+type providerIdentifier interface {
+	ProviderID() string
+}
+
 type Service struct {
 	db *sql.DB
 }
@@ -520,6 +524,7 @@ func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID st
 	if provider == nil {
 		return RunResult{}, fmt.Errorf("provider is required")
 	}
+	providerID := providerHealthID(provider, qs)
 	requestedItemsPerPage, effectiveItemsPerPage, itemsPerPageWarning := resolveItemsPerPage(
 		qs.ProviderScope,
 		qs.ItemsPerPage,
@@ -535,7 +540,7 @@ func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID st
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		items, lastErr = provider.Search(ctx, qs)
 		if lastErr == nil {
-			s.recordProviderHealth(ctx, "ebay", "ok", "")
+			s.recordProviderHealth(ctx, providerID, "ok", "")
 			result, persistErr := s.persistCandidatesForProfile(
 				ctx,
 				strings.TrimSpace(profileID),
@@ -548,8 +553,8 @@ func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID st
 			)
 			return result, persistErr
 		}
-		s.recordProviderHealth(ctx, "ebay", "error", lastErr.Error(), retryAfterSecondsFromError(lastErr))
-		s.logFailure(ctx, strings.TrimSpace(profileID), qs.ID, "ebay", lastErr.Error())
+		s.recordProviderHealth(ctx, providerID, "error", lastErr.Error(), retryAfterSecondsFromError(lastErr))
+		s.logFailure(ctx, strings.TrimSpace(profileID), qs.ID, providerID, lastErr.Error())
 		if attempt < maxAttempts {
 			sleep := time.Duration(1000/qs.RateLimitRPS) * time.Millisecond
 			if sleep < 100*time.Millisecond {
@@ -566,6 +571,20 @@ func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID st
 		PageCount:             0,
 		ItemsPerPageWarning:   itemsPerPageWarning,
 	}, fmt.Errorf("run failed: %w", lastErr)
+}
+
+func providerHealthID(provider Provider, qs QuerySet) string {
+	if identified, ok := provider.(providerIdentifier); ok {
+		if id := strings.TrimSpace(strings.ToLower(identified.ProviderID())); id != "" {
+			return id
+		}
+	}
+	for _, candidate := range qs.ProviderScope {
+		if id := strings.TrimSpace(strings.ToLower(candidate)); id != "" {
+			return id
+		}
+	}
+	return "ebay"
 }
 
 func (s *Service) RunScheduled(ctx context.Context, provider Provider) (int, error) {

--- a/internal/scanner/service_test.go
+++ b/internal/scanner/service_test.go
@@ -10,9 +10,14 @@ import (
 )
 
 type testProvider struct {
-	failures int
-	calls    int
-	items    []CandidateInput
+	providerID string
+	failures   int
+	calls      int
+	items      []CandidateInput
+}
+
+func (p *testProvider) ProviderID() string {
+	return p.providerID
 }
 
 func (p *testProvider) Search(_ context.Context, _ QuerySet) ([]CandidateInput, error) {
@@ -291,6 +296,67 @@ func TestFailureSnapshotsAreProfileScoped(t *testing.T) {
 	}
 	if reloadedOther.LastRunStatus != "never" || reloadedOther.LastRunMessage != "" {
 		t.Fatalf("expected profile-b clean snapshot, got %+v", reloadedOther)
+	}
+}
+
+func TestRunNowRecordsProviderHealthForExecutingProvider(t *testing.T) {
+	t.Parallel()
+
+	conn, err := db.OpenAndMigrate(context.Background(), filepath.Join(t.TempDir(), "cabinet.db"))
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	svc := NewService(conn)
+	qs, err := svc.CreateQuerySetForProfile(context.Background(), "profile-a", QuerySet{
+		Name:          "Bonza scoped health",
+		Keywords:      []string{"afx"},
+		ProviderScope: []string{"bonzaslotcars"},
+		Enabled:       true,
+		MaxRetryCount: 0,
+	})
+	if err != nil {
+		t.Fatalf("CreateQuerySetForProfile() error = %v", err)
+	}
+
+	_, err = svc.RunNowForProfile(context.Background(), "profile-a", qs.ID, &testProvider{
+		providerID: "bonzaslotcars",
+		failures:   1,
+	})
+	if err == nil {
+		t.Fatal("expected bonzaslotcars run failure")
+	}
+
+	bonzaHealth, err := svc.ProviderHealth(context.Background(), "bonzaslotcars")
+	if err != nil {
+		t.Fatalf("ProviderHealth(bonzaslotcars) error = %v", err)
+	}
+	if bonzaHealth["status"] != "error" || bonzaHealth["message"] != "temporary failure" {
+		t.Fatalf("expected bonzaslotcars health failure, got %+v", bonzaHealth)
+	}
+	ebayHealth, err := svc.ProviderHealth(context.Background(), "ebay")
+	if err != nil {
+		t.Fatalf("ProviderHealth(ebay) error = %v", err)
+	}
+	if ebayHealth["status"] != "unknown" || ebayHealth["message"] != "" {
+		t.Fatalf("non-ebay provider failure must not poison ebay health, got %+v", ebayHealth)
+	}
+	failures, err := svc.ListFailuresByProfile(context.Background(), "profile-a")
+	if err != nil {
+		t.Fatalf("ListFailuresByProfile(profile-a) error = %v", err)
+	}
+	if len(failures) != 1 {
+		t.Fatalf("expected one provider-scoped failure, got %+v", failures)
+	}
+	for key, expected := range map[string]string{
+		"provider":       "bonzaslotcars",
+		"retry_guidance": "Review provider status and retry the operation.",
+		"next_action":    "review_provider_status",
+	} {
+		if got := failures[0][key]; got != expected {
+			t.Fatalf("expected scoped failure %s=%q, got %q in %+v", key, expected, got, failures[0])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add optional scanner provider identity via ProviderID().
- Record scanner provider health and failure snapshots under the executing provider ID instead of hard-coding eBay.
- Add regression coverage proving Bonza-scoped failures do not poison eBay health and use generic provider retry guidance.

## Validation
- PASS git diff --check; .work-agent/logs/issue-1501-provider-health-scoped-failures/20260626-2022/diff-check.log
- PASS go test ./internal/scanner -run 'TestQuerySetAndRunNowLifecycle|TestFailureSnapshotsAreProfileScoped|TestRunNowRecordsProviderHealthForExecutingProvider|TestProviderRegistrySupportsAdditionalSources' -count=1; .work-agent/logs/issue-1501-provider-health-scoped-failures/20260626-2022/go-test-scanner-provider-health.log
- PASS go test ./internal/app -run 'TestEbayProviderRunMapsBrowseFailureToProviderHealthGuidance|TestScannerQuerySetsAndProviderHealthEndpoints|TestWave4ProvidersRegistryContract' -count=1; .work-agent/logs/issue-1501-provider-health-scoped-failures/20260626-2022/go-test-app-provider-health.log

Issue: #1501