### PR TITLE
#1527 Seed realistic Purchases sample data

### DIFF
--- a/internal/app/onboarding_sample.go
+++ b/internal/app/onboarding_sample.go
@@ -11,6 +11,7 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
+	"strings"
 
 	"github.com/collectors-tech/cabinet/internal/collection"
 	"github.com/collectors-tech/cabinet/internal/media"
@@ -28,6 +29,8 @@ type onboardingSampleSeedResult struct {
 	CreatedInstances        int    `json:"created_instances"`
 	CreatedPhotos           int    `json:"created_photos"`
 	CreatedWishlistEntries  int    `json:"created_wishlist_entries"`
+	CreatedPurchaseOrders   int    `json:"created_purchase_orders"`
+	TotalPurchaseOrders     int    `json:"total_purchase_orders"`
 	TotalItems              int    `json:"total_items"`
 	TotalWishlistEntries    int    `json:"total_wishlist_entries"`
 	AlreadySeededForProfile bool   `json:"already_seeded_for_profile"`
@@ -53,6 +56,22 @@ type onboardingPriceSnapshot struct {
 	MedianPrice  float64
 	LatestPrice  float64
 	StockCount   int
+}
+
+type onboardingPurchaseSampleLine struct {
+	EntryID        string
+	ArrivalID      string
+	ItemPartNumber string
+	OrderID        string
+	Source         string
+	Seller         string
+	Tracking       string
+	Quantity       int
+	Amount         float64
+	Status         string
+	ExpectedOn     string
+	DeliveredOn    string
+	Notes          string
 }
 
 func generatedShowcasePriceHistory(sequence int, anchorPrice float64) []onboardingPriceSnapshot {
@@ -288,6 +307,118 @@ func seedShowcaseItemPhotos(ctx context.Context, mediaSvc *media.Service, item c
 		created++
 	}
 	return created, nil
+}
+
+func onboardingPurchaseSamples() []onboardingPurchaseSampleLine {
+	return []onboardingPurchaseSampleLine{
+		{
+			EntryID:        "sample-purchase-life-ebay-watch-001",
+			ArrivalID:      "sample-purchase-arrival-ebay-watch-001",
+			ItemPartNumber: "CAB-DEMO-001",
+			OrderID:        "EBAY-SAMPLE-1001",
+			Source:         "ebay",
+			Seller:         "seller-one",
+			Tracking:       "TRACK-SAMPLE-1001",
+			Quantity:       2,
+			Amount:         17.98,
+			Status:         "expected",
+			ExpectedOn:     "2026-02-08",
+			Notes:          "source_url=https://example.test/orders/EBAY-SAMPLE-1001 review_state=pending_reconciliation",
+		},
+		{
+			EntryID:        "sample-purchase-life-ebay-watch-002",
+			ArrivalID:      "sample-purchase-arrival-ebay-watch-002",
+			ItemPartNumber: "CAB-DEMO-003",
+			OrderID:        "EBAY-SAMPLE-1001",
+			Source:         "ebay",
+			Seller:         "seller-one",
+			Tracking:       "TRACK-SAMPLE-1001",
+			Quantity:       1,
+			Amount:         15.25,
+			Status:         "delivered",
+			ExpectedOn:     "2026-02-08",
+			DeliveredOn:    "2026-02-07",
+			Notes:          "source_url=https://example.test/orders/EBAY-SAMPLE-1001 review_state=needs_review received_state=partial",
+		},
+		{
+			EntryID:        "sample-purchase-life-manual-2001",
+			ArrivalID:      "sample-purchase-arrival-manual-2001",
+			ItemPartNumber: "CAB-DEMO-006",
+			OrderID:        "MANUAL-SAMPLE-2001",
+			Source:         "manual",
+			Seller:         "Local-collectors-fair",
+			Tracking:       "PICKUP-SAMPLE-2001",
+			Quantity:       1,
+			Amount:         19.95,
+			Status:         "delivered",
+			ExpectedOn:     "2026-02-02",
+			DeliveredOn:    "2026-02-02",
+			Notes:          "source_url=https://example.test/orders/MANUAL-SAMPLE-2001 review_state=ready received_state=complete",
+		},
+		{
+			EntryID:        "sample-purchase-life-shop-3001",
+			ArrivalID:      "sample-purchase-arrival-shop-3001",
+			ItemPartNumber: "CAB-DEMO-004",
+			OrderID:        "SHOP-SAMPLE-3001",
+			Source:         "storefront",
+			Seller:         "Toy-Shop-AU",
+			Tracking:       "AUSPOST-SAMPLE-3001",
+			Quantity:       1,
+			Amount:         24.99,
+			Status:         "expected",
+			ExpectedOn:     "2026-02-12",
+			Notes:          "source_url=https://example.test/orders/SHOP-SAMPLE-3001 review_state=tracking_in_transit received_state=unreceived",
+		},
+	}
+}
+
+func seedOnboardingPurchaseSamples(ctx context.Context, dbConn *sql.DB, profileID string, itemByPart map[string]collection.Item) (int, int, error) {
+	samples := onboardingPurchaseSamples()
+	createdOrderKeys := map[string]struct{}{}
+	for _, sample := range samples {
+		item, ok := itemByPart[sample.ItemPartNumber]
+		if !ok {
+			return 0, 0, fmt.Errorf("purchase sample item %s missing", sample.ItemPartNumber)
+		}
+
+		notes := fmt.Sprintf(
+			"seller=%s tracking=%s %s",
+			sample.Seller,
+			sample.Tracking,
+			sample.Notes,
+		)
+		result, err := dbConn.ExecContext(ctx, `
+			INSERT OR IGNORE INTO commerce_lifecycle_entries(
+				id, profile_id, item_id, state, source, external_ref, quantity, amount, currency, notes
+			) VALUES (?, ?, ?, 'purchase', ?, ?, ?, ?, 'AUD', ?)
+		`, sample.EntryID, profileID, item.ID, sample.Source, sample.OrderID, sample.Quantity, sample.Amount, notes)
+		if err != nil {
+			return 0, 0, fmt.Errorf("insert purchase sample lifecycle %s: %w", sample.EntryID, err)
+		}
+		if rows, _ := result.RowsAffected(); rows > 0 {
+			createdOrderKeys[strings.ToLower(sample.Source)+":"+sample.OrderID] = struct{}{}
+		}
+		if _, err := dbConn.ExecContext(ctx, `
+			INSERT OR IGNORE INTO expected_arrivals(
+				id, profile_id, item_id, lifecycle_entry_id, source, external_ref, quantity, amount, currency, status, expected_on, delivered_on, notes
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'AUD', ?, ?, ?, ?)
+		`, sample.ArrivalID, profileID, item.ID, sample.EntryID, sample.Source, sample.OrderID, sample.Quantity, sample.Amount, sample.Status, sample.ExpectedOn, sample.DeliveredOn, notes); err != nil {
+			return 0, 0, fmt.Errorf("insert purchase sample arrival %s: %w", sample.ArrivalID, err)
+		}
+	}
+
+	var totalOrders int
+	if err := dbConn.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM (
+			SELECT source, external_ref
+			FROM commerce_lifecycle_entries
+			WHERE profile_id = ? AND state = 'purchase'
+			GROUP BY source, external_ref
+		)
+	`, profileID).Scan(&totalOrders); err != nil {
+		return 0, 0, fmt.Errorf("count purchase sample orders: %w", err)
+	}
+	return len(createdOrderKeys), totalOrders, nil
 }
 
 func seedOnboardingSampleData(
@@ -622,6 +753,13 @@ func seedOnboardingSampleData(
 			}
 		}
 	}
+
+	createdPurchaseEntries, totalPurchaseOrders, err := seedOnboardingPurchaseSamples(ctx, dbConn, active.ID, itemByPart)
+	if err != nil {
+		return onboardingSampleSeedResult{}, err
+	}
+	result.CreatedPurchaseOrders = createdPurchaseEntries
+	result.TotalPurchaseOrders = totalPurchaseOrders
 
 	totalItems, err := collectionRepo.ListItemsByProfile(ctx, active.ID)
 	if err != nil {

--- a/internal/app/onboarding_startup_seed_test.go
+++ b/internal/app/onboarding_startup_seed_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/collectors-tech/cabinet/internal/config"
@@ -48,6 +49,7 @@ func TestStartupSampleDataBootstrapSeedsShowcaseArtifacts(t *testing.T) {
 
 	a := newTestAppWithConfig(t, cfg)
 	assertStartupSampleWishlistSeeded(t, a)
+	assertStartupSamplePurchasesSeeded(t, a)
 	assertStartupSamplePriceHistorySeeded(t, a)
 	assertStartupSamplePhotosSeeded(t, a)
 }
@@ -70,6 +72,79 @@ func assertStartupSampleWishlistSeeded(t *testing.T, a *App) {
 	}
 	if len(payload.Items) < 3 {
 		t.Fatalf("expected startup sample seed to create wishlist rows, got %+v", payload.Items)
+	}
+}
+
+func assertStartupSamplePurchasesSeeded(t *testing.T, a *App) {
+	t.Helper()
+
+	resp := doRequest(t, a, http.MethodGet, "/api/commerce/purchase-orders?status=all&page=1&page_size=10", nil, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("purchase orders status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var payload struct {
+		Total  int `json:"total"`
+		Orders []struct {
+			OrderID         string `json:"order_id"`
+			Source          string `json:"source"`
+			Seller          string `json:"seller"`
+			Tracking        string `json:"tracking"`
+			Status          string `json:"status"`
+			LineItemCount   int    `json:"line_item_count"`
+			ReceivedCount   int    `json:"received_count"`
+			UnreceivedCount int    `json:"unreceived_count"`
+			LineItems       []struct {
+				Title  string `json:"title"`
+				Status string `json:"status"`
+			} `json:"line_items"`
+		} `json:"orders"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode purchase order payload: %v", err)
+	}
+	if payload.Total < 3 {
+		t.Fatalf("expected at least three seeded sample purchase orders, got %+v", payload.Orders)
+	}
+
+	var foundMultiLinePartial, foundReceived, foundShipped bool
+	for _, order := range payload.Orders {
+		switch order.OrderID {
+		case "EBAY-SAMPLE-1001":
+			foundMultiLinePartial = order.Source == "ebay" &&
+				order.Seller == "seller-one" &&
+				order.Tracking == "TRACK-SAMPLE-1001" &&
+				order.LineItemCount == 2 &&
+				order.ReceivedCount == 1 &&
+				order.UnreceivedCount == 1 &&
+				order.Status == "active"
+		case "MANUAL-SAMPLE-2001":
+			foundReceived = order.Source == "manual" &&
+				order.ReceivedCount == 1 &&
+				order.UnreceivedCount == 0 &&
+				order.Status == "received"
+		case "SHOP-SAMPLE-3001":
+			foundShipped = order.Source == "storefront" &&
+				order.Tracking == "AUSPOST-SAMPLE-3001" &&
+				order.UnreceivedCount == 1
+		}
+	}
+	if !foundMultiLinePartial {
+		t.Fatalf("expected seeded eBay multi-line partial purchase order, got %+v", payload.Orders)
+	}
+	if !foundReceived {
+		t.Fatalf("expected seeded manual fully received purchase order, got %+v", payload.Orders)
+	}
+	if !foundShipped {
+		t.Fatalf("expected seeded shipped/unreceived purchase order, got %+v", payload.Orders)
+	}
+
+	reviews := doRequest(t, a, http.MethodGet, "/api/commerce/purchase-orders?status=reviews", nil, nil)
+	if reviews.Code != http.StatusOK || !strings.Contains(reviews.Body.String(), "EBAY-SAMPLE-1001") {
+		t.Fatalf("expected review filter to include partial sample purchase, status=%d body=%s", reviews.Code, reviews.Body.String())
+	}
+	received := doRequest(t, a, http.MethodGet, "/api/commerce/purchase-orders?status=received", nil, nil)
+	if received.Code != http.StatusOK || !strings.Contains(received.Body.String(), "MANUAL-SAMPLE-2001") {
+		t.Fatalf("expected received filter to include manual received sample, status=%d body=%s", received.Code, received.Body.String())
 	}
 }
 

--- a/openspec/specs/commerce/reconciliation/spec.md
+++ b/openspec/specs/commerce/reconciliation/spec.md
@@ -147,6 +147,13 @@ Cabinet SHALL expose active-profile purchase lifecycle and expected-arrival reco
 - **AND** the table MUST render each returned purchase order as an order-centred row with grouped line-item rows visible beneath it.
 - **AND** the table MUST expose pagination controls and an empty state that distinguishes no persisted purchases from no matching filtered purchases.
 
+#### Scenario: Sample data seeds realistic purchase orders
+- **GIVEN** the onboarding sample/demo profile seed runs for an active profile
+- **WHEN** the sample data seed completes
+- **THEN** Cabinet MUST create deterministic purchase lifecycle and expected-arrival records owned by the onboarding sample seed service.
+- **AND** `GET /api/commerce/purchase-orders` MUST expose at least three realistic grouped sample orders spanning manual, storefront, and eBay-like sources.
+- **AND** the seeded orders MUST include at least one multi-line order, one partially received order, one fully received order, one shipped/unreceived order, and one review-needed order so `/purchases` filters and detail panes have stable demo data.
+
 ### Requirement COMMERCE-RECONCILIATION-014: Purchases SHALL expose split-pane order and item detail
 Cabinet SHALL present persisted purchase orders in an Inbox-style split pane with a table/list on the left and stable order or item detail on the right.
 


### PR DESCRIPTION
## Summary
- seeds deterministic sample/demo purchase lifecycle and expected-arrival records for Purchases
- covers eBay-like multi-line partial receipt, manual fully received, and storefront shipped/unreceived orders
- binds the sample seed to COMMERCE-RECONCILIATION-013 and extends startup sample seed coverage

## Validation
- PASS: `go test ./internal/app -run TestStartupSampleDataBootstrapSeedsShowcaseArtifacts -count=1`
- PASS: `go test ./internal/app -run TestCommercePurchaseOrdersAPIListsGroupedPurchases -count=1`
- PASS: `openspec validate --all --strict --no-interactive`
- PASS during push hook: OpenSpec validation and fast API docs smoke test

## Evidence
- Local logs: `.work-agent/logs/issue-1527-20260628-0030/go-test-startup-sample-purchases.log`
- Local logs: `.work-agent/logs/issue-1527-20260628-0030/go-test-commerce-purchase-orders.log`
- Local logs: `.work-agent/logs/issue-1527-20260628-0030/openspec-validate.log`

## Deployment
- Not deployed in this slice; PR is open against `develop` and deployment is pending review/merge gates.

Closes #1527