### PR TITLE
#1531 fix(wishlist): inline controls and hide delivered table column

### DIFF
--- a/cypress.ps1
+++ b/cypress.ps1
@@ -203,6 +203,17 @@ function Stop-PortListener([string]$url) {
   }
 }
 
+function Reset-CypressRuntimeDataDir([string]$runtimeDataDir) {
+  if ([string]::IsNullOrWhiteSpace($runtimeDataDir)) {
+    return
+  }
+  if (-not (Test-Path $runtimeDataDir)) {
+    return
+  }
+  Write-Step "Clearing managed Cypress runtime data dir: $runtimeDataDir"
+  Remove-Item -LiteralPath $runtimeDataDir -Recurse -Force
+}
+
 function Test-IsEphemeralRuntimePath([string]$path) {
   if ([string]::IsNullOrWhiteSpace($path)) {
     return $false
@@ -576,6 +587,7 @@ try {
     }
     else {
       Write-Step "Starting Cabinet server..."
+      Reset-CypressRuntimeDataDir $e2eDataDir
       if (-not [string]::IsNullOrWhiteSpace($resolvedRuntimeExecutablePath)) {
         Write-Step "Runtime executable resolved: $resolvedRuntimeExecutablePath"
         $serverProc = Start-Process -FilePath $resolvedRuntimeExecutablePath -ArgumentList @(

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10723,13 +10723,29 @@ func detectProviderFamily(ctx context.Context, client *http.Client, providerURL,
 	return best.name, best.score, best.evidence, domain, nil
 }
 
+var (
+	buildRevision string
+	buildDate     string
+)
+
 func runtimeBuildMetadata() (string, string) {
 	version := "dev"
-	buildDate := "unknown"
+	resolvedBuildDate := "unknown"
+
+	if strings.TrimSpace(buildRevision) != "" {
+		short := strings.TrimSpace(buildRevision)
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		version = "rev-" + short
+	}
+	if strings.TrimSpace(buildDate) != "" {
+		resolvedBuildDate = strings.TrimSpace(buildDate)
+	}
 
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return version, buildDate
+		return version, resolvedBuildDate
 	}
 
 	if strings.TrimSpace(info.Main.Version) != "" && info.Main.Version != "(devel)" {
@@ -10743,7 +10759,7 @@ func runtimeBuildMetadata() (string, string) {
 			vcsRevision = strings.TrimSpace(setting.Value)
 		case "vcs.time":
 			if strings.TrimSpace(setting.Value) != "" {
-				buildDate = strings.TrimSpace(setting.Value)
+				resolvedBuildDate = strings.TrimSpace(setting.Value)
 			}
 		}
 	}
@@ -10756,7 +10772,7 @@ func runtimeBuildMetadata() (string, string) {
 		version = "rev-" + short
 	}
 
-	return version, buildDate
+	return version, resolvedBuildDate
 }
 
 func (a *App) Run(ctx context.Context) error {

--- a/internal/app/e2e_hooks_reset_test.go
+++ b/internal/app/e2e_hooks_reset_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/collectors-tech/cabinet/internal/config"
@@ -50,6 +51,33 @@ func TestE2EResetEndpointClearsWishlistPurchaseDeliveryState(t *testing.T) {
 	assertTableEmpty(t, a, "wishlist_entries")
 	assertTableEmpty(t, a, "instances")
 	assertTableEmpty(t, a, "canonical_items")
+}
+
+func TestE2EBootstrapEndpointSeedsWishlistFixtures(t *testing.T) {
+	t.Parallel()
+
+	a := newE2ETestApp(t)
+
+	reset := doRequest(t, a, http.MethodPost, "/api/test/reset", nil, nil)
+	if reset.Code != http.StatusOK {
+		t.Fatalf("reset status=%d body=%s", reset.Code, reset.Body.String())
+	}
+	setupStatus := doRequest(t, a, http.MethodPost, "/api/test/runtime/setup-status", strings.NewReader(`{"state":"present"}`), map[string]string{"Content-Type": "application/json"})
+	if setupStatus.Code != http.StatusOK {
+		t.Fatalf("setup status=%d body=%s", setupStatus.Code, setupStatus.Body.String())
+	}
+	bootstrap := doRequest(t, a, http.MethodPost, "/api/test/bootstrap", nil, nil)
+	if bootstrap.Code != http.StatusOK {
+		t.Fatalf("bootstrap status=%d body=%s", bootstrap.Code, bootstrap.Body.String())
+	}
+
+	var wishlistCount int
+	if err := a.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM wishlist_entries WHERE profile_id = 'e2e-profile-001'`).Scan(&wishlistCount); err != nil {
+		t.Fatalf("count wishlist fixtures: %v", err)
+	}
+	if wishlistCount != 3 {
+		t.Fatalf("expected 3 seeded wishlist entries, got %d", wishlistCount)
+	}
 }
 
 func seedLegacyResetState(t *testing.T, a *App) {

--- a/openspec/specs/wishlist/ui-screen-wishlist/spec.md
+++ b/openspec/specs/wishlist/ui-screen-wishlist/spec.md
@@ -124,9 +124,9 @@ Wishlist rows SHALL expose Purchased state and purchase details through dedicate
 - **AND** saving MUST persist Purchased state, price paid, quantity, condition, purchase date, and URL
 - **AND** Wishlist row actions MUST NOT include `Mark owned`
 
-### Requirement UI-SCREEN-WISHLIST-020: Wishlist rows SHALL expose Purchased, Delivered, and Category workflow fields
+### Requirement UI-SCREEN-WISHLIST-020: Wishlist rows SHALL expose Purchased and Category workflow fields without a Delivered table column
 
-Wishlist rows, cards, filters, forms, and detail surfaces SHALL use `Purchased` wording instead of `Owned`, SHALL expose explicit Delivered state, and SHALL preserve Category when wishlist items move into downstream purchase and inventory records.
+Wishlist rows, cards, filters, forms, and detail surfaces SHALL use `Purchased` wording instead of `Owned`, SHALL preserve Category when wishlist items move into downstream purchase and inventory records, and SHALL NOT expose `Delivered` as a first-class Wishlist table column. Delivery/received reconciliation belongs in Purchases/Inventory flows or an explicit detail workflow, not the default Wishlist rows table.
 
 #### Scenario: Edit purchase-to-delivery workflow fields
 
@@ -136,6 +136,13 @@ Wishlist rows, cards, filters, forms, and detail surfaces SHALL use `Purchased` 
 - **AND** the UI MUST persist Category on the canonical item record
 - **AND** Delivered MUST either set Purchased or block the save with clear validation guidance
 - **AND** downstream Purchases and Inventory views MUST be able to show the resulting records with wishlist provenance
+
+#### Scenario: Hide Delivered from default rows table
+
+- **GIVEN** wishlist route shows rows view
+- **WHEN** the default Wishlist table renders
+- **THEN** the table headers MUST include `Purchased`
+- **AND** the table headers MUST NOT include `Delivered`
 
 ### Requirement UI-SCREEN-WISHLIST-016: Wishlist rows and cards SHALL render stable date context
 Wishlist rows and cards SHALL render date context without implying that normal edits refreshed price data.

--- a/scripts/build-cabinet.ps1
+++ b/scripts/build-cabinet.ps1
@@ -28,7 +28,33 @@ if ($LASTEXITCODE -ne 0) {
 Write-CabinetSection "Runtime"
 Write-CabinetKeyValue -Key "Output" -Value $targetPath
 Write-CabinetStatus -State "run" -Message "Building Cabinet executable."
-go build -o $targetPath ./cmd/cabinet
+$buildRevision = ""
+$buildDate = ""
+try {
+  $buildRevision = (& git -C $repoRoot rev-parse HEAD 2>$null).Trim()
+  $buildDate = (& git -C $repoRoot show -s --format=%cI HEAD 2>$null).Trim()
+}
+catch {
+  $buildRevision = ""
+  $buildDate = ""
+}
+
+$ldflags = @()
+if (-not [string]::IsNullOrWhiteSpace($buildRevision)) {
+  $ldflags += "-X"
+  $ldflags += "github.com/collectors-tech/cabinet/internal/app.buildRevision=$buildRevision"
+}
+if (-not [string]::IsNullOrWhiteSpace($buildDate)) {
+  $ldflags += "-X"
+  $ldflags += "github.com/collectors-tech/cabinet/internal/app.buildDate=$buildDate"
+}
+
+if ($ldflags.Count -gt 0) {
+  Write-CabinetKeyValue -Key "Revision" -Value $buildRevision
+  go build -ldflags ($ldflags -join " ") -o $targetPath ./cmd/cabinet
+} else {
+  go build -o $targetPath ./cmd/cabinet
+}
 if ($LASTEXITCODE -ne 0) {
   throw "go build failed with exit code $LASTEXITCODE"
 }

--- a/tests/runtime_script_policy_test.go
+++ b/tests/runtime_script_policy_test.go
@@ -78,3 +78,64 @@ func TestCypressScriptFailsOnStaleRuntimeAppVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestCypressScriptResetsManagedRuntimeDataDir(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join("..", "cypress.ps1")
+	raw, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read cypress script: %v", err)
+	}
+	content := string(raw)
+	for _, snippet := range []string{
+		"Reset-CypressRuntimeDataDir",
+		"Clearing managed Cypress runtime data dir",
+		"Remove-Item -LiteralPath $runtimeDataDir -Recurse -Force",
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("expected cypress script to reset managed runtime data dir with snippet %q", snippet)
+		}
+	}
+}
+
+func TestCabinetBuildScriptInjectsExplicitRuntimeRevision(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join("..", "scripts", "build-cabinet.ps1")
+	raw, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read build script: %v", err)
+	}
+	content := string(raw)
+	for _, snippet := range []string{
+		"git -C $repoRoot rev-parse HEAD",
+		"github.com/collectors-tech/cabinet/internal/app.buildRevision",
+		"github.com/collectors-tech/cabinet/internal/app.buildDate",
+		"-ldflags",
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("expected build script to include explicit revision stamping snippet %q", snippet)
+		}
+	}
+}
+
+func TestRuntimeMetadataUsesExplicitRevisionFallback(t *testing.T) {
+	t.Parallel()
+
+	appPath := filepath.Join("..", "internal", "app", "app.go")
+	raw, err := os.ReadFile(appPath)
+	if err != nil {
+		t.Fatalf("read app runtime metadata: %v", err)
+	}
+	content := string(raw)
+	for _, snippet := range []string{
+		"buildRevision",
+		"buildDate",
+		`version = "rev-" + short`,
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("expected runtime metadata to include explicit revision fallback snippet %q", snippet)
+		}
+	}
+}

--- a/ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts
+++ b/ui.web/cypress/e2e/dashboard/ui-screen-discover/spec.cy.ts
@@ -1030,9 +1030,7 @@ describe('dashboard/ui-screen-discover', () => {
         'be.visible'
       )
       cy.get('[data-testid="wishlist-delivered-checkbox-item-promoted-1"]').should(
-        'have.attr',
-        'aria-checked',
-        'false'
+        'not.exist'
       )
       cy.contains('Promoted from Discoveries result-promotion-001').should('be.visible')
     })

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -126,12 +126,19 @@ describe("ui-screen-wishlist", () => {
   }
 
   function openWishlistRowActions(rowText: string) {
-    cy.contains("tr", rowText)
+    cy.contains("tr", rowText, { timeout: 15000 })
       .find('[data-testid="task-row-actions-trigger"]')
-      .scrollIntoView()
       .should("be.visible")
-      .trigger("click", { force: true });
-    cy.get('[data-testid="task-row-actions-menu"]').should("be.visible");
+      .then(($trigger) => {
+        const rowId = $trigger.attr("data-row-id");
+        cy.wrap($trigger).click();
+        cy.get(
+          `[data-testid="task-row-actions-menu"][data-row-id="${rowId}"]`,
+          { timeout: 15000 }
+        )
+          .filter(":visible")
+          .should("have.length", 1);
+      });
   }
 
   function collectionFilterOptionKey(value: string) {

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -130,8 +130,8 @@ describe("ui-screen-wishlist", () => {
       .find('[data-testid="task-row-actions-trigger"]')
       .scrollIntoView()
       .should("be.visible")
-      .click({ force: true });
-    cy.get('[role="menu"]').should("be.visible");
+      .trigger("click", { force: true });
+    cy.get('[data-testid="task-row-actions-menu"]').should("be.visible");
   }
 
   function collectionFilterOptionKey(value: string) {

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -131,7 +131,12 @@ describe("ui-screen-wishlist", () => {
       .should("be.visible")
       .then(($trigger) => {
         const rowId = $trigger.attr("data-row-id");
-        cy.wrap($trigger).click();
+        cy.get(
+          `[data-testid="task-row-actions-trigger"][data-row-id="${rowId}"]`,
+          { timeout: 15000 }
+        )
+          .should("be.visible")
+          .click({ force: true });
         cy.get(
           `[data-testid="task-row-actions-menu"][data-row-id="${rowId}"]`,
           { timeout: 15000 }

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -702,7 +702,7 @@ describe("ui-screen-wishlist", () => {
       ensureScrollable: false,
     });
     cy.contains("th", "Purchased").should("exist");
-    cy.contains("th", "Delivered").should("exist");
+    cy.contains("th", "Delivered").should("not.exist");
     cy.contains("th", "Category").should("exist");
     cy.contains("th", "Owned").should("not.exist");
     cy.get('[data-testid="wishlist-category-item-collector-1"]').should(
@@ -710,9 +710,7 @@ describe("ui-screen-wishlist", () => {
       "Slot Cars"
     );
     cy.get('[data-testid="wishlist-delivered-checkbox-item-collector-1"]')
-      .scrollIntoView()
-      .should("be.visible")
-      .and("have.attr", "aria-checked", "false");
+      .should("not.exist");
 
     openWishlistRowActions("AFX Mega-G+ Camaro Wildfire");
     cy.contains('[role="menuitem"]', "Edit").click({ force: true });
@@ -745,9 +743,7 @@ describe("ui-screen-wishlist", () => {
       "Race Cars"
     );
     cy.get('[data-testid="wishlist-delivered-checkbox-item-collector-1"]').should(
-      "have.attr",
-      "aria-checked",
-      "true"
+      "not.exist"
     );
 
     cy.contains("button", "Cards").click();

--- a/ui.web/src/components/data-table/toolbar.tsx
+++ b/ui.web/src/components/data-table/toolbar.tsx
@@ -44,10 +44,10 @@ export function DataTableToolbar<TData>({
 
   return (
     <div
-      className='flex flex-wrap items-center justify-between gap-2'
+      className='flex flex-wrap items-center justify-between gap-2 lg:flex-nowrap'
       data-testid={toolbarTestId}
     >
-      <div className='flex flex-1 flex-col-reverse items-start gap-y-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2'>
+      <div className='flex min-w-0 flex-1 flex-col-reverse items-start gap-y-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2'>
         {searchKey ? (
           <Input
             placeholder={searchPlaceholder}
@@ -102,7 +102,7 @@ export function DataTableToolbar<TData>({
           </Button>
         )}
       </div>
-      <div className='ms-auto flex flex-wrap items-center justify-end gap-2'>
+      <div className='ms-auto flex shrink-0 flex-nowrap items-center justify-end gap-2'>
         {actions}
         <DataTableViewOptions table={table} />
       </div>

--- a/ui.web/src/features/tasks/components/data-table-row-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-row-actions.tsx
@@ -46,6 +46,7 @@ export function DataTableRowActions<TData>({
           aria-label={`Open actions for ${task.title}`}
           onPointerDown={(event) => {
             event.stopPropagation()
+            setOpen(true)
           }}
           onClick={(event) => {
             event.stopPropagation()

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -573,34 +573,6 @@ function WishlistPurchasedCell({
   )
 }
 
-function WishlistDeliveredCell({
-  task,
-  onWishlistInlineUpdate,
-}: {
-  task: Task
-  onWishlistInlineUpdate?: (
-    task: Task,
-    changes: WishlistInlineChanges
-  ) => Promise<void>
-}) {
-  const toggleDelivered = (checked: boolean) => {
-    void onWishlistInlineUpdate?.(task, {
-      delivered: checked,
-      owned: checked ? true : task.owned,
-    })
-  }
-
-  return (
-    <Checkbox
-      checked={Boolean(task.delivered)}
-      data-testid={`wishlist-delivered-checkbox-${task.id}`}
-      aria-label={`Delivered for ${task.title}`}
-      onClick={(event) => event.stopPropagation()}
-      onCheckedChange={(checked) => toggleDelivered(Boolean(checked))}
-    />
-  )
-}
-
 function WishlistPricePaidCell({ task }: { task: Task }) {
   return (
     <span
@@ -914,23 +886,6 @@ export function getTasksColumns({
               <WishlistPurchasedCell
                 task={row.original}
                 onWishlistPurchaseRow={onWishlistPurchaseRow}
-              />
-            ),
-            enableSorting: false,
-          } satisfies ColumnDef<Task>,
-          {
-            accessorKey: 'delivered',
-            header: ({ column }) => (
-              <DataTableColumnHeader column={column} title='Delivered' />
-            ),
-            meta: {
-              className: 'w-[7rem] min-w-[7rem] ps-1',
-              tdClassName: 'ps-4 pe-3',
-            },
-            cell: ({ row }) => (
-              <WishlistDeliveredCell
-                task={row.original}
-                onWishlistInlineUpdate={onWishlistInlineUpdate}
               />
             ),
             enableSorting: false,

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -1128,8 +1128,16 @@ export function getTasksColumns({
     {
       id: 'actions',
       meta: {
-        className: isInventoryRoute ? 'w-44' : undefined,
-        tdClassName: isInventoryRoute ? 'max-w-none' : undefined,
+        className: isInventoryRoute
+          ? 'w-44'
+          : isWishlistRoute
+            ? 'sticky right-0 z-20 w-12 bg-background text-right'
+            : undefined,
+        tdClassName: isInventoryRoute
+          ? 'max-w-none'
+          : isWishlistRoute
+            ? 'max-w-none'
+            : undefined,
       },
       cell: ({ row }) => (
         <div className='flex items-center justify-end gap-1'>

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -916,6 +916,31 @@ export function TasksTable({
     purchaseUrl,
   ])
 
+  const viewModeControls = (
+    <div className='flex shrink-0 items-center gap-2'>
+      <Button
+        size='sm'
+        variant={viewMode === 'rows' ? 'default' : 'outline'}
+        onClick={() => setViewMode('rows')}
+        onKeyDown={(event) => handleViewModeKeyDown('rows', event)}
+        aria-pressed={viewMode === 'rows'}
+        aria-label='Switch to rows view'
+      >
+        Rows
+      </Button>
+      <Button
+        size='sm'
+        variant={viewMode === 'cards' ? 'default' : 'outline'}
+        onClick={() => setViewMode('cards')}
+        onKeyDown={(event) => handleViewModeKeyDown('cards', event)}
+        aria-pressed={viewMode === 'cards'}
+        aria-label='Switch to cards view'
+      >
+        Cards
+      </Button>
+    </div>
+  )
+
   return (
     <div
       data-testid={
@@ -999,123 +1024,101 @@ export function TasksTable({
               ]
         }
         customFilters={customFilters}
+        actions={!isInventoryRoute ? viewModeControls : undefined}
       />
 
-      <div className='flex flex-wrap items-center justify-between gap-2'>
-        <div className='flex flex-wrap items-center gap-2'>
-          {isInventoryRoute ? (
-            <>
-              <select
-                className='h-9 min-w-[12rem] rounded-md border bg-background px-2 text-sm'
-                data-testid='inventory-saved-view-select'
-                value={activeSavedViewID}
-                disabled={inventoryProfileSettingsLoading}
-                onChange={(event) => {
-                  const nextID = event.target.value
-                  if (nextID === '') {
-                    setActiveSavedViewID('')
-                    setSavedViewFeedback(null)
-                    setSavedViewError(null)
-                    return
-                  }
-                  const nextView = inventorySavedViews.find(
-                    (view) => view.id === nextID
-                  )
-                  if (!nextView) {
-                    return
-                  }
-                  applyInventorySavedView(nextView)
-                }}
-              >
-                <option value=''>Saved views</option>
-                {inventorySavedViews.map((view) => (
-                  <option key={view.id} value={view.id}>
-                    {view.name}
-                  </option>
-                ))}
-              </select>
-              <Button
-                type='button'
-                size='sm'
-                variant='outline'
-                data-testid='inventory-saved-view-save'
-                disabled={
-                  inventoryProfileSettingsLoading ||
-                  inventoryProfileSettingsSaving
-                }
-                onClick={() => {
-                  setSaveViewDialogOpen(true)
+      {isInventoryRoute ? (
+        <div className='flex flex-wrap items-center justify-between gap-2'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <select
+              className='h-9 min-w-[12rem] rounded-md border bg-background px-2 text-sm'
+              data-testid='inventory-saved-view-select'
+              value={activeSavedViewID}
+              disabled={inventoryProfileSettingsLoading}
+              onChange={(event) => {
+                const nextID = event.target.value
+                if (nextID === '') {
+                  setActiveSavedViewID('')
                   setSavedViewFeedback(null)
                   setSavedViewError(null)
-                  setSaveViewName((previous) =>
-                    previous !== ''
-                      ? previous
-                      : activeSavedViewID !== ''
-                        ? (inventorySavedViews.find(
-                            (view) => view.id === activeSavedViewID
-                          )?.name ?? '')
-                        : ''
-                  )
-                }}
-              >
-                Save View
-              </Button>
-              <Button
-                type='button'
-                size='sm'
-                variant='outline'
-                data-testid='inventory-saved-view-delete'
-                disabled={
-                  activeSavedViewID === '' ||
-                  inventoryProfileSettingsLoading ||
-                  inventoryProfileSettingsSaving
+                  return
                 }
-                onClick={() => void handleDeleteInventoryView()}
+                const nextView = inventorySavedViews.find(
+                  (view) => view.id === nextID
+                )
+                if (!nextView) {
+                  return
+                }
+                applyInventorySavedView(nextView)
+              }}
+            >
+              <option value=''>Saved views</option>
+              {inventorySavedViews.map((view) => (
+                <option key={view.id} value={view.id}>
+                  {view.name}
+                </option>
+              ))}
+            </select>
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              data-testid='inventory-saved-view-save'
+              disabled={
+                inventoryProfileSettingsLoading ||
+                inventoryProfileSettingsSaving
+              }
+              onClick={() => {
+                setSaveViewDialogOpen(true)
+                setSavedViewFeedback(null)
+                setSavedViewError(null)
+                setSaveViewName((previous) =>
+                  previous !== ''
+                    ? previous
+                    : activeSavedViewID !== ''
+                      ? (inventorySavedViews.find(
+                          (view) => view.id === activeSavedViewID
+                        )?.name ?? '')
+                      : ''
+                )
+              }}
+            >
+              Save View
+            </Button>
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              data-testid='inventory-saved-view-delete'
+              disabled={
+                activeSavedViewID === '' ||
+                inventoryProfileSettingsLoading ||
+                inventoryProfileSettingsSaving
+              }
+              onClick={() => void handleDeleteInventoryView()}
+            >
+              Delete View
+            </Button>
+            {savedViewFeedback ? (
+              <p
+                className='text-xs text-muted-foreground'
+                data-testid='inventory-saved-view-feedback'
               >
-                Delete View
-              </Button>
-            </>
-          ) : null}
-          {savedViewFeedback ? (
-            <p
-              className='text-xs text-muted-foreground'
-              data-testid='inventory-saved-view-feedback'
-            >
-              {savedViewFeedback}
-            </p>
-          ) : null}
-          {savedViewError ? (
-            <p
-              className='text-xs text-destructive'
-              data-testid='inventory-saved-view-error'
-            >
-              {savedViewError}
-            </p>
-          ) : null}
+                {savedViewFeedback}
+              </p>
+            ) : null}
+            {savedViewError ? (
+              <p
+                className='text-xs text-destructive'
+                data-testid='inventory-saved-view-error'
+              >
+                {savedViewError}
+              </p>
+            ) : null}
+          </div>
+          {viewModeControls}
         </div>
-        <div className='flex items-center gap-2'>
-          <Button
-            size='sm'
-            variant={viewMode === 'rows' ? 'default' : 'outline'}
-            onClick={() => setViewMode('rows')}
-            onKeyDown={(event) => handleViewModeKeyDown('rows', event)}
-            aria-pressed={viewMode === 'rows'}
-            aria-label='Switch to rows view'
-          >
-            Rows
-          </Button>
-          <Button
-            size='sm'
-            variant={viewMode === 'cards' ? 'default' : 'outline'}
-            onClick={() => setViewMode('cards')}
-            onKeyDown={(event) => handleViewModeKeyDown('cards', event)}
-            aria-pressed={viewMode === 'cards'}
-            aria-label='Switch to cards view'
-          >
-            Cards
-          </Button>
-        </div>
-      </div>
+      ) : null}
 
       {viewMode === 'rows' ? (
         <div


### PR DESCRIPTION
## Summary
- Moves Wishlist Rows/Cards controls into the shared table toolbar action group so they sit inline with the View control at desktop widths.
- Removes Delivered from the default Wishlist rows table while leaving purchase/delivery data available in cards/edit workflows.
- Keeps the sticky row-actions control reliable by opening the controlled menu on pointer down before row/table event handling can detach the trigger.
- Updates the Wishlist OpenSpec contract, focused Cypress expectations, and Cypress runtime/version guard path for the default rows table.

## Validation
- PASS `git diff --check` -> `.work-agent/logs/issue-1531-wishlist-inline-controls/diff-check-cron-20260628-0900-current-head.log`
- PASS `openspec validate --all --strict --no-interactive` -> `.work-agent/logs/issue-1531-wishlist-inline-controls/openspec-validate-cron-20260628-0900-current-head.log`
- PASS changed-file Prettier -> `.work-agent/logs/issue-1531-wishlist-inline-controls/prettier-cron-20260628-0913-pointerdown-candidate.log`
- PASS changed-file ESLint -> `.work-agent/logs/issue-1531-wishlist-inline-controls/eslint-cron-20260628-0913-pointerdown-candidate.log`
- PASS `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron` at pushed head `6a06e3eec6ad7a240a5fbd42af8db9b9492765b4`: 21/21 passing, runtime `rev-6a06e3eec6ad`, summary `.work-agent/logs/cypress/20260628-091351-spec.cy.summary.json`, log `.work-agent/logs/issue-1531-wishlist-inline-controls/cypress-committed-pointerdown-cron-20260628-0915.log`.
- PASS push hook OpenSpec validation and fast API docs smoke test during `git push origin issue-1531-wishlist-inline-controls`.

## Demo
- Not deployed from this PR because it has not merged to `develop`.
- Current demo2 baseline remains healthy on existing `develop` (`rev-286fc61673a1`, port `17882`, pid `55120`). Evidence: `.work-agent/logs/issue-1531-wishlist-inline-controls/demo2-current-runtime-check-cron-20260628-0920.log`.

## Remaining #1531 Scope
- Purchase-to-inventory and soft-delete/deleted-view acceptance slices remain out of scope for this PR and still need follow-up work after this focused toolbar/row-actions slice is reviewed/merged.