### PR TITLE
#1553 feat(market-watch): persist scanner run records

### DIFF
--- a/internal/app/ebay_buyer_interest_import.go
+++ b/internal/app/ebay_buyer_interest_import.go
@@ -156,7 +156,7 @@ func persistEbayBuyerInterestDiscovery(ctx context.Context, conn *sql.DB, profil
 	if _, err := conn.ExecContext(ctx, `
 		INSERT INTO scanner_candidates(id, profile_id, query_set_id, listing_id, title, url, source, last_seen, status, stock_state)
 		VALUES (?, ?, ?, ?, ?, ?, 'ebay_buyer_interest', COALESCE(NULLIF(?, ''), CURRENT_TIMESTAMP), 'new', 'unknown')
-		ON CONFLICT(listing_id) DO UPDATE SET
+		ON CONFLICT(profile_id, query_set_id, source, listing_id) DO UPDATE SET
 			title = excluded.title,
 			url = excluded.url,
 			last_seen = excluded.last_seen,
@@ -165,7 +165,7 @@ func persistEbayBuyerInterestDiscovery(ctx context.Context, conn *sql.DB, profil
 	`, candidateID, profileID, querySetID, mapped.ProvenanceKey, strings.TrimSpace(mapped.Title), strings.TrimSpace(mapped.URL), strings.TrimSpace(mapped.ObservedAt)); err != nil {
 		return "", fmt.Errorf("upsert buyer interest discovery candidate: %w", err)
 	}
-	if err := conn.QueryRowContext(ctx, `SELECT id FROM scanner_candidates WHERE listing_id = ?`, mapped.ProvenanceKey).Scan(&candidateID); err != nil {
+	if err := conn.QueryRowContext(ctx, `SELECT id FROM scanner_candidates WHERE profile_id = ? AND query_set_id = ? AND source = 'ebay_buyer_interest' AND listing_id = ?`, profileID, querySetID, mapped.ProvenanceKey).Scan(&candidateID); err != nil {
 		return "", fmt.Errorf("load buyer interest discovery candidate: %w", err)
 	}
 	if _, err := conn.ExecContext(ctx, `

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -224,7 +225,7 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 			id TEXT PRIMARY KEY,
 			profile_id TEXT NOT NULL DEFAULT '',
 			query_set_id TEXT NOT NULL,
-			listing_id TEXT NOT NULL UNIQUE,
+			listing_id TEXT NOT NULL,
 			title TEXT NOT NULL,
 			price REAL NOT NULL DEFAULT 0,
 			shipping REAL NOT NULL DEFAULT 0,
@@ -243,6 +244,25 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 			FOREIGN KEY (query_set_id) REFERENCES scanner_query_sets(id) ON DELETE CASCADE
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_scanner_candidates_query_set_id ON scanner_candidates(query_set_id);`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_scanner_candidates_result_scope ON scanner_candidates(profile_id, query_set_id, source, listing_id);`,
+		`CREATE TABLE IF NOT EXISTS scanner_runs (
+			id TEXT PRIMARY KEY,
+			profile_id TEXT NOT NULL DEFAULT '',
+			query_set_id TEXT NOT NULL DEFAULT '',
+			provider TEXT NOT NULL DEFAULT '',
+			trigger_type TEXT NOT NULL DEFAULT 'manual',
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			finished_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			status TEXT NOT NULL,
+			result_count INTEGER NOT NULL DEFAULT 0,
+			new_result_count INTEGER NOT NULL DEFAULT 0,
+			error_category TEXT NOT NULL DEFAULT '',
+			error_message TEXT NOT NULL DEFAULT '',
+			retry_guidance TEXT NOT NULL DEFAULT '',
+			FOREIGN KEY (query_set_id) REFERENCES scanner_query_sets(id) ON DELETE CASCADE
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_scanner_runs_query_set_id ON scanner_runs(query_set_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_scanner_runs_profile_id ON scanner_runs(profile_id);`,
 		`CREATE TABLE IF NOT EXISTS scanner_matches (
 			candidate_id TEXT PRIMARY KEY,
 			item_id TEXT NOT NULL DEFAULT '',
@@ -758,6 +778,41 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 		conn.Close()
 		return nil, fmt.Errorf("ensure scanner_candidates profile index: %w", err)
 	}
+	if err := rebuildScannerCandidatesWithoutGlobalListingUnique(ctx, tx); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS idx_scanner_candidates_result_scope ON scanner_candidates(profile_id, query_set_id, source, listing_id);`); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure scanner_candidates scoped result index: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS scanner_runs (
+		id TEXT PRIMARY KEY,
+		profile_id TEXT NOT NULL DEFAULT '',
+		query_set_id TEXT NOT NULL DEFAULT '',
+		provider TEXT NOT NULL DEFAULT '',
+		trigger_type TEXT NOT NULL DEFAULT 'manual',
+		started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		finished_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		status TEXT NOT NULL,
+		result_count INTEGER NOT NULL DEFAULT 0,
+		new_result_count INTEGER NOT NULL DEFAULT 0,
+		error_category TEXT NOT NULL DEFAULT '',
+		error_message TEXT NOT NULL DEFAULT '',
+		retry_guidance TEXT NOT NULL DEFAULT '',
+		FOREIGN KEY (query_set_id) REFERENCES scanner_query_sets(id) ON DELETE CASCADE
+	);`); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure scanner_runs table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_scanner_runs_query_set_id ON scanner_runs(query_set_id);`); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure scanner_runs query set index: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_scanner_runs_profile_id ON scanner_runs(profile_id);`); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure scanner_runs profile index: %w", err)
+	}
 	if err := ensureColumn(ctx, tx, tx, "scanner_failures", "query_set_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("ensure scanner_failures.query_set_id: %w", err)
@@ -808,6 +863,54 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 	}
 
 	return conn, nil
+}
+
+func rebuildScannerCandidatesWithoutGlobalListingUnique(ctx context.Context, tx *sql.Tx) error {
+	var ddl string
+	if err := tx.QueryRowContext(ctx, `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'scanner_candidates'`).Scan(&ddl); err != nil {
+		return fmt.Errorf("inspect scanner_candidates schema: %w", err)
+	}
+	if !strings.Contains(strings.ToUpper(ddl), "LISTING_ID TEXT NOT NULL UNIQUE") {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE scanner_candidates RENAME TO scanner_candidates_legacy_unique_listing`); err != nil {
+		return fmt.Errorf("rename legacy scanner_candidates: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE scanner_candidates (
+		id TEXT PRIMARY KEY,
+		profile_id TEXT NOT NULL DEFAULT '',
+		query_set_id TEXT NOT NULL,
+		listing_id TEXT NOT NULL,
+		title TEXT NOT NULL,
+		price REAL NOT NULL DEFAULT 0,
+		shipping REAL NOT NULL DEFAULT 0,
+		url TEXT NOT NULL,
+		image TEXT NOT NULL DEFAULT '',
+		seller TEXT NOT NULL DEFAULT '',
+		first_seen TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		last_seen TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		status TEXT NOT NULL DEFAULT 'new',
+		source TEXT NOT NULL DEFAULT '',
+		observed_currency TEXT NOT NULL DEFAULT '',
+		reviewer_notes TEXT NOT NULL DEFAULT '',
+		source_result_url TEXT NOT NULL DEFAULT '',
+		stock_state TEXT NOT NULL DEFAULT 'unknown',
+		stock_count INTEGER NOT NULL DEFAULT -1,
+		FOREIGN KEY (query_set_id) REFERENCES scanner_query_sets(id) ON DELETE CASCADE
+	);`); err != nil {
+		return fmt.Errorf("create rebuilt scanner_candidates: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO scanner_candidates(
+		id, profile_id, query_set_id, listing_id, title, price, shipping, url, image, seller, first_seen, last_seen, status, source, observed_currency, reviewer_notes, source_result_url, stock_state, stock_count
+	)
+	SELECT id, profile_id, query_set_id, listing_id, title, price, shipping, url, image, seller, first_seen, last_seen, status, source, observed_currency, reviewer_notes, source_result_url, stock_state, stock_count
+	FROM scanner_candidates_legacy_unique_listing;`); err != nil {
+		return fmt.Errorf("copy rebuilt scanner_candidates: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE scanner_candidates_legacy_unique_listing`); err != nil {
+		return fmt.Errorf("drop legacy scanner_candidates: %w", err)
+	}
+	return nil
 }
 
 func ensureColumn(ctx context.Context, query queryRower, exec execer, table, column, definition string) error {

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -56,6 +56,77 @@ func TestOpenAndMigrateParallelFreshDBsCompletesWithinContext(t *testing.T) {
 	}
 }
 
+func TestOpenAndMigrateRebuildsLegacyScannerCandidateUniqueness(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "cabinet.db")
+	legacy, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open legacy sqlite: %v", err)
+	}
+	if _, err := legacy.Exec(`CREATE TABLE scanner_query_sets (
+		id TEXT PRIMARY KEY,
+		profile_id TEXT NOT NULL DEFAULT '',
+		name TEXT NOT NULL,
+		keywords_json TEXT NOT NULL,
+		exclusions_json TEXT NOT NULL DEFAULT '[]',
+		provider_scope_json TEXT NOT NULL DEFAULT '[]',
+		items_per_page INTEGER NOT NULL DEFAULT 24,
+		max_price REAL NOT NULL DEFAULT 0,
+		region TEXT NOT NULL DEFAULT '',
+		condition_filter TEXT NOT NULL DEFAULT '',
+		schedule_cron TEXT NOT NULL DEFAULT '',
+		enabled INTEGER NOT NULL DEFAULT 1,
+		rate_limit_rps INTEGER NOT NULL DEFAULT 2,
+		max_retry_count INTEGER NOT NULL DEFAULT 2,
+		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE TABLE scanner_candidates (
+		id TEXT PRIMARY KEY,
+		profile_id TEXT NOT NULL DEFAULT '',
+		query_set_id TEXT NOT NULL,
+		listing_id TEXT NOT NULL UNIQUE,
+		title TEXT NOT NULL,
+		price REAL NOT NULL DEFAULT 0,
+		shipping REAL NOT NULL DEFAULT 0,
+		url TEXT NOT NULL,
+		image TEXT NOT NULL DEFAULT '',
+		seller TEXT NOT NULL DEFAULT '',
+		first_seen TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		last_seen TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		status TEXT NOT NULL DEFAULT 'new',
+		source TEXT NOT NULL DEFAULT '',
+		observed_currency TEXT NOT NULL DEFAULT '',
+		reviewer_notes TEXT NOT NULL DEFAULT '',
+		source_result_url TEXT NOT NULL DEFAULT '',
+		stock_state TEXT NOT NULL DEFAULT 'unknown',
+		stock_count INTEGER NOT NULL DEFAULT -1,
+		FOREIGN KEY (query_set_id) REFERENCES scanner_query_sets(id) ON DELETE CASCADE
+	);`); err != nil {
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	conn, err := OpenAndMigrate(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	assertTableExists(t, conn, "scanner_runs")
+	if _, err := conn.Exec(`INSERT INTO scanner_query_sets(id, name, keywords_json) VALUES ('q1', 'Q1', '["afx"]'), ('q2', 'Q2', '["afx"]')`); err != nil {
+		t.Fatalf("insert query sets: %v", err)
+	}
+	if _, err := conn.Exec(`INSERT INTO scanner_candidates(id, profile_id, query_set_id, listing_id, title, url, source) VALUES
+		('c1', 'profile-a', 'q1', 'SHARED', 'Shared 1', 'https://example.test/1', 'ebay'),
+		('c2', 'profile-a', 'q2', 'SHARED', 'Shared 2', 'https://example.test/2', 'ebay')`); err != nil {
+		t.Fatalf("expected rebuilt scanner_candidates to allow per-watch shared listing ids: %v", err)
+	}
+}
+
 func assertTableExists(t *testing.T, conn *sql.DB, table string) {
 	t.Helper()
 

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -100,8 +100,10 @@ type RecognitionReview struct {
 }
 
 type RunResult struct {
+	RunID                 string `json:"run_id,omitempty"`
 	Attempts              int    `json:"attempts"`
 	Saved                 int    `json:"saved"`
+	NewResults            int    `json:"new_results"`
 	ItemsPerPageRequested int    `json:"items_per_page_requested"`
 	ItemsPerPageEffective int    `json:"items_per_page_effective"`
 	ObservedPageSize      int    `json:"observed_page_size"`
@@ -517,6 +519,10 @@ func (s *Service) RunNow(ctx context.Context, querySetID string, provider Provid
 }
 
 func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID string, provider Provider) (RunResult, error) {
+	return s.runNowForProfile(ctx, profileID, querySetID, provider, "manual")
+}
+
+func (s *Service) runNowForProfile(ctx context.Context, profileID, querySetID string, provider Provider, triggerType string) (RunResult, error) {
 	qs, err := s.GetQuerySetForProfile(ctx, strings.TrimSpace(profileID), querySetID)
 	if err != nil {
 		return RunResult{}, err
@@ -525,6 +531,8 @@ func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID st
 		return RunResult{}, fmt.Errorf("provider is required")
 	}
 	providerID := providerHealthID(provider, qs)
+	runID := uuid.NewString()
+	startedAt := time.Now().UTC()
 	requestedItemsPerPage, effectiveItemsPerPage, itemsPerPageWarning := resolveItemsPerPage(
 		qs.ProviderScope,
 		qs.ItemsPerPage,
@@ -551,6 +559,22 @@ func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID st
 				effectiveItemsPerPage,
 				itemsPerPageWarning,
 			)
+			result.RunID = runID
+			if persistErr == nil {
+				if err := s.recordRun(ctx, runRecord{
+					ID:             runID,
+					ProfileID:      strings.TrimSpace(profileID),
+					QuerySetID:     qs.ID,
+					Provider:       providerID,
+					TriggerType:    triggerType,
+					StartedAt:      startedAt,
+					Status:         "succeeded",
+					ResultCount:    result.Saved,
+					NewResultCount: result.NewResults,
+				}); err != nil {
+					return RunResult{}, err
+				}
+			}
 			return result, persistErr
 		}
 		s.recordProviderHealth(ctx, providerID, "error", lastErr.Error(), retryAfterSecondsFromError(lastErr))
@@ -563,14 +587,32 @@ func (s *Service) RunNowForProfile(ctx context.Context, profileID, querySetID st
 			time.Sleep(sleep * time.Duration(attempt))
 		}
 	}
-	return RunResult{
+	result := RunResult{
+		RunID:                 runID,
 		Attempts:              maxAttempts,
 		ItemsPerPageRequested: requestedItemsPerPage,
 		ItemsPerPageEffective: effectiveItemsPerPage,
 		ObservedPageSize:      effectiveItemsPerPage,
 		PageCount:             0,
 		ItemsPerPageWarning:   itemsPerPageWarning,
-	}, fmt.Errorf("run failed: %w", lastErr)
+	}
+	if err := s.recordRun(ctx, runRecord{
+		ID:             runID,
+		ProfileID:      strings.TrimSpace(profileID),
+		QuerySetID:     qs.ID,
+		Provider:       providerID,
+		TriggerType:    triggerType,
+		StartedAt:      startedAt,
+		Status:         "failed",
+		ResultCount:    0,
+		NewResultCount: 0,
+		ErrorCategory:  "provider_error",
+		ErrorMessage:   lastErr.Error(),
+		RetryGuidance:  retryGuidanceForProviderFailure(providerID),
+	}); err != nil {
+		return RunResult{}, err
+	}
+	return result, fmt.Errorf("run failed: %w", lastErr)
 }
 
 func providerHealthID(provider Provider, qs QuerySet) string {
@@ -601,12 +643,46 @@ func (s *Service) RunScheduledForProfile(ctx context.Context, profileID string, 
 		if !qs.Enabled || strings.TrimSpace(qs.ScheduleCron) == "" {
 			continue
 		}
-		if _, err := s.RunNowForProfile(ctx, strings.TrimSpace(profileID), qs.ID, provider); err != nil {
+		if _, err := s.runNowForProfile(ctx, strings.TrimSpace(profileID), qs.ID, provider, "scheduled"); err != nil {
 			return ran, err
 		}
 		ran++
 	}
 	return ran, nil
+}
+
+type runRecord struct {
+	ID             string
+	ProfileID      string
+	QuerySetID     string
+	Provider       string
+	TriggerType    string
+	StartedAt      time.Time
+	Status         string
+	ResultCount    int
+	NewResultCount int
+	ErrorCategory  string
+	ErrorMessage   string
+	RetryGuidance  string
+}
+
+func (s *Service) recordRun(ctx context.Context, record runRecord) error {
+	triggerType := strings.TrimSpace(record.TriggerType)
+	if triggerType == "" {
+		triggerType = "manual"
+	}
+	startedAt := record.StartedAt
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO scanner_runs(id, profile_id, query_set_id, provider, trigger_type, started_at, finished_at, status, result_count, new_result_count, error_category, error_message, retry_guidance)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)
+	`, strings.TrimSpace(record.ID), strings.TrimSpace(record.ProfileID), strings.TrimSpace(record.QuerySetID), strings.TrimSpace(record.Provider), triggerType, startedAt.Format(time.RFC3339Nano), strings.TrimSpace(record.Status), record.ResultCount, record.NewResultCount, strings.TrimSpace(record.ErrorCategory), strings.TrimSpace(record.ErrorMessage), strings.TrimSpace(record.RetryGuidance))
+	if err != nil {
+		return fmt.Errorf("record scanner run: %w", err)
+	}
+	return nil
 }
 
 func (s *Service) persistCandidates(ctx context.Context, querySetID string, items []CandidateInput, attempts int) (RunResult, error) {
@@ -646,8 +722,13 @@ func (s *Service) persistCandidatesForProfile(
 	itemsPerPageWarning string,
 ) (RunResult, error) {
 	saved := 0
+	newResults := 0
 	for _, it := range items {
-		if strings.TrimSpace(it.ListingID) == "" {
+		listingID := strings.TrimSpace(it.ListingID)
+		if listingID == "" && strings.TrimSpace(it.URL) != "" {
+			listingID = "url:" + strings.TrimSpace(it.URL)
+		}
+		if listingID == "" {
 			continue
 		}
 		source := strings.TrimSpace(it.Source)
@@ -665,8 +746,8 @@ func (s *Service) persistCandidatesForProfile(
 			SET title = ?, price = ?, shipping = ?, url = ?, image = ?, seller = ?, last_seen = CURRENT_TIMESTAMP,
 				status = CASE WHEN status IN ('ignored', 'archived', 'wishlisted', 'purchase_candidate', 'inventory_candidate') THEN status ELSE 'seen' END,
 				source = ?, stock_state = ?, stock_count = ?, observed_currency = ?
-			WHERE listing_id = ? AND (? = '' OR profile_id = ?)
-		`, it.Title, it.Price, it.Shipping, it.URL, it.Image, it.Seller, source, stockState, stockCount, observedCurrency, it.ListingID, strings.TrimSpace(profileID), strings.TrimSpace(profileID))
+			WHERE query_set_id = ? AND source = ? AND listing_id = ? AND (? = '' OR profile_id = ?)
+		`, it.Title, it.Price, it.Shipping, it.URL, it.Image, it.Seller, source, stockState, stockCount, observedCurrency, querySetID, source, listingID, strings.TrimSpace(profileID), strings.TrimSpace(profileID))
 		if err != nil {
 			return RunResult{}, fmt.Errorf("update candidate: %w", err)
 		}
@@ -677,16 +758,17 @@ func (s *Service) persistCandidatesForProfile(
 			_, err := s.db.ExecContext(ctx, `
 				INSERT INTO scanner_candidates(id, profile_id, query_set_id, listing_id, title, price, shipping, url, image, seller, first_seen, last_seen, status, source, stock_state, stock_count, observed_currency)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'new', ?, ?, ?, ?)
-			`, candidateID, strings.TrimSpace(profileID), querySetID, it.ListingID, it.Title, it.Price, it.Shipping, it.URL, it.Image, it.Seller, source, stockState, stockCount, observedCurrency)
+			`, candidateID, strings.TrimSpace(profileID), querySetID, listingID, it.Title, it.Price, it.Shipping, it.URL, it.Image, it.Seller, source, stockState, stockCount, observedCurrency)
 			if err != nil {
 				return RunResult{}, fmt.Errorf("insert candidate: %w", err)
 			}
+			newResults++
 		} else {
 			if err := s.db.QueryRowContext(ctx, `
 				SELECT id
 				FROM scanner_candidates
-				WHERE listing_id = ? AND (? = '' OR profile_id = ?)
-			`, it.ListingID, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&candidateID); err != nil {
+				WHERE query_set_id = ? AND source = ? AND listing_id = ? AND (? = '' OR profile_id = ?)
+			`, querySetID, source, listingID, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&candidateID); err != nil {
 				return RunResult{}, fmt.Errorf("load candidate id for discovery match: %w", err)
 			}
 		}
@@ -700,6 +782,7 @@ func (s *Service) persistCandidatesForProfile(
 	return RunResult{
 		Attempts:              attempts,
 		Saved:                 saved,
+		NewResults:            newResults,
 		ItemsPerPageRequested: requestedItemsPerPage,
 		ItemsPerPageEffective: effectiveItemsPerPage,
 		ObservedPageSize:      effectiveItemsPerPage,

--- a/internal/scanner/service_test.go
+++ b/internal/scanner/service_test.go
@@ -159,6 +159,128 @@ func TestRunNowPersistsObservedCurrency(t *testing.T) {
 	}
 }
 
+func TestRunNowPersistsDurableRunRecordAndDedupesResults(t *testing.T) {
+	t.Parallel()
+
+	conn, err := db.OpenAndMigrate(context.Background(), filepath.Join(t.TempDir(), "cabinet.db"))
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	svc := NewService(conn)
+	qs, err := svc.CreateQuerySetForProfile(context.Background(), "profile-a", QuerySet{
+		Name:          "Durable AFX watch",
+		Keywords:      []string{"afx"},
+		ProviderScope: []string{"bonzaslotcars"},
+		Enabled:       true,
+	})
+	if err != nil {
+		t.Fatalf("CreateQuerySetForProfile() error = %v", err)
+	}
+	provider := &testProvider{
+		providerID: "bonzaslotcars",
+		items: []CandidateInput{
+			{ListingID: "AFX-100", Title: "AFX listing", Price: 42.5, Currency: "AUD", Shipping: 9.5, URL: "https://shop.test/afx-100", Source: "bonzaslotcars"},
+			{Title: "URL-only listing", Price: 18, Currency: "AUD", URL: "https://shop.test/url-only", Source: "bonzaslotcars"},
+		},
+	}
+	if _, err := svc.RunNowForProfile(context.Background(), "profile-a", qs.ID, provider); err != nil {
+		t.Fatalf("RunNowForProfile() first pass error = %v", err)
+	}
+	provider.items[0].Price = 39.95
+	provider.items[1].Price = 17.5
+	if _, err := conn.Exec(`UPDATE scanner_candidates SET status = 'wishlisted' WHERE query_set_id = ? AND listing_id = ?`, qs.ID, "AFX-100"); err != nil {
+		t.Fatalf("seed decision state: %v", err)
+	}
+	if _, err := svc.RunNowForProfile(context.Background(), "profile-a", qs.ID, provider); err != nil {
+		t.Fatalf("RunNowForProfile() second pass error = %v", err)
+	}
+
+	var runCount, resultCount int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM scanner_runs WHERE profile_id = ? AND query_set_id = ? AND provider = ? AND status = 'succeeded'`, "profile-a", qs.ID, "bonzaslotcars").Scan(&runCount); err != nil {
+		t.Fatalf("query run records: %v", err)
+	}
+	if runCount != 2 {
+		t.Fatalf("expected two durable run records, got %d", runCount)
+	}
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM scanner_candidates WHERE profile_id = ? AND query_set_id = ?`, "profile-a", qs.ID).Scan(&resultCount); err != nil {
+		t.Fatalf("query result records: %v", err)
+	}
+	if resultCount != 2 {
+		t.Fatalf("expected listing-id and source-url dedupe to keep two results after rerun, got %d", resultCount)
+	}
+	var status string
+	var price float64
+	if err := conn.QueryRow(`SELECT status, price FROM scanner_candidates WHERE profile_id = ? AND query_set_id = ? AND listing_id = ?`, "profile-a", qs.ID, "AFX-100").Scan(&status, &price); err != nil {
+		t.Fatalf("load deduped listing result: %v", err)
+	}
+	if status != "wishlisted" {
+		t.Fatalf("expected rerun to preserve user decision status, got %q", status)
+	}
+	if price != 39.95 {
+		t.Fatalf("expected rerun to refresh listing metadata, got price=%v", price)
+	}
+	var urlOnlyListingID string
+	if err := conn.QueryRow(`SELECT listing_id FROM scanner_candidates WHERE profile_id = ? AND query_set_id = ? AND url = ?`, "profile-a", qs.ID, "https://shop.test/url-only").Scan(&urlOnlyListingID); err != nil {
+		t.Fatalf("load URL-only result: %v", err)
+	}
+	if urlOnlyListingID == "" {
+		t.Fatal("expected URL-only result to receive a durable synthetic listing key")
+	}
+}
+
+func TestRunNowDedupeIsScopedByProfileAndWatch(t *testing.T) {
+	t.Parallel()
+
+	conn, err := db.OpenAndMigrate(context.Background(), filepath.Join(t.TempDir(), "cabinet.db"))
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	svc := NewService(conn)
+	profileAWatch, err := svc.CreateQuerySetForProfile(context.Background(), "profile-a", QuerySet{Name: "A watch", Keywords: []string{"afx"}})
+	if err != nil {
+		t.Fatalf("CreateQuerySetForProfile(profile-a) error = %v", err)
+	}
+	profileASecondWatch, err := svc.CreateQuerySetForProfile(context.Background(), "profile-a", QuerySet{Name: "A second watch", Keywords: []string{"afx"}})
+	if err != nil {
+		t.Fatalf("CreateQuerySetForProfile(profile-a second) error = %v", err)
+	}
+	profileBWatch, err := svc.CreateQuerySetForProfile(context.Background(), "profile-b", QuerySet{Name: "B watch", Keywords: []string{"afx"}})
+	if err != nil {
+		t.Fatalf("CreateQuerySetForProfile(profile-b) error = %v", err)
+	}
+	provider := &testProvider{providerID: "ebay", items: []CandidateInput{{
+		ListingID: "SHARED-LISTING",
+		Title:     "Shared listing",
+		URL:       "https://market.test/shared-listing",
+		Source:    "ebay",
+	}}}
+
+	for _, run := range []struct {
+		profileID  string
+		querySetID string
+	}{
+		{"profile-a", profileAWatch.ID},
+		{"profile-a", profileASecondWatch.ID},
+		{"profile-b", profileBWatch.ID},
+	} {
+		if _, err := svc.RunNowForProfile(context.Background(), run.profileID, run.querySetID, provider); err != nil {
+			t.Fatalf("RunNowForProfile(%s, %s) error = %v", run.profileID, run.querySetID, err)
+		}
+	}
+
+	var count int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM scanner_candidates WHERE listing_id = 'SHARED-LISTING'`).Scan(&count); err != nil {
+		t.Fatalf("count shared listing candidates: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected shared provider listing to persist once per profile/watch, got %d", count)
+	}
+}
+
 func TestRunNowDoesNotReintroduceArchivedDiscoveryCandidate(t *testing.T) {
 	t.Parallel()
 

--- a/openspec/specs/integrations/ui-screen-market-watch/spec.md
+++ b/openspec/specs/integrations/ui-screen-market-watch/spec.md
@@ -176,6 +176,21 @@ Market Watch output-detail Discoveries handoff SHALL use the saved watch keyword
 - **THEN** UI MUST request Discoveries candidates using the saved watch keyword as the query
 - **AND** UI MUST show a testable Discoveries handoff status with the returned item count
 
+### Requirement UI-SCREEN-MARKET-WATCH-013: Market Watch SHALL persist run and result records within profile and watch scope
+Market Watch SHALL store saved-watch executions as durable run records and SHALL dedupe discovered results within the current profile and saved watch so private watch state, result decisions, and rerun metadata survive reloads without leaking across profiles.
+
+#### Scenario: Durable run record for saved watch execution
+- **GIVEN** a saved Market Watch query exists for the active profile
+- **WHEN** the query is run manually or by schedule
+- **THEN** the backend MUST create a durable run record with run ID, profile ID, query-set ID, provider, trigger type, started/finished timestamps, status, result count, new-result count, and actionable error/retry metadata when the run fails
+
+#### Scenario: Scoped result dedupe preserves user decisions
+- **GIVEN** a provider returns the same listing ID or source URL across repeated runs
+- **WHEN** Market Watch persists the run results
+- **THEN** results MUST dedupe within the same profile, saved watch, provider, and listing/source URL key
+- **AND** existing user decision status such as ignored, archived, wishlisted, purchase candidate, or inventory candidate MUST be preserved while refreshed result metadata is updated
+- **AND** the same provider listing may be tracked independently by another profile or another saved watch without corrupting the original watch state
+
 ## Use-Case IDs and E2E Mapping
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |
@@ -194,3 +209,4 @@ Market Watch output-detail Discoveries handoff SHALL use the saved watch keyword
 | UC-MW-13 | Inventory handoff from output detail | Output detail Inventory handoff posts selected candidate, reports success, and persists Market Watch provenance to the reloaded Inventory route | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-010 persists output-detail Inventory handoff provenance` |
 | UC-MW-14 | Route handoff bootstrap | Barcode handoff route pre-fills saved-query fields and persists the selected provider scope when created | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-011 creates saved query from route barcode handoff state` |
 | UC-MW-15 | Discoveries handoff from output detail | Output detail Discoveries handoff queries Discoveries with the saved watch keyword and reports returned item count | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-012 hands output-detail context to Discoveries with saved-watch keyword` |
+| UC-MW-16 | Persist saved-watch run/result records | Manual and scheduled runs create durable run records; results dedupe by profile/watch/provider/listing or source URL while preserving decision state | implemented: `internal/scanner/service_test.go` `TestRunNowPersistsDurableRunRecordAndDedupesResults`; `TestRunNowDedupeIsScopedByProfileAndWatch` |


### PR DESCRIPTION
## Summary
- Adds durable `scanner_runs` records for Market Watch/manual and scheduled saved-watch executions.
- Scopes result dedupe by profile, saved watch, provider/source, and listing/source URL key so shared provider listings do not corrupt another profile or watch.
- Preserves user decision statuses during reruns while refreshing result metadata.
- Adds legacy SQLite migration coverage for removing the previous global `scanner_candidates.listing_id` uniqueness.
- Updates the eBay buyer-interest discovery importer to use the new scoped scanner-candidate uniqueness key.
- Binds the backend persistence contract as `UI-SCREEN-MARKET-WATCH-013`.

## Validation
- PASS: `git diff --check origin/develop...HEAD` (`.work-agent/logs/issue-1553/merge-gate-diff-check.log`)
- PASS: `go test ./internal/scanner -count=1` (`.work-agent/logs/issue-1553/merge-gate-go-scanner-after-fix.log`)
- PASS: `go test ./internal/db -count=1` (`.work-agent/logs/issue-1553/merge-gate-go-db-after-fix.log`)
- PASS: `go test ./internal/app -run 'TestScannerQuerySetsAndProviderHealthEndpoints|TestScannerQuerySetUpdateAndDeleteEndpoints|TestScannerRunItemsPerPageSummaryAppliesSafeCap|TestScannerRetryFailuresEndpoint|TestEbayBuyerInterestImportPersistsWishlistAndDiscovery' -count=1` (`.work-agent/logs/issue-1553/merge-gate-go-app-scanner-api-after-fix.log`)
- PASS: `go test ./internal/app -run TestEbayBuyerInterestImportPersistsWishlistAndDiscovery -count=1` (`.work-agent/logs/issue-1553/fix-buyer-interest-import.log`)
- PASS: `go test ./... -count=1` (`.work-agent/logs/issue-1553/merge-gate-go-all-after-fix.log`)
- PASS: `openspec validate --all --strict --no-interactive` (`.work-agent/logs/issue-1553/merge-gate-openspec-after-fix.log`)
- PASS: pre-push OpenSpec + fast API docs smoke test

## Notes
- This PR does not claim full #1553 closure; it lands the backend run/result persistence foundation needed by the downstream Market Watch UX tickets.