### PR TITLE
#1541 fix(users): move actions into shell header

### DIFF
--- a/openspec/specs/users/ui-screen-users/spec.md
+++ b/openspec/specs/users/ui-screen-users/spec.md
@@ -40,7 +40,7 @@ When no active profile is currently set for the authenticated session, `GET /api
 #### Scenario: Users route loads without an active profile
 - **GIVEN** an authenticated user lands on `/users` and profile runtime returns no active profile id
 - **WHEN** the screen requests `GET /api/users`
-- **THEN** API response MUST be `200` with `users[]` payload and the screen MUST render `User List` without `users_fetch_failed_404`
+- **THEN** API response MUST be `200` with `users[]` payload and the screen MUST render the `Users` shell title without `users_fetch_failed_404`
 
 ### Requirement UI-SCREEN-USERS-006: Users screen SHALL expose deterministic loading and empty states
 Users screen SHALL keep the route shell and primary controls visible while list data loads, and SHALL render a deterministic empty table state when the Cabinet users API returns no rows.
@@ -76,6 +76,17 @@ Users screen SHALL make selected-row bulk invite, status, and delete actions dur
 - **AND** status actions MUST call `PUT /api/users/{id}` for each selected user and refresh the table with the persisted status
 - **AND** delete actions MUST require explicit confirmation, call `DELETE /api/users/{id}` for each selected user, refresh the table, and remove deleted rows from the visible source-of-truth state
 
+### Requirement UI-SCREEN-USERS-009: Users screen SHALL use compact global header actions with table controls in the toolbar
+Users screen SHALL present route identity and primary user actions in the shared Cabinet shell header while keeping search, filters, and table view controls visually attached to the table toolbar.
+
+#### Scenario: Render Users actions in the shell header action lane
+- **GIVEN** an authenticated desktop user opens `/users`
+- **WHEN** the Users screen renders ready, loading, or empty table states
+- **THEN** the sticky shell header MUST expose `Users`, `Invite User`, and `Add User` in the global header action lane
+- **AND** the workspace MUST NOT render a duplicate `User List` heading block above the table
+- **AND** the table toolbar MUST retain the username search, status filter, role filter, and `View` column-control action next to the table
+- **AND** keyboard focus order MUST reach shell actions before table toolbar controls.
+
 ## Use-Case IDs and E2E Mapping
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |
@@ -88,3 +99,4 @@ Users screen SHALL make selected-row bulk invite, status, and delete actions dur
 | UC-USR-07 | Loading and empty list states | Pending users list shows loading feedback; empty API response renders table empty state without stale rows or error banner | implemented: `ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts` `UI-SCREEN-USERS-006 renders deterministic loading and empty states` |
 | UC-USR-08 | Table view options | View menu hides optional columns while preserving core row context | implemented: `ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts` `UI-SCREEN-USERS-007 hides optional table columns from the View menu` |
 | UC-USR-09 | Bulk user actions | Selected-row invite, status, and delete actions call Cabinet APIs, refresh the users list, and prove persisted table outcomes | implemented: `ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts` `UI-SCREEN-USERS-008 persists bulk invite, status, and delete actions through Cabinet API` |
+| UC-USR-10 | Compact global header actions | Users title, Invite User, and Add User render in the shell header while search/filter/View controls remain in the table toolbar and duplicate page chrome is absent | implemented: `ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts` `UI-SCREEN-USERS-009 keeps primary actions in the Users shell header and table controls in the toolbar` |

--- a/ui.web/cypress/e2e/users/ui-screen-users/fallback-profile-scope.cy.ts
+++ b/ui.web/cypress/e2e/users/ui-screen-users/fallback-profile-scope.cy.ts
@@ -12,6 +12,6 @@ describe('ui-screen-users-fallback-profile-scope', () => {
 
     cy.wait('@listUsers').its('response.statusCode').should('eq', 200)
     cy.contains('users_fetch_failed_404').should('not.exist')
-    cy.contains('h2', 'User List').should('be.visible')
+    cy.get('[data-testid="users-header-title"]').should('contain', 'Users')
   })
 })

--- a/ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts
+++ b/ui.web/cypress/e2e/users/ui-screen-users/spec.cy.ts
@@ -20,6 +20,7 @@ describe('ui-screen-users', () => {
   }
 
   beforeEach(() => {
+    cy.viewport(2048, 900)
     cy.clearCookies()
     cy.clearLocalStorage()
     cy.intercept('GET', '/api/users*').as('listUsers')
@@ -27,8 +28,44 @@ describe('ui-screen-users', () => {
     cy.wait('@listUsers')
   })
 
+  it('UI-SCREEN-USERS-009 keeps primary actions in the Users shell header and table controls in the toolbar', () => {
+    cy.get('[data-testid="users-shell-header"]').should('be.visible')
+    cy.get('[data-testid="users-header-title"]')
+      .should('be.visible')
+      .and('contain', 'Users')
+      .and('have.attr', 'title', 'Manage users and roles.')
+    cy.get('[data-testid="users-global-header-actions"]')
+      .should('be.visible')
+      .within(() => {
+        cy.get('[data-testid="users-invite-action"]')
+          .should('be.visible')
+          .and('contain', 'Invite User')
+        cy.get('[data-testid="users-add-action"]')
+          .should('be.visible')
+          .and('contain', 'Add User')
+      })
+    cy.get('[data-testid="users-header-action-separator"]').should('be.visible')
+    cy.get('[data-testid="users-workspace"]').should('be.visible')
+    cy.contains('h2', 'User List').should('not.exist')
+    cy.contains('Manage your users and their roles here.').should('not.exist')
+    cy.get('input[placeholder="Filter users..."]').should('be.visible')
+    cy.contains('button', 'Status').should('be.visible')
+    cy.contains('button', 'Role').should('be.visible')
+    cy.contains('button', 'View').should('be.visible')
+
+    cy.get('[data-testid="users-invite-action"]').then(($invite) => {
+      const inviteTop = $invite[0].getBoundingClientRect().top
+      cy.get('input[placeholder="Filter users..."]').then(($search) => {
+        const searchTop = $search[0].getBoundingClientRect().top
+        expect(inviteTop, 'header actions appear before toolbar').to.be.lessThan(
+          searchTop
+        )
+      })
+    })
+  })
+
   it('UI-SCREEN-USERS-001 reads users table from Cabinet API and supports filter/sort/pagination workflows', () => {
-    cy.contains('h2', 'User List').should('be.visible')
+    cy.get('[data-testid="users-header-title"]').should('contain', 'Users')
     cy.get('tbody tr').first().find('td').eq(1).invoke('text').then((usernameRaw) => {
       const username = usernameRaw.trim()
       const token = username.slice(0, Math.min(4, username.length))
@@ -48,7 +85,7 @@ describe('ui-screen-users', () => {
     cy.intercept('POST', '/api/users').as('createUser')
     cy.intercept('POST', '/api/users/invite').as('inviteUser')
 
-    cy.contains('button', 'Add User').click()
+    cy.get('[data-testid="users-add-action"]').click()
     cy.contains('[role="dialog"]', 'Add New User').should('be.visible')
     cy.get('input[placeholder="John"]').type('Auto')
     cy.get('input[placeholder="Doe"]').type('User')
@@ -64,7 +101,7 @@ describe('ui-screen-users', () => {
     cy.get('input[placeholder="Filter users..."]').clear().type(username)
     cy.contains(username).should('be.visible')
 
-    cy.contains('button', 'Invite User').click()
+    cy.get('[data-testid="users-invite-action"]').click()
     cy.contains('[role="dialog"]', 'Invite User').should('be.visible')
     cy.get('input[placeholder="eg: john.doe@gmail.com"]').type(inviteEmail)
     cy.get('[role="dialog"] button[role="combobox"]').first().click()
@@ -259,7 +296,7 @@ describe('ui-screen-users', () => {
     cy.wait('@retryUsersList').its('response.statusCode').should('eq', 200)
 
     cy.get('[data-testid="users-load-error"]').should('not.exist')
-    cy.contains('h2', 'User List').should('be.visible')
+    cy.get('[data-testid="users-header-title"]').should('contain', 'Users')
     cy.contains('retry_user').should('be.visible')
   })
 
@@ -273,9 +310,9 @@ describe('ui-screen-users', () => {
     }).as('emptyUsersList')
 
     cy.reload()
-    cy.contains('h2', 'User List').should('be.visible')
-    cy.contains('button', 'Invite User').should('be.visible')
-    cy.contains('button', 'Add User').should('be.visible')
+    cy.get('[data-testid="users-header-title"]').should('contain', 'Users')
+    cy.get('[data-testid="users-invite-action"]').should('be.visible')
+    cy.get('[data-testid="users-add-action"]').should('be.visible')
     cy.contains('Loading users...').should('be.visible')
 
     cy.wait('@emptyUsersList').its('response.statusCode').should('eq', 200)
@@ -288,7 +325,7 @@ describe('ui-screen-users', () => {
 
   it('UI-SCREEN-USERS-007 hides optional table columns from the View menu', () => {
     cy.viewport(1280, 900)
-    cy.contains('h2', 'User List').should('be.visible')
+    cy.get('[data-testid="users-header-title"]').should('contain', 'Users')
     cy.contains('th', 'Username').should('be.visible')
     cy.contains('th', 'Email').should('be.visible')
     cy.contains('th', 'Status').should('be.visible')

--- a/ui.web/src/features/users/components/users-primary-buttons.tsx
+++ b/ui.web/src/features/users/components/users-primary-buttons.tsx
@@ -7,13 +7,18 @@ export function UsersPrimaryButtons() {
   return (
     <div className='flex gap-2'>
       <Button
+        data-testid='users-invite-action'
         variant='outline'
         className='space-x-1'
         onClick={() => setOpen('invite')}
       >
         <span>Invite User</span> <MailPlus size={18} />
       </Button>
-      <Button className='space-x-1' onClick={() => setOpen('add')}>
+      <Button
+        data-testid='users-add-action'
+        className='space-x-1'
+        onClick={() => setOpen('add')}
+      >
         <span>Add User</span> <UserPlus size={18} />
       </Button>
     </div>

--- a/ui.web/src/features/users/index.tsx
+++ b/ui.web/src/features/users/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { getRouteApi } from '@tanstack/react-router'
 import { Users as UsersIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { LanguageSwitch } from '@/components/language-switch'
 import { Header, HeaderTitle } from '@/components/layout/header'
@@ -50,7 +51,7 @@ export function Users() {
 
   return (
     <UsersProvider>
-      <Header fixed>
+      <Header fixed data-testid='users-shell-header'>
         <Search />
         <HeaderTitle
           title='Users'
@@ -60,26 +61,30 @@ export function Users() {
           iconTestId='users-page-icon'
         />
         <div
-          className='ms-auto flex items-center space-x-4'
+          className='ms-auto flex min-w-0 items-center gap-3'
           data-header-title-avoid='true'
         >
-          <LanguageSwitch />
-          <ThemeSwitch />
-          <ConfigDrawer />
-          <ProfileDropdown />
+          <div
+            className='flex min-w-0 flex-wrap items-center justify-end gap-2'
+            data-testid='users-global-header-actions'
+          >
+            <UsersPrimaryButtons />
+          </div>
+          <Separator
+            orientation='vertical'
+            className='h-6'
+            data-testid='users-header-action-separator'
+          />
+          <div className='flex items-center gap-4'>
+            <LanguageSwitch />
+            <ThemeSwitch />
+            <ConfigDrawer />
+            <ProfileDropdown />
+          </div>
         </div>
       </Header>
 
-      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
-        <div className='flex flex-wrap items-end justify-between gap-2'>
-          <div>
-            <h2 className='text-2xl font-bold tracking-tight'>User List</h2>
-            <p className='text-muted-foreground'>
-              Manage your users and their roles here.
-            </p>
-          </div>
-          <UsersPrimaryButtons />
-        </div>
+      <Main fixed className='gap-3 sm:gap-4' data-testid='users-workspace'>
         {loadError ? (
           <div
             className='rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm'


### PR DESCRIPTION
## Summary
- Moves Users `Invite User` and `Add User` actions from the duplicate in-page heading block into the shared sticky shell header action lane.
- Removes the wasted `User List` page chrome so the table toolbar starts higher while keeping search, status/role filters, and `View` column controls attached to the table.
- Adds `UI-SCREEN-USERS-009` OpenSpec coverage plus focused Cypress assertions for the compact Users header contract.

## Validation
- `openspec validate --all --strict --no-interactive` PASS (`.work-agent/logs/issue-1541-users-header-actions/openspec-validate-rerun.log`)
- `npx eslint src/features/users/index.tsx src/features/users/components/users-primary-buttons.tsx cypress/e2e/users/ui-screen-users/spec.cy.ts cypress/e2e/users/ui-screen-users/fallback-profile-scope.cy.ts` PASS (`.work-agent/logs/issue-1541-users-header-actions/changed-file-eslint-rerun.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/users/ui-screen-users/spec.cy.ts -Browser chrome -RequireE2EHooks` PASS, 10/10 (`.work-agent/logs/issue-1541-users-header-actions/cypress-users-ui-screen-users-rerun.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/users/ui-screen-users/fallback-profile-scope.cy.ts -Browser chrome -RequireE2EHooks` PASS, 1/1 (`.work-agent/logs/issue-1541-users-header-actions/cypress-users-fallback-profile-rerun.log`)
- Push hook also passed OpenSpec and fast API docs smoke test.

Closes #1541