### PR TITLE
#1552 Persist provider outputs into Discoveries review queue

### DIFF
--- a/internal/app/provider_frontline_discovery_api_test.go
+++ b/internal/app/provider_frontline_discovery_api_test.go
@@ -220,6 +220,28 @@ const indexName = 'frontline_products_live';
 		}
 	}
 
+	discoveries := doRequest(t, a, http.MethodGet, "/api/discovery/not-in-collection?q=AFX", nil, nil)
+	if discoveries.Code != http.StatusOK {
+		t.Fatalf("discovery list status=%d body=%s", discoveries.Code, discoveries.Body.String())
+	}
+	var discoveryPayload struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.NewDecoder(discoveries.Body).Decode(&discoveryPayload); err != nil {
+		t.Fatalf("decode discovery payload: %v", err)
+	}
+	if len(discoveryPayload.Items) != 2 {
+		t.Fatalf("expected persisted provider candidates to enter Discoveries, got %+v", discoveryPayload.Items)
+	}
+	for _, item := range discoveryPayload.Items {
+		if item["source_provider"] != "frontlinehobbies" || item["query_set_id"] != qs.ID {
+			t.Fatalf("expected Discoveries item to retain provider/query provenance, got %+v", item)
+		}
+		if item["triage_status"] != "new" || item["match_type"] != "market_watch_result" {
+			t.Fatalf("expected provider output to be a new Market Watch discovery, got %+v", item)
+		}
+	}
+
 	reloaded := doRequest(t, a, http.MethodGet, "/api/scanner/query-sets", nil, nil)
 	if reloaded.Code != http.StatusOK {
 		t.Fatalf("reload query sets status=%d body=%s", reloaded.Code, reloaded.Body.String())

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -662,20 +662,37 @@ func (s *Service) persistCandidatesForProfile(
 		stockState := normalizeStockState(it.StockState, stockCount)
 		res, err := s.db.ExecContext(ctx, `
 			UPDATE scanner_candidates
-			SET title = ?, price = ?, shipping = ?, url = ?, image = ?, seller = ?, last_seen = CURRENT_TIMESTAMP, status = 'seen', source = ?, stock_state = ?, stock_count = ?, observed_currency = ?
+			SET title = ?, price = ?, shipping = ?, url = ?, image = ?, seller = ?, last_seen = CURRENT_TIMESTAMP,
+				status = CASE WHEN status IN ('ignored', 'archived', 'wishlisted', 'purchase_candidate', 'inventory_candidate') THEN status ELSE 'seen' END,
+				source = ?, stock_state = ?, stock_count = ?, observed_currency = ?
 			WHERE listing_id = ? AND (? = '' OR profile_id = ?)
 		`, it.Title, it.Price, it.Shipping, it.URL, it.Image, it.Seller, source, stockState, stockCount, observedCurrency, it.ListingID, strings.TrimSpace(profileID), strings.TrimSpace(profileID))
 		if err != nil {
 			return RunResult{}, fmt.Errorf("update candidate: %w", err)
 		}
 		affected, _ := res.RowsAffected()
+		var candidateID string
 		if affected == 0 {
+			candidateID = uuid.NewString()
 			_, err := s.db.ExecContext(ctx, `
 				INSERT INTO scanner_candidates(id, profile_id, query_set_id, listing_id, title, price, shipping, url, image, seller, first_seen, last_seen, status, source, stock_state, stock_count, observed_currency)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'new', ?, ?, ?, ?)
-			`, uuid.NewString(), strings.TrimSpace(profileID), querySetID, it.ListingID, it.Title, it.Price, it.Shipping, it.URL, it.Image, it.Seller, source, stockState, stockCount, observedCurrency)
+			`, candidateID, strings.TrimSpace(profileID), querySetID, it.ListingID, it.Title, it.Price, it.Shipping, it.URL, it.Image, it.Seller, source, stockState, stockCount, observedCurrency)
 			if err != nil {
 				return RunResult{}, fmt.Errorf("insert candidate: %w", err)
+			}
+		} else {
+			if err := s.db.QueryRowContext(ctx, `
+				SELECT id
+				FROM scanner_candidates
+				WHERE listing_id = ? AND (? = '' OR profile_id = ?)
+			`, it.ListingID, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&candidateID); err != nil {
+				return RunResult{}, fmt.Errorf("load candidate id for discovery match: %w", err)
+			}
+		}
+		if strings.TrimSpace(candidateID) != "" {
+			if err := s.ensureDiscoveryMatch(ctx, candidateID, it); err != nil {
+				return RunResult{}, err
 			}
 		}
 		saved++
@@ -689,6 +706,22 @@ func (s *Service) persistCandidatesForProfile(
 		PageCount:             calculatePageCount(saved, effectiveItemsPerPage),
 		ItemsPerPageWarning:   itemsPerPageWarning,
 	}, nil
+}
+
+func (s *Service) ensureDiscoveryMatch(ctx context.Context, candidateID string, it CandidateInput) error {
+	partNumber := strings.TrimSpace(it.ListingID)
+	if partNumber == "" {
+		partNumber = strings.TrimSpace(it.Title)
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO scanner_matches(candidate_id, item_id, state, confidence, needs_review, extracted_part_number, updated_at)
+		VALUES (?, '', 'not_in_collection', 0, 1, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(candidate_id) DO NOTHING
+	`, strings.TrimSpace(candidateID), partNumber)
+	if err != nil {
+		return fmt.Errorf("ensure discovery match: %w", err)
+	}
+	return nil
 }
 
 func calculatePageCount(saved, pageSize int) int {

--- a/internal/scanner/service_test.go
+++ b/internal/scanner/service_test.go
@@ -159,6 +159,63 @@ func TestRunNowPersistsObservedCurrency(t *testing.T) {
 	}
 }
 
+func TestRunNowDoesNotReintroduceArchivedDiscoveryCandidate(t *testing.T) {
+	t.Parallel()
+
+	conn, err := db.OpenAndMigrate(context.Background(), filepath.Join(t.TempDir(), "cabinet.db"))
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	svc := NewService(conn)
+	qs, err := svc.CreateQuerySet(context.Background(), QuerySet{
+		Name:     "Archived duplicate",
+		Keywords: []string{"afx"},
+	})
+	if err != nil {
+		t.Fatalf("CreateQuerySet() error = %v", err)
+	}
+	provider := &testProvider{items: []CandidateInput{{
+		ListingID: "ARCHIVED-DISCOVERY-1",
+		Title:     "Archived AFX candidate",
+		Price:     42.5,
+		Currency:  "AUD",
+		URL:       "https://example.test/provider/archived",
+		Source:    "frontlinehobbies",
+	}}}
+	if _, err := svc.RunNow(context.Background(), qs.ID, provider); err != nil {
+		t.Fatalf("RunNow() first pass error = %v", err)
+	}
+	if _, err := conn.Exec(`UPDATE scanner_candidates SET status = 'archived' WHERE listing_id = 'ARCHIVED-DISCOVERY-1'`); err != nil {
+		t.Fatalf("archive candidate: %v", err)
+	}
+	provider.items[0].Price = 39.95
+	if _, err := svc.RunNow(context.Background(), qs.ID, provider); err != nil {
+		t.Fatalf("RunNow() duplicate pass error = %v", err)
+	}
+
+	var status string
+	var price float64
+	if err := conn.QueryRow(`SELECT status, price FROM scanner_candidates WHERE listing_id = 'ARCHIVED-DISCOVERY-1'`).Scan(&status, &price); err != nil {
+		t.Fatalf("load candidate: %v", err)
+	}
+	if status != "archived" {
+		t.Fatalf("duplicate provider refresh reintroduced archived candidate with status=%q", status)
+	}
+	if price != 39.95 {
+		t.Fatalf("expected duplicate refresh to update metadata without changing status, price=%v", price)
+	}
+
+	var matchCount int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM scanner_matches WHERE candidate_id = (SELECT id FROM scanner_candidates WHERE listing_id = 'ARCHIVED-DISCOVERY-1')`).Scan(&matchCount); err != nil {
+		t.Fatalf("load match count: %v", err)
+	}
+	if matchCount != 1 {
+		t.Fatalf("expected one stable discovery match row, got %d", matchCount)
+	}
+}
+
 func TestUpdateQuerySetPreservesProviderScopeWhenOmitted(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Ensures provider/Market Watch scanner persistence creates a default `not_in_collection` discovery match row when no richer match exists, so persisted provider outputs enter the Discoveries review inbox.
- Preserves handled candidate statuses (`ignored`, `archived`, `wishlisted`, `purchase_candidate`, `inventory_candidate`) during duplicate provider refreshes instead of reintroducing them as active results.
- Adds app/scanner regression coverage for Frontline provider output appearing in `/api/discovery/not-in-collection` with provider/query provenance and for archived duplicate refresh behavior.

## Validation
- `go test ./internal/app -run 'TestFrontlineRunPersistsAlgoliaCandidatesAndHydratesSnapshot|TestDiscoveryActionResponseReturnsEbayHandoffProvenance' -count=1` PASS (`.work-agent/logs/issue-1552/go-test-provider-discovery.log`)
- `go test ./internal/scanner ./internal/discovery -run 'TestRunNow|TestListNotInCollection|TestApplySavedSearchActionsRetainAuditProvenance|TestApplyAction' -count=1` PASS (`.work-agent/logs/issue-1552/go-test-scanner-discovery.log`)
- `go test ./internal/app ./internal/discovery ./internal/scanner -run Discovery -count=1` PASS (`.work-agent/logs/issue-1552/go-test-suggested-discovery.log`)
- Push hook OpenSpec validation PASS: 11 items passed, 0 failed
- Push hook API docs smoke test PASS: `go test ./internal/app` smoke target

## Notes
- Demo deployment pending merge to `develop`; no demo claim for this PR branch.