### PR TITLE
#1575 fix(api-docs): satisfy Redocly OpenAPI gate

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3311,8 +3311,7 @@ components:
         message: { type: string, description: Structured upstream Browse failure details preserved for diagnostics. }
         next_action: { type: string, enum: [check_provider_health_and_credentials] }
         retry_after_seconds:
-          type: integer
-          nullable: true
+          type: [integer, "null"]
           description: Upstream eBay Retry-After seconds when Browse rate limiting provides retry timing.
         query_set_id: { type: string }
     ProviderRegistryResponse:
@@ -3397,18 +3396,14 @@ components:
           enum: [ready, degraded, disabled]
         message: { type: string }
         last_error:
-          type: string
-          nullable: true
+          type: [string, "null"]
         retry_after_seconds:
-          type: integer
-          nullable: true
+          type: [integer, "null"]
         next_action:
-          type: string
-          nullable: true
-          enum: [check_provider_health_and_credentials, review_provider_status]
+          type: [string, "null"]
+          enum: [check_provider_health_and_credentials, review_provider_status, null]
         updated_at:
-          type: string
-          nullable: true
+          type: [string, "null"]
     ProviderTestResponse:
       type: object
       required: [provider, status, code, provider_test_passed, checked_at]
@@ -3434,8 +3429,7 @@ components:
             - OPENAI_BROWSER_AUTH_PROVIDER_TEST_PASSED
             - OPENAI_BROWSER_AUTH_PROOF_REQUIRED
         auth_method:
-          type: string
-          nullable: true
+          type: [string, "null"]
         credential_present:
           type: boolean
         provider_test_passed:
@@ -3444,17 +3438,13 @@ components:
           type: string
           format: date-time
         base_domain:
-          type: string
-          nullable: true
+          type: [string, "null"]
         browser_auth_state:
-          type: string
-          nullable: true
+          type: [string, "null"]
         provider_test_state:
-          type: string
-          nullable: true
+          type: [string, "null"]
         provider_test_artifact_id:
-          type: string
-          nullable: true
+          type: [string, "null"]
         message:
           type: string
         next_action:
@@ -3552,7 +3542,9 @@ components:
         last_seen: { type: string }
         status: { type: string }
         source: { type: string, enum: [ebay] }
-        stock_state: { type: string, description: Normalized eBay stock state such as in_stock, low_stock, out_of_stock, or unknown. }
+        stock_state:
+          type: string
+          description: Normalized eBay stock state such as in_stock, low_stock, out_of_stock, or unknown.
         stock_count: { type: integer }
     EbayProviderRunSnapshot:
       type: object
@@ -3819,7 +3811,9 @@ components:
         first_seen: { type: string }
         last_seen: { type: string }
         status: { type: string }
-        stock_state: { type: string, description: Normalized provider stock state such as in_stock, low_stock, out_of_stock, or unknown. }
+        stock_state:
+          type: string
+          description: Normalized provider stock state such as in_stock, low_stock, out_of_stock, or unknown.
         stock_count: { type: integer, description: Normalized provider stock quantity when available; -1 indicates unknown. }
         source: { type: string, description: Source provider id such as ebay. }
     MatchResult:

--- a/openspec/specs/general/api-docs/spec.md
+++ b/openspec/specs/general/api-docs/spec.md
@@ -26,3 +26,12 @@ Every documented OpenAPI operation SHALL include at least one explicit `4XX` res
 - **WHEN** the OpenAPI validation gate inspects operation responses
 - **THEN** every operation MUST declare at least one `4XX` response
 - **AND** shared client-error responses MUST use the canonical error response schema where applicable
+
+### Requirement API-DOCS-004: OpenAPI source SHALL pass Redocly merge-gate validation
+Cabinet's OpenAPI source SHALL use OpenAPI 3.1-compatible schema forms and YAML syntax that Redocly can parse without structural lint failures.
+
+#### Scenario: Validate OpenAPI source with Redocly
+- **GIVEN** `docs/api/openapi.yaml` is the API documentation source of truth
+- **WHEN** the Redocly lint and docs-build gates run against the document
+- **THEN** nullable response fields MUST use OpenAPI 3.1 schema representations accepted by Redocly
+- **AND** inline descriptions MUST be represented so punctuation in prose is parsed as description text rather than object properties


### PR DESCRIPTION
## Summary
- Replaces OpenAPI 3.0-style `nullable: true` response field schemas with OpenAPI 3.1 union types accepted by Redocly.
- Expands stock-state flow-style schema descriptions so comma-separated prose is parsed as description text, not extra object properties.
- Adds API-DOCS-004 to bind Redocly OpenAPI lint/build-docs merge-gate compatibility.

## Validation
- PASS: `npx --yes @redocly/cli@latest lint docs/api/openapi.yaml` (`.work-agent/logs/1575/redocly-lint-after.log`)
- PASS: `npx --yes @redocly/cli@latest build-docs docs/api/openapi.yaml -o .work-agent/logs/1575/openapi-index.html` (`.work-agent/logs/1575/redocly-build-docs.log`)
- PASS: `openspec validate --all --strict --no-interactive` (`.work-agent/logs/1575/openspec-validate.log`)
- PASS: pre-push OpenSpec hook
- PASS: pre-push fast API docs smoke test (`go test github.com/collectors-tech/cabinet/internal/app`, hook output)

Closes #1575