### PR TITLE
#1556 feat(discoveries): contextualize discovery actions

### DIFF
--- a/internal/discovery/service.go
+++ b/internal/discovery/service.go
@@ -304,6 +304,10 @@ func (s *Service) ApplyActionWithResult(ctx context.Context, a Action) (ActionRe
 
 	switch a.Type {
 	case ActionReview:
+		_, err = s.db.ExecContext(ctx, `DELETE FROM ignored_candidates WHERE candidate_id = ?`, a.CandidateID)
+		if err != nil {
+			return ActionResult{}, fmt.Errorf("restore ignored candidate for review: %w", err)
+		}
 		if err := s.updateCandidateTriage(ctx, a.CandidateID, "reviewing", reviewerNotes); err != nil {
 			return ActionResult{}, err
 		}

--- a/internal/discovery/service_test.go
+++ b/internal/discovery/service_test.go
@@ -569,3 +569,60 @@ func TestApplyActionPersistsDestinationStatusesAndWishlistDoesNotClaimOwnership(
 		t.Fatalf("confirmed inventory promotion created %d item(s), want 1", ownedCreateCount)
 	}
 }
+
+func TestReviewActionRestoresIgnoredCandidateForDefaultQueue(t *testing.T) {
+	t.Parallel()
+
+	conn, err := db.OpenAndMigrate(context.Background(), filepath.Join(t.TempDir(), "cabinet.db"))
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if _, err := conn.Exec(`INSERT INTO scanner_query_sets(id, name, keywords_json, exclusions_json) VALUES ('q1','Restore Query','["restore"]','[]')`); err != nil {
+		t.Fatalf("seed query set: %v", err)
+	}
+	if _, err := conn.Exec(`INSERT INTO scanner_candidates(id, query_set_id, listing_id, title, price, shipping, url, image, seller, first_seen, last_seen, status, source) VALUES ('c-restore','q1','RESTORE-001','Restore Candidate',25,0,'https://example.test/restore','','seller',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,'ignored','ebay')`); err != nil {
+		t.Fatalf("seed candidate: %v", err)
+	}
+	if _, err := conn.Exec(`INSERT INTO scanner_matches(candidate_id, item_id, state, confidence, needs_review, extracted_part_number, updated_at) VALUES ('c-restore','','not_in_collection',0.7,1,'RESTORE-001',CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatalf("seed match: %v", err)
+	}
+	if _, err := conn.Exec(`INSERT INTO ignored_candidates(candidate_id) VALUES ('c-restore')`); err != nil {
+		t.Fatalf("seed ignored candidate: %v", err)
+	}
+
+	svc := NewService(conn)
+	defaultItems, err := svc.ListNotInCollection(context.Background(), Filter{})
+	if err != nil {
+		t.Fatalf("ListNotInCollection(default) error = %v", err)
+	}
+	if len(defaultItems) != 0 {
+		t.Fatalf("expected ignored candidate hidden by default, got %+v", defaultItems)
+	}
+
+	if err := svc.ApplyAction(context.Background(), Action{
+		CandidateID: "c-restore",
+		Type:        ActionReview,
+		Payload: map[string]any{
+			"reviewer_notes": "restore for follow-up",
+		},
+	}); err != nil {
+		t.Fatalf("ApplyAction(review) error = %v", err)
+	}
+
+	restored, err := svc.ListNotInCollection(context.Background(), Filter{})
+	if err != nil {
+		t.Fatalf("ListNotInCollection(restored) error = %v", err)
+	}
+	if len(restored) != 1 || restored[0].CandidateID != "c-restore" || restored[0].TriageStatus != "reviewing" {
+		t.Fatalf("expected restored reviewing candidate in default queue, got %+v", restored)
+	}
+	var ignoredCount int
+	if err := conn.QueryRow(`SELECT COUNT(1) FROM ignored_candidates WHERE candidate_id = 'c-restore'`).Scan(&ignoredCount); err != nil {
+		t.Fatalf("load ignored count: %v", err)
+	}
+	if ignoredCount != 0 {
+		t.Fatalf("expected review restore to remove ignored marker, got %d", ignoredCount)
+	}
+}

--- a/openspec/specs/dashboard/ui-screen-discover/spec.md
+++ b/openspec/specs/dashboard/ui-screen-discover/spec.md
@@ -114,6 +114,14 @@ preserving the candidate-inbox destination workflow.
 - **AND** ignored or archived candidates MUST be hidden from the default view and reachable through an explicit filter
 - **AND** source-result, Wishlist, Purchase follow-up, Inventory handoff, and ignore/archive actions MUST remain contextual and accessible without claiming ownership by default
 
+#### Scenario: Contextual action set by candidate state
+- **GIVEN** Discoveries renders wishlist-match, new non-wishlist, promoted, and ignored or archived candidates
+- **WHEN** row actions are shown
+- **THEN** wishlist-match rows MUST expose source review, purchase follow-up, and ignore/archive actions without duplicate Wishlist or Inventory promotion controls
+- **AND** new non-wishlist rows MUST expose source review, Wishlist promotion, Purchase follow-up, Inventory handoff, and ignore/archive actions
+- **AND** promoted rows MUST expose linked destination access where available and suppress duplicate promotion controls
+- **AND** ignored or archived rows MUST be reachable only through the explicit ignored/archived filter and expose restore-for-review only when the data model can return them to the review queue
+
 #### Scenario: Dashboard API fields and archived opt-in
 - **GIVEN** scanner candidates include wishlist linkage, saved-search provenance, price snapshots, provider health, thumbnails, and ignored or archived status
 - **WHEN** Discoveries requests `/api/discovery/not-in-collection?include_archived=true`
@@ -154,3 +162,4 @@ preserving the candidate-inbox destination workflow.
 | UC-DIS-16 | Discoveries dashboard API fields | Backend returns deal ranking, wishlist linkage, provider trust, display labels, and archived candidates only through explicit opt-in | implemented: `internal/discovery/service_test.go` `TestListNotInCollectionDashboardFieldsAndArchivedOptIn`; `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-007 + #1533 renders dashboard summary source filters and ranked deal table` |
 | UC-DIS-17 | Source filters and ranking stability | Source filters and table sort controls narrow or reorder visible rows without posting discovery actions or mutating candidate state, while wishlist/deal candidates remain ranked ahead of lower-signal rows by default | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-007 keeps ranking and source filters deterministic without mutating candidates`; `UI-SCREEN-DISCOVER-007 sorts the dashboard table by deal and recency without mutating candidates` |
 | UC-DIS-18 | Provider attention, no-match, and promoted states | Provider-attention, unmatched/no-match, and already-promoted candidates render distinct review states, and promoted rows expose destination access instead of duplicate promotion actions | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-007 renders provider-attention no-match and promoted destination states` |
+| UC-DIS-19 | Contextual discovery actions | Wishlist-match, new non-wishlist, promoted, and ignored/archived candidates expose only state-safe actions, and restore returns archived candidates to review | implemented: `ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` `UI-SCREEN-DISCOVER-007 + #1556 shows contextual actions for wishlist, new, and archived candidates`; `internal/discovery/service_test.go` `TestReviewActionRestoresIgnoredCandidateForDefaultQueue` |

--- a/ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts
+++ b/ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts
@@ -833,6 +833,102 @@ describe('dashboard/ui-screen-discover', () => {
     )
   })
 
+  it('UI-SCREEN-DISCOVER-007 + #1556 shows contextual actions for wishlist, new, and archived candidates', () => {
+    cy.intercept('GET', '/api/discovery/not-in-collection*', {
+      statusCode: 200,
+      body: {
+        items: [
+          {
+            candidate_id: 'cand-wishlist-match-actions',
+            title: 'Wishlist Match Action Candidate',
+            price: 35,
+            currency: 'AUD',
+            match_type: 'wishlist_match',
+            wishlist_id: 'wish-action-1',
+            wishlist_item_id: 'item-action-1',
+            source_result_url: 'https://provider.test/wishlist-match',
+            first_seen: '2026-06-21T00:00:00Z',
+            last_seen: '2026-06-26T00:00:00Z',
+            stock_state: 'in_stock',
+            stock_count: 1,
+            triage_status: 'new',
+          },
+          {
+            candidate_id: 'cand-new-actions',
+            title: 'New Discovery Action Candidate',
+            price: 22,
+            currency: 'AUD',
+            match_type: 'provider_search',
+            source_result_url: 'https://provider.test/new-result',
+            first_seen: '2026-06-21T00:00:00Z',
+            last_seen: '2026-06-26T00:00:00Z',
+            stock_state: 'in_stock',
+            stock_count: 3,
+            triage_status: 'new',
+          },
+          {
+            candidate_id: 'cand-archived-actions',
+            title: 'Archived Action Candidate',
+            price: 18,
+            currency: 'AUD',
+            match_type: 'provider_search',
+            source_result_url: 'https://provider.test/archived-result',
+            first_seen: '2026-06-20T00:00:00Z',
+            last_seen: '2026-06-26T00:00:00Z',
+            stock_state: 'out_of_stock',
+            stock_count: 0,
+            triage_status: 'archived',
+          },
+        ],
+      },
+    }).as('discoverContextActionsList')
+
+    cy.intercept('POST', '/api/discovery/action', (req) => {
+      expect(req.body).to.deep.equal({
+        candidate_id: 'cand-archived-actions',
+        type: 'review',
+        payload: {},
+      })
+      req.reply({ statusCode: 200, body: { ok: true } })
+    }).as('discoverRestoreAction')
+
+    signInToDiscoveries()
+    cy.wait('@discoverContextActionsList')
+
+    cy.get('[data-testid="discover-candidate-row-cand-wishlist-match-actions"]')
+      .should('contain', 'Wishlist match')
+      .within(() => {
+        cy.get('[data-testid="discover-action-review-source-cand-wishlist-match-actions"]').should('exist')
+        cy.get('[data-testid="discover-action-track-cand-wishlist-match-actions"]').should('exist')
+        cy.get('[data-testid="discover-action-ignore-cand-wishlist-match-actions"]').should('exist')
+        cy.get('[data-testid="discover-action-wishlist-cand-wishlist-match-actions"]').should('not.exist')
+        cy.get('[data-testid="discover-action-create-cand-wishlist-match-actions"]').should('not.exist')
+      })
+
+    cy.get('[data-testid="discover-candidate-row-cand-new-actions"]').within(() => {
+      cy.get('[data-testid="discover-action-review-source-cand-new-actions"]').should('exist')
+      cy.get('[data-testid="discover-action-wishlist-cand-new-actions"]').should('exist')
+      cy.get('[data-testid="discover-action-track-cand-new-actions"]').should('exist')
+      cy.get('[data-testid="discover-action-create-cand-new-actions"]').should('exist')
+      cy.get('[data-testid="discover-action-ignore-cand-new-actions"]').should('exist')
+    })
+
+    cy.get('[data-testid="discover-filter-tab-archived"]').click()
+    cy.get('[data-testid="discover-candidate-row-cand-archived-actions"]').within(() => {
+      cy.get('[data-testid="discover-action-restore-cand-archived-actions"]').should('exist')
+      cy.get('[data-testid="discover-action-wishlist-cand-archived-actions"]').should('not.exist')
+      cy.get('[data-testid="discover-action-track-cand-archived-actions"]').should('not.exist')
+      cy.get('[data-testid="discover-action-create-cand-archived-actions"]').should('not.exist')
+    })
+
+    cy.get('[data-testid="discover-action-restore-cand-archived-actions"]').click()
+    cy.wait('@discoverRestoreAction')
+    cy.get('[data-testid="discover-action-status"]').should(
+      'contain',
+      'review:cand-archived-actions'
+    )
+  })
+
   it('UI-SCREEN-DISCOVER-006 promotes a candidate to Wishlist without purchased state', () => {
     let wishlistEntries: Array<Record<string, unknown>> = []
     let wishlistItems: Array<Record<string, unknown>> = []

--- a/ui.web/src/features/discover/index.tsx
+++ b/ui.web/src/features/discover/index.tsx
@@ -5,6 +5,7 @@ import {
   ExternalLink,
   Heart,
   PackagePlus,
+  RotateCcw,
   ShoppingCart,
   Telescope,
 } from 'lucide-react'
@@ -65,6 +66,8 @@ type DiscoveryActionType =
   | 'add_to_wishlist'
   | 'track_price'
   | 'create_item'
+  | 'review'
+  | 'archive'
 
 type DiscoveryTab =
   | 'all'
@@ -197,6 +200,16 @@ export function Discover() {
   const isArchived = (item: DiscoveryItem) => {
     const status = statusLabel(item).toLowerCase()
     return status.includes('ignored') || status.includes('archived')
+  }
+
+  const isPromotedStatus = (item: DiscoveryItem) => {
+    const status = statusLabel(item).toLowerCase()
+    return (
+      Boolean(item.destination_link) ||
+      status.includes('wishlisted') ||
+      status.includes('purchase_candidate') ||
+      status.includes('inventory_candidate')
+    )
   }
 
   const isWishlistMatch = (item: DiscoveryItem) =>
@@ -604,7 +617,13 @@ export function Discover() {
                 <tbody className='divide-y'>
                   {visibleItems.map((item) => {
                     const delta = dealDeltaPercent(item)
-                    const alreadyPromoted = Boolean(item.destination_link)
+                    const alreadyPromoted = isPromotedStatus(item)
+                    const archived = isArchived(item)
+                    const canPromoteWishlist =
+                      !archived && !alreadyPromoted && !isWishlistMatch(item)
+                    const canPurchaseFollowUp = !archived && !alreadyPromoted
+                    const canInventoryHandoff =
+                      !archived && !alreadyPromoted && !isWishlistMatch(item)
                     return (
                       <tr
                         key={item.candidate_id}
@@ -700,7 +719,7 @@ export function Discover() {
                           </p>
                         </td>
                         <td className='px-3 py-3 align-top'>
-                          {alreadyPromoted ? (
+                          {alreadyPromoted && item.destination_link ? (
                             <Button size='sm' variant='outline' asChild>
                               <a
                                 href={item.destination_link}
@@ -725,62 +744,90 @@ export function Discover() {
                                   </a>
                                 </Button>
                               ) : null}
-                              <Button
-                                size='icon'
-                                variant='outline'
-                                aria-label='Ignore or archive'
-                                title='Ignore or archive'
-                                data-testid={`discover-action-ignore-${item.candidate_id}`}
-                                onClick={() =>
-                                  void applyAction(item.candidate_id, 'ignore')
-                                }
-                              >
-                                <Archive className='h-4 w-4' />
-                              </Button>
-                              <Button
-                                size='icon'
-                                variant='outline'
-                                aria-label='Promote to Wishlist'
-                                title='Promote to Wishlist'
-                                data-testid={`discover-action-wishlist-${item.candidate_id}`}
-                                onClick={() =>
-                                  void applyAction(
-                                    item.candidate_id,
-                                    'add_to_wishlist'
-                                  )
-                                }
-                              >
-                                <Heart className='h-4 w-4' />
-                              </Button>
-                              <Button
-                                size='icon'
-                                variant='outline'
-                                aria-label='Purchase follow-up'
-                                title='Purchase follow-up'
-                                data-testid={`discover-action-track-${item.candidate_id}`}
-                                onClick={() =>
-                                  void applyAction(
-                                    item.candidate_id,
-                                    'track_price'
-                                  )
-                                }
-                              >
-                                <ShoppingCart className='h-4 w-4' />
-                              </Button>
-                              <Button
-                                size='icon'
-                                aria-label='Inventory handoff'
-                                title='Inventory handoff'
-                                data-testid={`discover-action-create-${item.candidate_id}`}
-                                onClick={() =>
-                                  void applyAction(
-                                    item.candidate_id,
-                                    'create_item'
-                                  )
-                                }
-                              >
-                                <PackagePlus className='h-4 w-4' />
-                              </Button>
+                              {archived ? (
+                                <Button
+                                  size='icon'
+                                  variant='outline'
+                                  aria-label='Restore for review'
+                                  title='Restore for review'
+                                  data-testid={`discover-action-restore-${item.candidate_id}`}
+                                  onClick={() =>
+                                    void applyAction(
+                                      item.candidate_id,
+                                      'review'
+                                    )
+                                  }
+                                >
+                                  <RotateCcw className='h-4 w-4' />
+                                </Button>
+                              ) : null}
+                              {!archived ? (
+                                <Button
+                                  size='icon'
+                                  variant='outline'
+                                  aria-label='Ignore or archive'
+                                  title='Ignore or archive'
+                                  data-testid={`discover-action-ignore-${item.candidate_id}`}
+                                  onClick={() =>
+                                    void applyAction(
+                                      item.candidate_id,
+                                      'ignore'
+                                    )
+                                  }
+                                >
+                                  <Archive className='h-4 w-4' />
+                                </Button>
+                              ) : null}
+                              {canPromoteWishlist ? (
+                                <Button
+                                  size='icon'
+                                  variant='outline'
+                                  aria-label='Promote to Wishlist'
+                                  title='Promote to Wishlist'
+                                  data-testid={`discover-action-wishlist-${item.candidate_id}`}
+                                  onClick={() =>
+                                    void applyAction(
+                                      item.candidate_id,
+                                      'add_to_wishlist'
+                                    )
+                                  }
+                                >
+                                  <Heart className='h-4 w-4' />
+                                </Button>
+                              ) : null}
+                              {canPurchaseFollowUp ? (
+                                <Button
+                                  size='icon'
+                                  variant='outline'
+                                  aria-label='Purchase follow-up'
+                                  title='Purchase follow-up'
+                                  data-testid={`discover-action-track-${item.candidate_id}`}
+                                  onClick={() =>
+                                    void applyAction(
+                                      item.candidate_id,
+                                      'track_price'
+                                    )
+                                  }
+                                >
+                                  <ShoppingCart className='h-4 w-4' />
+                                </Button>
+                              ) : null}
+                              {canInventoryHandoff ? (
+                                <Button
+                                  size='icon'
+                                  aria-label='Inventory handoff'
+                                  title='Inventory handoff'
+                                  data-testid={`discover-action-create-${item.candidate_id}`}
+                                  onClick={() =>
+                                    void applyAction(
+                                      item.candidate_id,
+                                      'create_item'
+                                    )
+                                  }
+                                >
+                                  <PackagePlus className='h-4 w-4' />
+                                </Button>
+                              ) : null}
                             </div>
                           )}
                         </td>


### PR DESCRIPTION
## Summary
- Adds state-aware Discoveries row actions for wishlist matches, new non-wishlist candidates, promoted rows, and ignored/archived review rows.
- Restores ignored candidates through the review action by removing the ignored marker and returning them to the default review queue.
- Updates Discoveries OpenSpec traceability plus Cypress and Go coverage for #1556 contextual actions.

## Validation
- `go test ./internal/discovery -run "Test(ListNotInCollection|ApplyAction|ReviewAction)" -count=1` PASS (`.work-agent/logs/issue-1556/go-test-discovery.log`)
- `openspec validate --all --strict --no-interactive` PASS (`.work-agent/logs/issue-1556/openspec-validate.log`)
- `cd ui.web; npx eslint src/features/discover/index.tsx cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts` PASS (`.work-agent/logs/issue-1556/eslint-discover-files-rerun.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts -Browser chrome -RequireE2EHooks` PASS, 17/17 (`.work-agent/logs/issue-1556/cypress-discover-rerun.log`; wrapper summary `.work-agent/logs/cypress/20260627-133901-spec.cy.summary.json`)

Fixes #1556