### PR TITLE
#1531 fix(wishlist): soft delete wishlist rows

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3594,7 +3594,8 @@ func New(cfg config.Config) (*App, error) {
 		profileID := strings.TrimSpace(active.ID)
 		switch r.Method {
 		case http.MethodGet:
-			items, err := wishlistSvc.ListByProfile(r.Context(), profileID)
+			showDeleted := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("deleted")), "true")
+			items, err := wishlistSvc.ListByProfileDeleted(r.Context(), profileID, showDeleted)
 			if err != nil {
 				http.Error(w, `{"error":"failed_to_list_wishlist"}`, http.StatusInternalServerError)
 				return
@@ -3687,7 +3688,13 @@ func New(cfg config.Config) (*App, error) {
 				http.Error(w, `{"error":"missing_id"}`, http.StatusBadRequest)
 				return
 			}
-			if err := wishlistSvc.DeleteForProfile(r.Context(), profileID, id); err != nil {
+			var err error
+			if strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("permanent")), "true") {
+				err = wishlistSvc.PermanentDeleteForProfile(r.Context(), profileID, id)
+			} else {
+				err = wishlistSvc.DeleteForProfile(r.Context(), profileID, id)
+			}
+			if err != nil {
 				http.Error(w, `{"error":"failed_to_delete_wishlist"}`, http.StatusBadRequest)
 				return
 			}
@@ -3695,6 +3702,27 @@ func New(cfg config.Config) (*App, error) {
 		default:
 			http.Error(w, `{"error":"method_not_allowed"}`, http.StatusMethodNotAllowed)
 		}
+	})
+	mux.HandleFunc("/api/wishlist/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		active, _ := profiles.GetActiveProfile(r.Context())
+		profileID := strings.TrimSpace(active.ID)
+		path := strings.TrimPrefix(r.URL.Path, "/api/wishlist/")
+		if !strings.HasSuffix(path, "/restore") || r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method_not_allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		id := strings.TrimSpace(strings.TrimSuffix(path, "/restore"))
+		id = strings.Trim(id, "/")
+		if id == "" {
+			http.Error(w, `{"error":"missing_id"}`, http.StatusBadRequest)
+			return
+		}
+		if err := wishlistSvc.RestoreForProfile(r.Context(), profileID, id); err != nil {
+			http.Error(w, `{"error":"failed_to_restore_wishlist"}`, http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 	})
 	mux.HandleFunc("/api/wishlist/hits", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/app/wishlist_delete_restore_api_test.go
+++ b/internal/app/wishlist_delete_restore_api_test.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestWishlistDeleteRestoreAndPermanentDeleteEndpoint(t *testing.T) {
+	t.Parallel()
+
+	a := newTestApp(t)
+	createProfile := doRequest(t, a, http.MethodPost, "/api/profiles", strings.NewReader(`{"name":"Wishlist Delete Restore"}`), map[string]string{"Content-Type": "application/json"})
+	if createProfile.Code != http.StatusCreated {
+		t.Fatalf("create profile status=%d body=%s", createProfile.Code, createProfile.Body.String())
+	}
+	var profile struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createProfile.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	setActive := doRequest(t, a, http.MethodPut, "/api/profiles/active", strings.NewReader(`{"profile_id":"`+profile.ID+`"}`), map[string]string{"Content-Type": "application/json"})
+	if setActive.Code != http.StatusOK {
+		t.Fatalf("set active profile status=%d body=%s", setActive.Code, setActive.Body.String())
+	}
+
+	createItem := doRequest(t, a, http.MethodPost, "/api/items", strings.NewReader(`{"part_number":"WISH-DEL-001","title":"Wishlist Delete Restore Item","brand":"AFX","category":"Slot Cars"}`), map[string]string{"Content-Type": "application/json"})
+	if createItem.Code != http.StatusCreated {
+		t.Fatalf("create item status=%d body=%s", createItem.Code, createItem.Body.String())
+	}
+	var item struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createItem.Body).Decode(&item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	createWish := doRequest(t, a, http.MethodPost, "/api/wishlist", strings.NewReader(`{"item_id":"`+item.ID+`","target_price":42,"priority":"high","notes":"delete restore"}`), map[string]string{"Content-Type": "application/json"})
+	if createWish.Code != http.StatusCreated {
+		t.Fatalf("create wishlist status=%d body=%s", createWish.Code, createWish.Body.String())
+	}
+	var wish struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(createWish.Body).Decode(&wish); err != nil {
+		t.Fatalf("decode wishlist: %v", err)
+	}
+
+	softDelete := doRequest(t, a, http.MethodDelete, "/api/wishlist?id="+wish.ID, nil, nil)
+	if softDelete.Code != http.StatusNoContent {
+		t.Fatalf("soft delete wishlist status=%d body=%s", softDelete.Code, softDelete.Body.String())
+	}
+	activeList := doRequest(t, a, http.MethodGet, "/api/wishlist", nil, nil)
+	if activeList.Code != http.StatusOK {
+		t.Fatalf("active wishlist status=%d body=%s", activeList.Code, activeList.Body.String())
+	}
+	assertWishlistIDs(t, activeList.Body.String(), nil)
+	deletedList := doRequest(t, a, http.MethodGet, "/api/wishlist?deleted=true", nil, nil)
+	if deletedList.Code != http.StatusOK {
+		t.Fatalf("deleted wishlist status=%d body=%s", deletedList.Code, deletedList.Body.String())
+	}
+	assertWishlistIDs(t, deletedList.Body.String(), []string{wish.ID})
+
+	restore := doRequest(t, a, http.MethodPost, "/api/wishlist/"+wish.ID+"/restore", nil, nil)
+	if restore.Code != http.StatusOK {
+		t.Fatalf("restore wishlist status=%d body=%s", restore.Code, restore.Body.String())
+	}
+	restoredList := doRequest(t, a, http.MethodGet, "/api/wishlist", nil, nil)
+	if restoredList.Code != http.StatusOK {
+		t.Fatalf("restored wishlist status=%d body=%s", restoredList.Code, restoredList.Body.String())
+	}
+	assertWishlistIDs(t, restoredList.Body.String(), []string{wish.ID})
+
+	if _, err := a.db.Exec(`INSERT INTO instances(id, item_id, condition, status, quantity, notes) VALUES ('wishlist-delete-restore-instance', ?, 'loose', 'loose', 1, 'preserve inventory')`, item.ID); err != nil {
+		t.Fatalf("seed inventory instance: %v", err)
+	}
+	if resp := doRequest(t, a, http.MethodDelete, "/api/wishlist?id="+wish.ID, nil, nil); resp.Code != http.StatusNoContent {
+		t.Fatalf("soft delete before permanent status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	permanentDelete := doRequest(t, a, http.MethodDelete, "/api/wishlist?id="+wish.ID+"&permanent=true", nil, nil)
+	if permanentDelete.Code != http.StatusNoContent {
+		t.Fatalf("permanent delete wishlist status=%d body=%s", permanentDelete.Code, permanentDelete.Body.String())
+	}
+	deletedAfterPermanent := doRequest(t, a, http.MethodGet, "/api/wishlist?deleted=true", nil, nil)
+	if deletedAfterPermanent.Code != http.StatusOK {
+		t.Fatalf("deleted wishlist after permanent status=%d body=%s", deletedAfterPermanent.Code, deletedAfterPermanent.Body.String())
+	}
+	assertWishlistIDs(t, deletedAfterPermanent.Body.String(), nil)
+	var instanceCount int
+	if err := a.db.QueryRow(`SELECT COUNT(1) FROM instances WHERE id = 'wishlist-delete-restore-instance'`).Scan(&instanceCount); err != nil {
+		t.Fatalf("count inventory instance: %v", err)
+	}
+	if instanceCount != 1 {
+		t.Fatalf("expected inventory instance to survive permanent wishlist delete, got %d", instanceCount)
+	}
+}
+
+func assertWishlistIDs(t *testing.T, body string, want []string) {
+	t.Helper()
+	var payload struct {
+		Items []struct {
+			ID string `json:"id"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(strings.NewReader(body)).Decode(&payload); err != nil {
+		t.Fatalf("decode wishlist payload: %v", err)
+	}
+	if len(payload.Items) != len(want) {
+		t.Fatalf("expected wishlist ids %v, got %+v", want, payload.Items)
+	}
+	for index, id := range want {
+		if payload.Items[index].ID != id {
+			t.Fatalf("expected wishlist id %q at index %d, got %+v", id, index, payload.Items)
+		}
+	}
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -318,6 +318,7 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 			purchase_condition TEXT NOT NULL DEFAULT '',
 			quantity INTEGER NOT NULL DEFAULT 0,
 			needed_quantity INTEGER NOT NULL DEFAULT 1,
+			deleted INTEGER NOT NULL DEFAULT 0,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			FOREIGN KEY (item_id) REFERENCES canonical_items(id) ON DELETE CASCADE
@@ -725,6 +726,10 @@ func OpenAndMigrate(ctx context.Context, path string) (*sql.DB, error) {
 	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "needed_quantity", "INTEGER NOT NULL DEFAULT 1"); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("ensure wishlist_entries.needed_quantity: %w", err)
+	}
+	if err := ensureColumn(ctx, tx, tx, "wishlist_entries", "deleted", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ensure wishlist_entries.deleted: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_wishlist_entries_profile_id ON wishlist_entries(profile_id);`); err != nil {
 		conn.Close()

--- a/internal/wishlist/service.go
+++ b/internal/wishlist/service.go
@@ -25,6 +25,7 @@ type Entry struct {
 	PurchaseCondition string  `json:"purchase_condition"`
 	Quantity          int     `json:"quantity"`
 	NeededQuantity    int     `json:"needed_quantity"`
+	Deleted           bool    `json:"deleted"`
 	CreatedAt         string  `json:"created_at"`
 	UpdatedAt         string  `json:"updated_at"`
 }
@@ -160,14 +161,68 @@ func (s *Service) ConvertToOwnedForProfile(ctx context.Context, profileID, id st
 func (s *Service) DeleteForProfile(ctx context.Context, profileID, id string) error {
 	trimmedProfileID := strings.TrimSpace(profileID)
 	itemID, _ := s.itemIDForEntry(ctx, trimmedProfileID, id)
-	_, err := s.db.ExecContext(ctx, `DELETE FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)`, id, trimmedProfileID, trimmedProfileID)
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE wishlist_entries
+		SET deleted = 1, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND (? = '' OR profile_id = ?)
+	`, strings.TrimSpace(id), trimmedProfileID, trimmedProfileID)
 	if err != nil {
 		return err
+	}
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		return fmt.Errorf("wishlist entry not found")
 	}
 	if strings.TrimSpace(itemID) == "" {
 		return nil
 	}
 	return s.syncItemWishlistState(ctx, trimmedProfileID, itemID, "active", "")
+}
+
+func (s *Service) PermanentDeleteForProfile(ctx context.Context, profileID, id string) error {
+	trimmedProfileID := strings.TrimSpace(profileID)
+	itemID, _ := s.itemIDForEntry(ctx, trimmedProfileID, id)
+	result, err := s.db.ExecContext(ctx, `DELETE FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)`, strings.TrimSpace(id), trimmedProfileID, trimmedProfileID)
+	if err != nil {
+		return err
+	}
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		return fmt.Errorf("wishlist entry not found")
+	}
+	if strings.TrimSpace(itemID) == "" {
+		return nil
+	}
+	return s.syncItemWishlistState(ctx, trimmedProfileID, itemID, "active", "")
+}
+
+func (s *Service) RestoreForProfile(ctx context.Context, profileID, id string) error {
+	trimmedProfileID := strings.TrimSpace(profileID)
+	itemID, err := s.itemIDForEntry(ctx, trimmedProfileID, id)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE wishlist_entries
+		SET deleted = 0, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND (? = '' OR profile_id = ?)
+	`, strings.TrimSpace(id), trimmedProfileID, trimmedProfileID)
+	if err != nil {
+		return err
+	}
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		return fmt.Errorf("wishlist entry not found")
+	}
+	var priority string
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT priority
+		FROM wishlist_entries
+		WHERE id = ? AND (? = '' OR profile_id = ?)
+	`, strings.TrimSpace(id), trimmedProfileID, trimmedProfileID).Scan(&priority); err != nil {
+		return err
+	}
+	return s.syncItemWishlistState(ctx, trimmedProfileID, itemID, "wishlist", priority)
 }
 
 func (s *Service) GetByID(ctx context.Context, id string) (Entry, error) {
@@ -180,10 +235,11 @@ func (s *Service) GetByIDForProfile(ctx context.Context, profileID, id string) (
 	var belowTargetNow int
 	var owned int
 	var delivered int
+	var deleted int
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, delivered, price_paid, purchase_url, purchase_date, purchase_condition, quantity, needed_quantity, created_at, updated_at
+		SELECT id, item_id, target_price, priority, notes, highlight_hit, below_target_now, owned, delivered, price_paid, purchase_url, purchase_date, purchase_condition, quantity, needed_quantity, deleted, created_at, updated_at
 		FROM wishlist_entries WHERE id = ? AND (? = '' OR profile_id = ?)
-	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &belowTargetNow, &owned, &delivered, &e.PricePaid, &e.PurchaseURL, &e.PurchaseDate, &e.PurchaseCondition, &e.Quantity, &e.NeededQuantity, &e.CreatedAt, &e.UpdatedAt)
+	`, id, strings.TrimSpace(profileID), strings.TrimSpace(profileID)).Scan(&e.ID, &e.ItemID, &e.TargetPrice, &e.Priority, &e.Notes, &highlight, &belowTargetNow, &owned, &delivered, &e.PricePaid, &e.PurchaseURL, &e.PurchaseDate, &e.PurchaseCondition, &e.Quantity, &e.NeededQuantity, &deleted, &e.CreatedAt, &e.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return Entry{}, fmt.Errorf("wishlist entry not found")
@@ -194,6 +250,7 @@ func (s *Service) GetByIDForProfile(ctx context.Context, profileID, id string) (
 	e.BelowTargetNow = belowTargetNow == 1 || s.isBelowTarget(ctx, e.ItemID, e.TargetPrice)
 	e.Owned = owned == 1
 	e.Delivered = delivered == 1
+	e.Deleted = deleted == 1
 	return e, nil
 }
 
@@ -202,7 +259,20 @@ func (s *Service) List(ctx context.Context) ([]Entry, error) {
 }
 
 func (s *Service) ListByProfile(ctx context.Context, profileID string) ([]Entry, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id FROM wishlist_entries WHERE (? = '' OR profile_id = ?) ORDER BY created_at ASC`, strings.TrimSpace(profileID), strings.TrimSpace(profileID))
+	return s.ListByProfileDeleted(ctx, profileID, false)
+}
+
+func (s *Service) ListByProfileDeleted(ctx context.Context, profileID string, deleted bool) ([]Entry, error) {
+	deletedValue := 0
+	if deleted {
+		deletedValue = 1
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id
+		FROM wishlist_entries
+		WHERE (? = '' OR profile_id = ?) AND deleted = ?
+		ORDER BY created_at ASC
+	`, strings.TrimSpace(profileID), strings.TrimSpace(profileID), deletedValue)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wishlist/service_test.go
+++ b/internal/wishlist/service_test.go
@@ -73,4 +73,57 @@ func TestWishlistCRUDAndBelowTarget(t *testing.T) {
 	if len(empty) != 0 {
 		t.Fatalf("expected empty wishlist, got %d", len(empty))
 	}
+	deleted, err := svc.ListByProfileDeleted(context.Background(), "", true)
+	if err != nil {
+		t.Fatalf("ListByProfileDeleted() after delete error = %v", err)
+	}
+	if len(deleted) != 1 || deleted[0].ID != created.ID || !deleted[0].Deleted {
+		t.Fatalf("expected soft-deleted wishlist row, got %+v", deleted)
+	}
+	var itemStatus string
+	if err := conn.QueryRow(`SELECT status FROM canonical_items WHERE id = 'i1'`).Scan(&itemStatus); err != nil {
+		t.Fatalf("load item status after soft delete: %v", err)
+	}
+	if itemStatus != "active" {
+		t.Fatalf("expected soft delete to restore item status active, got %q", itemStatus)
+	}
+	if err := svc.RestoreForProfile(context.Background(), "", created.ID); err != nil {
+		t.Fatalf("RestoreForProfile() error = %v", err)
+	}
+	restored, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() after restore error = %v", err)
+	}
+	if len(restored) != 1 || restored[0].ID != created.ID || restored[0].Deleted {
+		t.Fatalf("expected restored wishlist row, got %+v", restored)
+	}
+	if err := conn.QueryRow(`SELECT status FROM canonical_items WHERE id = 'i1'`).Scan(&itemStatus); err != nil {
+		t.Fatalf("load item status after restore: %v", err)
+	}
+	if itemStatus != "wishlist" {
+		t.Fatalf("expected restore to set item status wishlist, got %q", itemStatus)
+	}
+	if _, err := conn.Exec(`INSERT INTO instances(id, item_id, condition, status, quantity, notes) VALUES ('inst1','i1','loose','loose',1,'keep inventory')`); err != nil {
+		t.Fatalf("seed inventory instance: %v", err)
+	}
+	if err := svc.Delete(context.Background(), created.ID); err != nil {
+		t.Fatalf("Delete() before permanent delete error = %v", err)
+	}
+	if err := svc.PermanentDeleteForProfile(context.Background(), "", created.ID); err != nil {
+		t.Fatalf("PermanentDeleteForProfile() error = %v", err)
+	}
+	deletedAfterPermanent, err := svc.ListByProfileDeleted(context.Background(), "", true)
+	if err != nil {
+		t.Fatalf("ListByProfileDeleted() after permanent delete error = %v", err)
+	}
+	if len(deletedAfterPermanent) != 0 {
+		t.Fatalf("expected permanent delete to remove deleted row, got %+v", deletedAfterPermanent)
+	}
+	var instanceCount int
+	if err := conn.QueryRow(`SELECT COUNT(1) FROM instances WHERE item_id = 'i1'`).Scan(&instanceCount); err != nil {
+		t.Fatalf("count inventory instance after permanent delete: %v", err)
+	}
+	if instanceCount != 1 {
+		t.Fatalf("expected permanent wishlist delete to preserve inventory instances, got %d", instanceCount)
+	}
 }

--- a/openspec/specs/wishlist/ui-screen-wishlist/spec.md
+++ b/openspec/specs/wishlist/ui-screen-wishlist/spec.md
@@ -212,6 +212,24 @@ selected wishlist entry.
 - **AND** the highlighted wishlist row MUST move to the entry currently shown in the side panel
 - **AND** existing close and save behavior MUST remain available
 
+### Requirement UI-SCREEN-WISHLIST-023: Wishlist deletion SHALL soft-delete active rows before permanent removal
+
+Wishlist default deletion SHALL hide active wishlist rows without immediately
+hard-deleting the data, expose a Deleted filter/view for review and restore,
+and require an explicit permanent-delete confirmation from the Deleted view.
+
+#### Scenario: Soft delete, review, restore, and permanently delete wishlist rows
+
+- **GIVEN** wishlist rows view is visible with an active wishlist entry
+- **WHEN** user deletes the active row from the normal Wishlist view
+- **THEN** Cabinet MUST soft-delete the wishlist entry and hide it from the default active list
+- **AND** the deleted row MUST remain available from a `Deleted` filter or view
+- **AND** the Deleted view MUST expose a restore/undo action for the soft-deleted row
+- **AND** deleting the same row from the Deleted view MUST open a permanent-delete confirmation modal
+- **AND** the modal MUST explain that the wishlist row and linked wishlist metadata/history will be removed
+- **AND** the modal MUST explain that inventory records already created from the wishlist item will not be deleted
+- **AND** Cabinet MUST NOT permanently delete the row until the user confirms the modal
+
 ## Use-Case IDs and E2E Mapping
 
 | UC ID     | Flow                             | Expected Result                                                                                                        | E2E Mapping                                                                                                                                            |

--- a/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
+++ b/ui.web/cypress/e2e/wishlist/ui-screen-wishlist/spec.cy.ts
@@ -23,6 +23,10 @@ describe("ui-screen-wishlist", () => {
         ],
       },
     }).as("wishlistItems");
+    cy.intercept("GET", "/api/wishlist?deleted=true", {
+      statusCode: 200,
+      body: { items: [] },
+    }).as("deletedWishlistItems");
     cy.intercept("GET", "/api/items?status=wishlist", {
       statusCode: 200,
       body: {
@@ -46,6 +50,10 @@ describe("ui-screen-wishlist", () => {
         ],
       },
     }).as("catalogItems");
+    cy.intercept("GET", "/api/items?status=active", {
+      statusCode: 200,
+      body: { items: [] },
+    }).as("activeItems");
     cy.intercept("GET", "/api/pricing/stats?item_id=item-collector-1", {
       statusCode: 200,
       body: { min: 35, median: 40, latest: 42.5 },
@@ -106,7 +114,11 @@ describe("ui-screen-wishlist", () => {
       stubWishlistData();
     } else if (!options.useExistingIntercepts) {
       cy.intercept("GET", "/api/wishlist").as("wishlistItems");
+      cy.intercept("GET", "/api/wishlist?deleted=true").as(
+        "deletedWishlistItems"
+      );
       cy.intercept("GET", "/api/items?status=wishlist").as("catalogItems");
+      cy.intercept("GET", "/api/items?status=active").as("activeItems");
     }
     cy.intercept("GET", "/api/profiles/*/settings").as("profileSettings");
     cy.e2eReset();
@@ -681,9 +693,17 @@ describe("ui-screen-wishlist", () => {
     cy.intercept("GET", "/api/wishlist", (req) => {
       req.reply({ statusCode: 200, body: { items: wishlistEntries } });
     }).as("wishlistItems");
+    cy.intercept("GET", "/api/wishlist?deleted=true", {
+      statusCode: 200,
+      body: { items: [] },
+    }).as("deletedWishlistItems");
     cy.intercept("GET", "/api/items?status=wishlist", (req) => {
       req.reply({ statusCode: 200, body: { items: wishlistItems } });
     }).as("catalogItems");
+    cy.intercept("GET", "/api/items?status=active", {
+      statusCode: 200,
+      body: { items: [] },
+    }).as("activeItems");
     cy.intercept("PUT", "/api/items/item-collector-1", (req) => {
       expect(req.body.category).to.eq("Race Cars");
       wishlistItems = wishlistItems.map((item) =>
@@ -1060,8 +1080,8 @@ describe("ui-screen-wishlist", () => {
           .should("be.visible")
           .click({ force: true });
       });
-    cy.contains("Delete this wishlist entry").should("be.visible");
-    cy.contains("button", "Delete").click();
+    cy.contains("Hide this wishlist entry").should("be.visible");
+    cy.contains("button", "Hide").click();
 
     cy.wait("@deleteWishlistEntry");
     cy.wait("@wishlistItems");

--- a/ui.web/src/features/tasks/components/data-table-row-actions.tsx
+++ b/ui.web/src/features/tasks/components/data-table-row-actions.tsx
@@ -98,7 +98,7 @@ export function DataTableRowActions<TData>({
             handleDeleteRow()
           }}
         >
-          Delete
+          {isWishlistRoute && task.deleted ? 'Delete permanently' : 'Delete'}
           <DropdownMenuShortcut>
             <Trash2 size={16} />
           </DropdownMenuShortcut>

--- a/ui.web/src/features/tasks/components/tasks-columns.tsx
+++ b/ui.web/src/features/tasks/components/tasks-columns.tsx
@@ -5,6 +5,7 @@ import {
   ImageIcon,
   MinusIcon,
   PlusIcon,
+  RotateCcwIcon,
   TagsIcon,
 } from 'lucide-react'
 import { Line, LineChart, XAxis, YAxis } from 'recharts'
@@ -42,6 +43,7 @@ type TasksColumnsOptions = {
   onBarcodeRow?: (task: Task) => void
   onAssignCollectionRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
+  onRestoreRow?: (task: Task) => void
   onWishlistInlineUpdate?: (
     task: Task,
     changes: WishlistInlineChanges
@@ -692,6 +694,7 @@ export function getTasksColumns({
   onBarcodeRow,
   onAssignCollectionRow,
   onDeleteRow,
+  onRestoreRow,
   onWishlistInlineUpdate,
   onWishlistPurchaseRow,
 }: TasksColumnsOptions): ColumnDef<Task>[] {
@@ -1186,6 +1189,22 @@ export function getTasksColumns({
                 <ImageIcon className='h-4 w-4' />
               </Button>
             </>
+          ) : null}
+          {isWishlistRoute && row.original.deleted ? (
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              className='h-8 px-2'
+              aria-label={`Restore ${row.original.title}`}
+              onClick={(event) => {
+                event.stopPropagation()
+                onRestoreRow?.(row.original)
+              }}
+            >
+              <RotateCcwIcon className='mr-1 h-4 w-4' />
+              Restore
+            </Button>
           ) : null}
           <DataTableRowActions
             row={row}

--- a/ui.web/src/features/tasks/components/tasks-dialogs.tsx
+++ b/ui.web/src/features/tasks/components/tasks-dialogs.tsx
@@ -188,16 +188,25 @@ export function TasksDialogs({
             cancelTestId='task-delete-cancel'
             confirmTestId='task-delete-confirm'
             title={
-              isWishlistRoute
-                ? `Delete this wishlist entry: ${currentRow.title} ?`
-                : `Delete this task: ${currentRow.id} ?`
+              isWishlistRoute && currentRow.deleted
+                ? `Permanently delete wishlist entry`
+                : isWishlistRoute
+                  ? `Hide this wishlist entry`
+                  : `Delete this task: ${currentRow.id} ?`
             }
             desc={
-              isWishlistRoute ? (
+              isWishlistRoute && currentRow.deleted ? (
                 <>
-                  You are about to delete the wishlist entry for{' '}
-                  <strong>{currentRow.title}</strong>. <br />
-                  This action cannot be undone.
+                  Permanently delete <strong>{currentRow.title}</strong> from
+                  the deleted wishlist view. This removes the wishlist row and
+                  linked wishlist metadata/history. Inventory records already
+                  created from this wishlist item will not be deleted.
+                </>
+              ) : isWishlistRoute ? (
+                <>
+                  Hide <strong>{currentRow.title}</strong> from the active
+                  Wishlist list. You can review and restore it from the Deleted
+                  view.
                 </>
               ) : (
                 <>
@@ -207,7 +216,13 @@ export function TasksDialogs({
                 </>
               )
             }
-            confirmText='Delete'
+            confirmText={
+              isWishlistRoute && currentRow.deleted
+                ? 'Permanently delete'
+                : isWishlistRoute
+                  ? 'Hide'
+                  : 'Delete'
+            }
           />
         </>
       )}

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -440,12 +440,15 @@ export function TasksTable({
         }
       }
       const rawStatus = (routeSearch as Record<string, unknown>).status
-      return Array.isArray(rawStatus)
+      const routeStatuses = Array.isArray(rawStatus)
         ? rawStatus.filter(
             (value): value is string =>
               typeof value === 'string' && value.trim() !== ''
           )
         : []
+      return routeStatuses.length > 0
+        ? routeStatuses
+        : ['wishlist', 'discovered']
     }
   )
 
@@ -492,10 +495,14 @@ export function TasksTable({
   }, [isWishlistRoute, wishlistStatusFilters])
 
   const filteredData = useMemo(() => {
-    if (!isWishlistRoute || wishlistStatusFilters.length === 0) {
+    if (!isWishlistRoute) {
       return data
     }
-    return data.filter((task) => wishlistStatusFilters.includes(task.status))
+    const activeFilters =
+      wishlistStatusFilters.length > 0
+        ? wishlistStatusFilters
+        : ['wishlist', 'discovered']
+    return data.filter((task) => activeFilters.includes(task.status))
   }, [data, isWishlistRoute, wishlistStatusFilters])
 
   const table = useReactTable({

--- a/ui.web/src/features/tasks/components/tasks-table.tsx
+++ b/ui.web/src/features/tasks/components/tasks-table.tsx
@@ -62,6 +62,7 @@ type DataTableProps = {
   onBarcodeRow?: (task: Task) => void
   onAssignCollectionRow?: (task: Task) => void
   onDeleteRow?: (task: Task) => void
+  onRestoreRow?: (task: Task) => void
   onWishlistBulkStatusChange?: (tasks: Task[], status: string) => Promise<void>
   onWishlistBulkPriorityChange?: (
     tasks: Task[],
@@ -270,6 +271,7 @@ export function TasksTable({
   onBarcodeRow,
   onAssignCollectionRow,
   onDeleteRow,
+  onRestoreRow,
   onWishlistBulkStatusChange,
   onWishlistBulkPriorityChange,
   onWishlistBulkDelete,
@@ -306,6 +308,7 @@ export function TasksTable({
         onBarcodeRow,
         onAssignCollectionRow,
         onDeleteRow,
+        onRestoreRow,
         onWishlistInlineUpdate,
         onWishlistPurchaseRow: openPurchaseDialog,
       }),
@@ -316,6 +319,7 @@ export function TasksTable({
       onBarcodeRow,
       onAssignCollectionRow,
       onDeleteRow,
+      onRestoreRow,
       onWishlistInlineUpdate,
       openPurchaseDialog,
     ]
@@ -827,6 +831,7 @@ export function TasksTable({
       ? [
           { label: 'Watching', value: 'wishlist' },
           { label: 'Below target', value: 'discovered' },
+          { label: 'Deleted', value: 'deleted' },
         ]
       : statuses
   const categoryFilterOptions = isInventoryRoute

--- a/ui.web/src/features/tasks/data/schema.ts
+++ b/ui.web/src/features/tasks/data/schema.ts
@@ -39,6 +39,7 @@ export const taskSchema = z.object({
   purchaseCondition: z.string().optional(),
   quantity: z.number().optional(),
   neededQuantity: z.number().optional(),
+  deleted: z.boolean().optional(),
 })
 
 export type Task = z.infer<typeof taskSchema>

--- a/ui.web/src/features/tasks/index.tsx
+++ b/ui.web/src/features/tasks/index.tsx
@@ -140,6 +140,7 @@ type WishlistEntryPayload = {
   purchase_condition?: string
   quantity?: number
   needed_quantity?: number
+  deleted?: boolean
   created_at?: string
   updated_at?: string
 }
@@ -700,36 +701,62 @@ export function Tasks({
     }
   }, [isWishlistRoute])
   const loadWishlistData = useCallback(async () => {
-    const [wishlistResponse, itemsResponse] = await Promise.all([
+    const [
+      wishlistResponse,
+      deletedWishlistResponse,
+      wishlistItemsResponse,
+      activeItemsResponse,
+    ] = await Promise.all([
       fetch('/api/wishlist'),
+      fetch('/api/wishlist?deleted=true'),
       fetch('/api/items?status=wishlist'),
+      fetch('/api/items?status=active'),
     ])
-    if (!wishlistResponse.ok || !itemsResponse.ok) {
+    if (
+      !wishlistResponse.ok ||
+      !deletedWishlistResponse.ok ||
+      !wishlistItemsResponse.ok ||
+      !activeItemsResponse.ok
+    ) {
       throw new Error('wishlist_bootstrap_failed')
     }
     const wishlistPayload = (await wishlistResponse.json()) as {
       items?: WishlistEntryPayload[]
     }
-    const itemsPayload = (await itemsResponse.json()) as {
+    const deletedWishlistPayload = (await deletedWishlistResponse.json()) as {
+      items?: WishlistEntryPayload[]
+    }
+    const wishlistItemsPayload = (await wishlistItemsResponse.json()) as {
       items?: WishlistItemPayload[]
     }
-    const wishlistByItemID = new Map<string, WishlistEntryPayload>()
-    ;(wishlistPayload.items ?? []).forEach((entry) => {
-      const itemID = entry.item_id?.trim()
-      if (!itemID) {
-        return
+    const activeItemsPayload = (await activeItemsResponse.json()) as {
+      items?: WishlistItemPayload[]
+    }
+    const itemByID = new Map<string, WishlistItemPayload>()
+    ;[
+      ...(wishlistItemsPayload.items ?? []),
+      ...(activeItemsPayload.items ?? []),
+    ].forEach((item) => {
+      const itemID = item.id?.trim()
+      if (itemID) {
+        itemByID.set(itemID, item)
       }
-      wishlistByItemID.set(itemID, entry)
     })
+    const wishlistEntries = [
+      ...(wishlistPayload.items ?? []),
+      ...(deletedWishlistPayload.items ?? []),
+    ]
     return Promise.all(
-      (itemsPayload.items ?? []).map(async (item, index) => {
-        const itemID = item.id?.trim() || `wishlist-item-${index + 1}`
-        const wishlistEntry = wishlistByItemID.get(itemID)
+      wishlistEntries.map(async (wishlistEntry, index) => {
+        const itemID =
+          wishlistEntry.item_id?.trim() || `wishlist-item-${index + 1}`
+        const item: WishlistItemPayload = itemByID.get(itemID) ?? {}
         const pricingSummary = await loadWishlistPricingSummary(itemID)
+        const isDeleted = Boolean(wishlistEntry.deleted)
         return {
           id: itemID,
           itemID: itemID,
-          wishlistEntryID: wishlistEntry?.id?.trim(),
+          wishlistEntryID: wishlistEntry.id?.trim(),
           title:
             item.title?.trim() ||
             item.part_number?.trim() ||
@@ -739,7 +766,11 @@ export function Tasks({
           itemType: item.item_type?.trim(),
           packagingGradeType: item.packaging_grade_type?.trim(),
           condition: item.condition?.trim(),
-          status: wishlistEntry?.below_target_now ? 'discovered' : 'wishlist',
+          status: isDeleted
+            ? 'deleted'
+            : wishlistEntry.below_target_now
+              ? 'discovered'
+              : 'wishlist',
           label: item.category?.trim() || 'collection',
           priority:
             wishlistEntry?.priority?.trim() ||
@@ -780,6 +811,7 @@ export function Tasks({
             typeof wishlistEntry?.needed_quantity === 'number'
               ? wishlistEntry.needed_quantity
               : 1,
+          deleted: isDeleted,
         } satisfies Task
       })
     )
@@ -1220,15 +1252,18 @@ export function Tasks({
 
       setIsWishlistMutating(true)
       try {
+        const permanentParam = task.deleted ? '&permanent=true' : ''
         const response = await fetch(
-          `/api/wishlist?id=${encodeURIComponent(wishlistEntryID)}`,
+          `/api/wishlist?id=${encodeURIComponent(wishlistEntryID)}${permanentParam}`,
           { method: 'DELETE' }
         )
         if (!response.ok) {
           throw new Error('wishlist_delete_failed')
         }
         await refreshWishlistTable()
-        const message = `${task.title} removed from wishlist.`
+        const message = task.deleted
+          ? `${task.title} permanently deleted from wishlist.`
+          : `${task.title} hidden from active wishlist.`
         toast.success(
           message,
           wishlistToastHistory(
@@ -1247,6 +1282,57 @@ export function Tasks({
           )
         )
         throw new Error('wishlist_delete_failed')
+      } finally {
+        setIsWishlistMutating(false)
+      }
+    },
+    [refreshWishlistTable]
+  )
+
+  const handleWishlistRestore = useCallback(
+    async (task: Task) => {
+      const wishlistEntryID = task.wishlistEntryID?.trim()
+      if (!wishlistEntryID) {
+        toast.error(
+          'Wishlist entry is missing restore metadata.',
+          wishlistToastHistory(
+            'wishlist-restore-missing-metadata',
+            'Wishlist entry is missing restore metadata.',
+            'Wishlist restore validation feedback was preserved in Inbox history.'
+          )
+        )
+        return
+      }
+
+      setIsWishlistMutating(true)
+      try {
+        const response = await fetch(
+          `/api/wishlist/${encodeURIComponent(wishlistEntryID)}/restore`,
+          { method: 'POST' }
+        )
+        if (!response.ok) {
+          throw new Error('wishlist_restore_failed')
+        }
+        await refreshWishlistTable()
+        const message = `${task.title} restored to active wishlist.`
+        toast.success(
+          message,
+          wishlistToastHistory(
+            'wishlist-restore-success',
+            message,
+            'Wishlist restore feedback was preserved in Inbox history.'
+          )
+        )
+      } catch {
+        toast.error(
+          'Wishlist restore failed. Try again.',
+          wishlistToastHistory(
+            'wishlist-restore-failed',
+            'Wishlist restore failed. Try again.',
+            'Wishlist restore failure feedback was preserved in Inbox history.'
+          )
+        )
+        throw new Error('wishlist_restore_failed')
       } finally {
         setIsWishlistMutating(false)
       }
@@ -2252,6 +2338,13 @@ export function Tasks({
               setCurrentDialogRow(task)
               setDialogOpen('delete')
             }}
+            onRestoreRow={
+              isWishlistRoute
+                ? (task) => {
+                    void handleWishlistRestore(task)
+                  }
+                : undefined
+            }
             onWishlistBulkStatusChange={
               isWishlistRoute ? handleWishlistBulkStatusChange : undefined
             }


### PR DESCRIPTION
## Summary
- Adds a migrated `deleted` state to wishlist entries and keeps default `/api/wishlist` results scoped to active rows.
- Changes normal Wishlist delete to soft-hide rows, adds `?deleted=true` list support, adds `/api/wishlist/{id}/restore`, and keeps `?permanent=true` as the hard-delete path.
- Wires the Wishlist table to load active and deleted rows, adds a Deleted status filter, exposes Restore in the Deleted view, and changes Deleted-view deletion to a permanent-delete confirmation with data-impact copy.
- Adds OpenSpec `UI-SCREEN-WISHLIST-023` and focused service/API regression coverage.

## Validation
- PASS `git diff --check` -> `.work-agent/logs/issue-1531-wishlist-soft-delete-product/diff-check-final-20260628-1100.log`
- PASS `openspec validate --all --strict --no-interactive` -> `.work-agent/logs/issue-1531-wishlist-soft-delete-product/openspec-validate-final-20260628-1100.log`
- PASS `go test ./internal/wishlist ./internal/app -run 'TestWishlistCRUDAndBelowTarget|TestWishlistDeleteRestoreAndPermanentDeleteEndpoint' -count=1` -> `.work-agent/logs/issue-1531-wishlist-soft-delete-product/go-test-wishlist-delete-restore-api-final-20260628-1100.log`
- PASS `npx prettier --check ...changed UI files...` -> `.work-agent/logs/issue-1531-wishlist-soft-delete-product/prettier-check-ui-final-20260628-1100.log`
- PASS `npm run build` from `ui.web` -> `.work-agent/logs/issue-1531-wishlist-soft-delete-product/npm-build-ui-20260628-1100.log`
- PUSH hook PASS OpenSpec + fast API docs smoke test.

## Demo
- Not deployed from this branch. Demo2 remains pending merge to `develop` and post-merge recycle.

## Notes
- Draft guard PR #1592 should be rerun against this product branch/after merge. If `/api/test/reset` still fails, recover the E2E reset precondition before using that Cypress result as product proof.