### PR TITLE
#1531 test(wishlist): guard soft delete flow

### DIFF
--- a/openspec/specs/wishlist/ui-screen-wishlist/spec.md
+++ b/openspec/specs/wishlist/ui-screen-wishlist/spec.md
@@ -212,6 +212,24 @@ selected wishlist entry.
 - **AND** the highlighted wishlist row MUST move to the entry currently shown in the side panel
 - **AND** existing close and save behavior MUST remain available
 
+### Requirement UI-SCREEN-WISHLIST-023: Wishlist deletion SHALL soft-delete active rows before permanent removal
+
+Wishlist default deletion SHALL hide active wishlist rows without immediately
+hard-deleting the data, expose a Deleted filter/view for review and restore,
+and require an explicit permanent-delete confirmation from the Deleted view.
+
+#### Scenario: Soft delete, review, restore, and permanently delete wishlist rows
+
+- **GIVEN** wishlist rows view is visible with an active wishlist entry
+- **WHEN** user deletes the active row from the normal Wishlist view
+- **THEN** Cabinet MUST soft-delete the wishlist entry and hide it from the default active list
+- **AND** the deleted row MUST remain available from a `Deleted` filter or view
+- **AND** the Deleted view MUST expose a restore/undo action for the soft-deleted row
+- **AND** deleting the same row from the Deleted view MUST open a permanent-delete confirmation modal
+- **AND** the modal MUST explain that the wishlist row and linked wishlist metadata/history will be removed
+- **AND** the modal MUST explain that inventory records already created from the wishlist item will not be deleted
+- **AND** Cabinet MUST NOT permanently delete the row until the user confirms the modal
+
 ## Use-Case IDs and E2E Mapping
 
 | UC ID     | Flow                             | Expected Result                                                                                                        | E2E Mapping                                                                                                                                            |

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -126,6 +126,9 @@ describe("ui-screen-wishlist", () => {
   }
 
   function openWishlistRowActions(rowText: string) {
+    cy.get('[data-testid="wishlist-table-surface"]').scrollTo("right", {
+      ensureScrollable: false,
+    });
     cy.contains("tr", rowText, { timeout: 15000 })
       .find('[data-testid="task-row-actions-trigger"]')
       .should("be.visible")
@@ -136,6 +139,7 @@ describe("ui-screen-wishlist", () => {
           { timeout: 15000 }
         )
           .should("be.visible")
+          .trigger("pointerdown", { force: true })
           .click({ force: true });
         cy.get(
           `[data-testid="task-row-actions-menu"][data-row-id="${rowId}"]`,
@@ -1067,5 +1071,120 @@ describe("ui-screen-wishlist", () => {
     cy.wait("@wishlistItems");
     cy.wait("@catalogItems");
     cy.contains("AFX Mega-G+ Camaro Updated").should("not.exist");
+  });
+
+  it("UI-SCREEN-WISHLIST-023 soft deletes, restores, and gates permanent deletion", () => {
+    let showDeleted = false;
+    let wishlistEntries = [
+      {
+        id: "wish-soft-delete-1",
+        item_id: "item-soft-delete-1",
+        priority: "medium",
+        below_target_now: false,
+        notes: "Preserve purchase history",
+        target_price: 44,
+        deleted: false,
+      },
+    ];
+    const wishlistItems = [
+      {
+        id: "item-soft-delete-1",
+        title: "Soft Delete Wishlist Guard",
+        part_number: "SD-1531",
+        status: "wishlist",
+        category: "Slot Cars",
+        priority: "medium",
+      },
+    ];
+
+    cy.intercept("GET", "/api/wishlist*", (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          items: wishlistEntries.filter((entry) =>
+            showDeleted ? entry.deleted : !entry.deleted
+          ),
+        },
+      });
+    }).as("wishlistItems");
+    cy.intercept("GET", /\/api\/items\?status=wishlist.*/, (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          items: wishlistItems.filter((item) =>
+            wishlistEntries.some(
+              (entry) =>
+                entry.item_id === item.id &&
+                (showDeleted ? entry.deleted : !entry.deleted)
+            )
+          ),
+        },
+      });
+    }).as("catalogItems");
+    cy.intercept("PUT", "/api/wishlist", (req) => {
+      expect(req.body).to.include({
+        id: "wish-soft-delete-1",
+        deleted: true,
+      });
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === "wish-soft-delete-1" ? { ...entry, deleted: true } : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("softDeleteWishlistEntry");
+    cy.intercept("POST", "/api/wishlist/wish-soft-delete-1/restore", (req) => {
+      wishlistEntries = wishlistEntries.map((entry) =>
+        entry.id === "wish-soft-delete-1" ? { ...entry, deleted: false } : entry
+      );
+      req.reply({ statusCode: 204, body: "" });
+    }).as("restoreWishlistEntry");
+    cy.intercept("DELETE", "/api/wishlist?id=wish-soft-delete-1&permanent=true", {
+      statusCode: 204,
+      body: "",
+    }).as("permanentlyDeleteWishlistEntry");
+
+    signInToWishlist({ skipStub: true, useExistingIntercepts: true });
+    cy.get('button[aria-label="Switch to rows view"]').click();
+    cy.contains("Soft Delete Wishlist Guard").should("be.visible");
+
+    openWishlistRowActions("Soft Delete Wishlist Guard");
+    cy.contains('[role="menuitem"]', /^Delete$/).click({ force: true });
+    cy.contains("Hide this wishlist entry").should("be.visible");
+    cy.contains("button", /^Hide$/).click();
+
+    cy.wait("@softDeleteWishlistEntry");
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("Soft Delete Wishlist Guard").should("not.exist");
+
+    showDeleted = true;
+    cy.contains("button", /^Deleted$/).click();
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("Soft Delete Wishlist Guard").should("be.visible");
+    cy.contains("button", /^Restore$/).click();
+    cy.wait("@restoreWishlistEntry");
+
+    showDeleted = false;
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    cy.contains("Soft Delete Wishlist Guard").should("be.visible");
+
+    showDeleted = true;
+    cy.contains("button", /^Deleted$/).click();
+    cy.wait("@wishlistItems");
+    cy.wait("@catalogItems");
+    openWishlistRowActions("Soft Delete Wishlist Guard");
+    cy.contains('[role="menuitem"]', /^Delete permanently$/).click({
+      force: true,
+    });
+    cy.contains("Permanently delete wishlist entry").should("be.visible");
+    cy.contains("wishlist row and linked wishlist metadata/history").should(
+      "be.visible"
+    );
+    cy.contains(
+      "Inventory records already created from this wishlist item will not be deleted"
+    ).should("be.visible");
+    cy.contains("button", /^Permanently delete$/).click();
+    cy.wait("@permanentlyDeleteWishlistEntry");
   });
 });


### PR DESCRIPTION
## Summary
- Adds OpenSpec coverage for #1531's remaining Wishlist deletion model: default delete should soft-hide active rows, Deleted view/filter should expose hidden rows, restore should be available, and permanent deletion should require an impact-summary confirmation.
- Adds a focused Cypress guard for soft delete, restore, and permanent-delete confirmation behavior.
- Tightens the Wishlist row-action helper by scrolling to the action column and dispatching pointerdown before click, matching the current controlled menu behavior.

## Validation
- PASS `git diff --check` -> `.work-agent/logs/issue-1531-soft-delete-guard/diff-check-20260628-1035.log`
- PASS `openspec validate --all --strict --no-interactive` -> `.work-agent/logs/issue-1531-soft-delete-guard/openspec-validate-20260628-1035.log`
- PASS `npx prettier --check cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts` -> `.work-agent/logs/issue-1531-soft-delete-guard/prettier-check-20260628-1035.log`
- BLOCKED/EXPECTED FAIL `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts -Browser electron` -> `.work-agent/logs/issue-1531-soft-delete-guard/cypress-ui-screen-wishlist-soft-delete-guard-20260628-1035.log`, summary `.work-agent/logs/cypress/20260628-103515-spec.cy.summary.json`; runtime preflight passed at `rev-bcf4712dbbf3`, result `19 passing / 3 failing`, with later failures caused by `/api/test/reset` 500 `failed_to_reset_e2e_state` before the new soft-delete guard could complete.

## Blocker
- Keep draft until the #1531 product slice implements soft-delete/deleted-view/restore/permanent-delete confirmation behavior.
- If `/api/test/reset` continues failing after the product slice, recover or harden the E2E reset path before rerunning the focused Wishlist wrapper.

## Evidence
- Machine summary: `.work-agent/logs/issue-1531-soft-delete-guard/final-summary-20260628-1039.json`