### PR TITLE
#1531 fix(wishlist): sync purchased items to inventory

### DIFF
--- a/internal/app/wishlist_purchase_delivery_api_test.go
+++ b/internal/app/wishlist_purchase_delivery_api_test.go
@@ -137,3 +137,93 @@ func TestWishlistPurchasedDeliveredSyncsCommerceAndInventoryState(t *testing.T) 
 		t.Fatalf("expected one delivered inventory instance, got %d", instanceCount)
 	}
 }
+
+func TestWishlistPurchasedSyncsInventoryInstanceWithoutDoubleCounting(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+
+	createProfile := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"Wishlist Purchased Inventory"}`), map[string]string{"Content-Type": "application/json"})
+	if createProfile.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", createProfile.Code, createProfile.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createProfile.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	setActive := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profile.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if setActive.Code != http.StatusOK {
+		t.Fatalf("set active profile status=%d body=%s", setActive.Code, setActive.Body.String())
+	}
+
+	createItem := doRequest(t, a, http.MethodPost, "/api/items", strings.NewReader(`{"part_number":"WISH-PURCHASE-INV-001","title":"Wishlist Purchased Inventory Item","brand":"AFX","category":"Slot Cars","status":"wishlist"}`), map[string]string{"Content-Type": "application/json"})
+	if createItem.Code != http.StatusCreated {
+		t.Fatalf("create item status=%d body=%s", createItem.Code, createItem.Body.String())
+	}
+	var item struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createItem.Body).Decode(&item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if item.ID == "" {
+		t.Fatal("expected item id")
+	}
+
+	if _, err := a.db.Exec(`INSERT INTO instances(id, item_id, condition, status, quantity, notes) VALUES ('existing-wishlist-purchase-instance', ?, 'loose', 'loose', 2, 'existing inventory')`, item.ID); err != nil {
+		t.Fatalf("seed existing inventory instance: %v", err)
+	}
+
+	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"purchase sync","owned":true,"price_paid":37.5,"purchase_url":"https://example.test/order","purchase_date":"2026-04-27","purchase_condition":"sealed","quantity":3,"needed_quantity":3}`), map[string]string{"Content-Type": "application/json"})
+	if createWish.Code != http.StatusCreated {
+		t.Fatalf("create purchased wishlist status=%d body=%s", createWish.Code, createWish.Body.String())
+	}
+	var createdWish struct {
+		ID        string `json:"id"`
+		Owned     bool   `json:"owned"`
+		Delivered bool   `json:"delivered"`
+	}
+	if err := json.NewDecoder(createWish.Body).Decode(&createdWish); err != nil {
+		t.Fatalf("decode purchased wishlist: %v", err)
+	}
+	if createdWish.ID == "" || !createdWish.Owned || createdWish.Delivered {
+		t.Fatalf("expected purchased but undelivered wishlist response, got %+v", createdWish)
+	}
+
+	assertWishlistPurchaseInstance := func(wantQuantity int) {
+		t.Helper()
+		var instanceCount int
+		if err := a.db.QueryRow(`SELECT COUNT(1) FROM instances WHERE item_id = ?`, item.ID).Scan(&instanceCount); err != nil {
+			t.Fatalf("count inventory instances: %v", err)
+		}
+		if instanceCount != 1 {
+			t.Fatalf("expected purchase to update existing inventory instance, got %d instances", instanceCount)
+		}
+		var quantity int
+		var status, notes string
+		if err := a.db.QueryRow(`SELECT quantity, status, notes FROM instances WHERE item_id = ?`, item.ID).Scan(&quantity, &status, &notes); err != nil {
+			t.Fatalf("load inventory instance: %v", err)
+		}
+		if quantity != wantQuantity || status != "on_track" || !strings.Contains(notes, "wishlist:"+createdWish.ID) {
+			t.Fatalf("unexpected inventory instance quantity=%d status=%q notes=%q", quantity, status, notes)
+		}
+	}
+
+	assertWishlistPurchaseInstance(5)
+
+	repeatPurchase := doRequest(t, a, http.MethodPut, "/api/wishlist", strings.NewReader(`{"id":"`+createdWish.ID+`","owned":true,"quantity":3}`), map[string]string{"Content-Type": "application/json"})
+	if repeatPurchase.Code != http.StatusOK {
+		t.Fatalf("repeat purchase status=%d body=%s", repeatPurchase.Code, repeatPurchase.Body.String())
+	}
+	assertWishlistPurchaseInstance(5)
+
+	var itemStatus, itemCategory string
+	if err := a.db.QueryRow(`SELECT status, category FROM canonical_items WHERE id = ? AND profile_id = ?`, item.ID, profile.ID).Scan(&itemStatus, &itemCategory); err != nil {
+		t.Fatalf("load purchased item: %v", err)
+	}
+	if itemStatus != "wishlist" || itemCategory != "Slot Cars" {
+		t.Fatalf("expected purchased wishlist item to stay visible in Wishlist with category preserved, got status=%q category=%q", itemStatus, itemCategory)
+	}
+}

--- a/internal/wishlist/service.go
+++ b/internal/wishlist/service.go
@@ -327,12 +327,12 @@ func (s *Service) syncPurchaseDeliveryState(ctx context.Context, profileID, entr
 	if err != nil {
 		return err
 	}
-	if !in.Delivered {
-		return nil
-	}
-	instanceID, err := s.ensureDeliveredInstance(ctx, in)
+	instanceID, err := s.ensurePurchasedInventoryInstance(ctx, in, !in.Delivered)
 	if err != nil {
 		return err
+	}
+	if !in.Delivered {
+		return nil
 	}
 	if err := s.markPurchaseArrivalDelivered(ctx, profileID, lifecycleID, instanceID, in); err != nil {
 		return err
@@ -414,36 +414,62 @@ func (s *Service) ensureExpectedArrival(ctx context.Context, profileID, lifecycl
 	return nil
 }
 
-func (s *Service) ensureDeliveredInstance(ctx context.Context, in Entry) (string, error) {
-	notes := "wishlist:" + strings.TrimSpace(in.ID)
+func (s *Service) ensurePurchasedInventoryInstance(ctx context.Context, in Entry, inTransit bool) (string, error) {
+	wishlistNote := wishlistInstanceNote(in.ID)
 	var id string
+	var quantity int
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id
+		SELECT id, quantity
 		FROM instances
-		WHERE item_id = ? AND notes = ?
+		WHERE item_id = ? AND notes LIKE ?
 		LIMIT 1
-	`, strings.TrimSpace(in.ItemID), notes).Scan(&id)
+	`, strings.TrimSpace(in.ItemID), "%"+wishlistNote+"%").Scan(&id, &quantity)
 	if err == nil {
+		nextQuantity := purchaseQuantity(in)
+		if inTransit && quantity > nextQuantity {
+			nextQuantity = quantity
+		}
 		_, updateErr := s.db.ExecContext(ctx, `
 			UPDATE instances
 			SET condition = ?, status = ?, quantity = ?, acquisition_price = ?, acquisition_date = ?, updated_at = CURRENT_TIMESTAMP
 			WHERE id = ?
-		`, deliveredCondition(in), deliveredCondition(in), purchaseQuantity(in), in.PricePaid, strings.TrimSpace(in.PurchaseDate), id)
+		`, purchaseCondition(in, inTransit), purchaseStatus(in, inTransit), nextQuantity, in.PricePaid, strings.TrimSpace(in.PurchaseDate), id)
 		if updateErr != nil {
-			return "", fmt.Errorf("update wishlist delivered instance: %w", updateErr)
+			return "", fmt.Errorf("update wishlist purchase inventory instance: %w", updateErr)
 		}
 		return id, nil
 	}
 	if err != sql.ErrNoRows {
-		return "", fmt.Errorf("load wishlist delivered instance: %w", err)
+		return "", fmt.Errorf("load wishlist purchase inventory instance: %w", err)
+	}
+	err = s.db.QueryRowContext(ctx, `
+		SELECT id, quantity
+		FROM instances
+		WHERE item_id = ?
+		ORDER BY created_at ASC
+		LIMIT 1
+	`, strings.TrimSpace(in.ItemID)).Scan(&id, &quantity)
+	if err == nil {
+		_, updateErr := s.db.ExecContext(ctx, `
+			UPDATE instances
+			SET condition = ?, status = ?, quantity = ?, acquisition_price = ?, acquisition_date = ?, notes = CASE WHEN TRIM(notes) = '' THEN ? ELSE notes || ' ' || ? END, updated_at = CURRENT_TIMESTAMP
+			WHERE id = ?
+		`, purchaseCondition(in, inTransit), purchaseStatus(in, inTransit), quantity+purchaseQuantity(in), in.PricePaid, strings.TrimSpace(in.PurchaseDate), wishlistNote, wishlistNote, id)
+		if updateErr != nil {
+			return "", fmt.Errorf("link wishlist purchase inventory instance: %w", updateErr)
+		}
+		return id, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", fmt.Errorf("load existing wishlist purchase inventory instance: %w", err)
 	}
 	id = uuid.NewString()
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO instances(id, item_id, condition, status, quantity, storage_location, acquisition_price, acquisition_date, notes)
 		VALUES (?, ?, ?, ?, ?, '', ?, ?, ?)
-	`, id, strings.TrimSpace(in.ItemID), deliveredCondition(in), deliveredCondition(in), purchaseQuantity(in), in.PricePaid, strings.TrimSpace(in.PurchaseDate), notes)
+	`, id, strings.TrimSpace(in.ItemID), purchaseCondition(in, inTransit), purchaseStatus(in, inTransit), purchaseQuantity(in), in.PricePaid, strings.TrimSpace(in.PurchaseDate), wishlistNote)
 	if err != nil {
-		return "", fmt.Errorf("create wishlist delivered instance: %w", err)
+		return "", fmt.Errorf("create wishlist purchase inventory instance: %w", err)
 	}
 	return id, nil
 }
@@ -490,4 +516,22 @@ func deliveredCondition(in Entry) string {
 	default:
 		return "custom"
 	}
+}
+
+func purchaseCondition(in Entry, inTransit bool) string {
+	if inTransit && strings.TrimSpace(in.PurchaseCondition) == "" {
+		return "on_track"
+	}
+	return deliveredCondition(in)
+}
+
+func purchaseStatus(in Entry, inTransit bool) string {
+	if inTransit {
+		return "on_track"
+	}
+	return deliveredCondition(in)
+}
+
+func wishlistInstanceNote(entryID string) string {
+	return "wishlist:" + strings.TrimSpace(entryID)
 }

--- a/openspec/specs/wishlist/wishlist-items/spec.md
+++ b/openspec/specs/wishlist/wishlist-items/spec.md
@@ -42,6 +42,10 @@ Cabinet SHALL treat wishlist `owned`/Purchased state as purchase intent evidence
 - **THEN** Cabinet MUST persist the wishlist entry as Purchased
 - **AND** Cabinet MUST create or update one `purchase` commerce lifecycle entry with `source=wishlist`, `external_ref` equal to the wishlist entry id, purchase amount, quantity, and notes
 - **AND** Cabinet MUST create or update the linked expected-arrival record for that purchase lifecycle entry
+- **AND** Cabinet MUST create or update one wishlist-linked inventory instance for the canonical item
+- **AND** if an inventory instance for that canonical item already exists, Cabinet MUST link and increment that instance instead of creating a duplicate
+- **AND** repeating the same Purchased save MUST update the existing wishlist-linked inventory instance without double-counting quantity
+- **AND** the canonical item category MUST remain unchanged for downstream Inventory visibility
 
 #### Scenario: Delivered wishlist entry creates inventory receipt evidence
 - **GIVEN** an authenticated user has an active profile with a wishlist entry for a canonical item


### PR DESCRIPTION
## Summary
- Updates Wishlist purchase sync so owned=true creates or updates one wishlist-linked inventory instance immediately.
- Links existing inventory instances with wishlist:<entry-id> and avoids double-counting repeated purchase saves.
- Extends Wishlist OpenSpec and backend coverage for the purchase-to-inventory path.

## Validation
- PASS openspec validate --all --strict --no-interactive -> .work-agent/logs/issue-1531-purchase-inventory-sync/openspec-validate-20260628-1000.log
- PASS go test ./internal/wishlist ./internal/app -run 'TestWishlistPurchased|TestWishlistCRUDAndBelowTarget' -count=1 -> .work-agent/logs/issue-1531-purchase-inventory-sync/go-test-wishlist-purchase-sync-20260628-1000.log
- PASS git diff --check -> .work-agent/logs/issue-1531-purchase-inventory-sync/diff-check-20260628-1000.log
- PASS push hook OpenSpec + fast API docs smoke test during git push -u origin issue-1531-purchase-inventory-sync

## Notes
- #1531 remains open after this PR because soft-delete/deleted-view and remaining permanent delete confirmation acceptance slices still need follow-up.
- PR #1589 is an older draft guard PR for the already-merged toolbar/Delivered-column slice and appears stale against current develop.