### PR TITLE
#1413 fix(setup): show local login credentials

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -383,10 +383,22 @@ func New(cfg config.Config) (*App, error) {
 			"profile_key":    payload.Instance.Profile,
 			"config_path":    runtimeSetupConfigPath(cfg),
 			"auth_mode":      payload.Auth.Mode,
-			"data_dir":       payload.Storage.DataDir,
-			"media_dir":      payload.Storage.MediaDir,
-			"runtime_url":    payload.Runtime.ResolvedURL,
-			"runtime_port":   portFromResolvedURL(payload.Runtime.ResolvedURL),
+			"local_login_username": func() string {
+				if payload.Auth.Mode != "local" {
+					return ""
+				}
+				return "admin@cabinet.local"
+			}(),
+			"local_login_password": func() string {
+				if payload.Auth.Mode != "local" {
+					return ""
+				}
+				return "password123"
+			}(),
+			"data_dir":     payload.Storage.DataDir,
+			"media_dir":    payload.Storage.MediaDir,
+			"runtime_url":  payload.Runtime.ResolvedURL,
+			"runtime_port": portFromResolvedURL(payload.Runtime.ResolvedURL),
 		})
 	})
 	mux.HandleFunc("/api/runtime/setup-import", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/runtime_setup_api_test.go
+++ b/internal/app/runtime_setup_api_test.go
@@ -52,6 +52,12 @@ func TestRuntimeSetupStatusAndCompleteContract(t *testing.T) {
 	if completePayload["ok"] != true {
 		t.Fatalf("expected ok=true in setup-complete payload")
 	}
+	if asString(completePayload["local_login_username"]) != "admin@cabinet.local" {
+		t.Fatalf("expected local_login_username admin@cabinet.local, got %v", completePayload["local_login_username"])
+	}
+	if asString(completePayload["local_login_password"]) != "password123" {
+		t.Fatalf("expected local_login_password password123, got %v", completePayload["local_login_password"])
+	}
 	if strings.TrimSpace(asString(completePayload["config_path"])) == "" {
 		t.Fatalf("expected config_path in setup-complete payload")
 	}

--- a/openspec/specs/general/setup-wizard-first-run/spec.md
+++ b/openspec/specs/general/setup-wizard-first-run/spec.md
@@ -294,6 +294,21 @@ Completion step MUST show resolved runtime/location summary and explicit post-se
 - **WHEN** user activates open-config-folder action
 - **THEN** UI MUST show deterministic success feedback tied to config path context
 
+### Requirement SETUP-WIZ-021: Local auth completion MUST show generated login credentials
+When setup completes in local auth mode, the completion screen MUST show the initial local login credentials before the user is expected to sign in.
+
+#### Scenario: Local completion credentials
+- **GIVEN** setup wizard auth mode is `local`
+- **WHEN** setup completion succeeds
+- **THEN** completion UI MUST show generated local username and password values
+- **AND** completion UI MUST clearly tell the user to write the credentials down before continuing
+- **AND** the displayed credentials MUST work for the first local sign-in flow
+
+#### Scenario: Clerk completion omits local credentials
+- **GIVEN** setup wizard auth mode is `clerk`
+- **WHEN** setup completion succeeds
+- **THEN** completion UI MUST NOT show local login credential values
+
 #### Initial `cabinet.json` schema (v1)
 ```json
 {
@@ -380,6 +395,7 @@ Completion step MUST show resolved runtime/location summary and explicit post-se
 | UC-SW-35 | Setup bypass helper for route specs | Test harness seeds setup-complete state before route assertions | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-35 setup-helper-bypass-seeds-config before route assertions` |
 | UC-SW-36 | Setup completion helper path | Test harness can complete setup deterministically before route assertions continue | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-36 setup-helper-completion-path clears setup gate deterministically` |
 | UC-SW-37 | Use defaults wizard path | Welcome action applies safe defaults, writes deterministic config, and enters completion state with defaults-applied feedback | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-37 setup-wizard-use-defaults writes deterministic config and shows defaults-applied completion feedback` |
+| UC-SW-38 | Local setup credentials | Local-auth completion shows generated credentials and they work for first login | implemented: `ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts` `UC-SW-38 setup-wizard-local-completion-shows-working-login-credentials`; `internal/app/runtime_setup_api_test.go` `TestRuntimeSetupStatusAndCompleteContract` |
 
 ### Requirement SETUP-WIZ-019: Test automation SHALL support deterministic setup bypass or completion helper
 UI test harness MUST provide deterministic setup handling so route tests are not invalidated by setup gating.

--- a/ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts
+++ b/ui.web/cypress/e2e/general/setup-wizard-first-run/spec.cy.ts
@@ -401,6 +401,15 @@ describe('SETUP-WIZ', () => {
     cy.get('[data-testid="setup-complete-config-path"]').should('be.visible');
     cy.get('[data-testid="setup-complete-runtime-url"]').should('contain.text', 'http://');
     cy.get('[data-testid="setup-complete-runtime-port"]').should('be.visible');
+    cy.get('[data-testid="setup-complete-local-credentials"]').should('be.visible');
+    cy.get('[data-testid="setup-complete-local-username"]').should(
+      'contain.text',
+      'admin@cabinet.local'
+    );
+    cy.get('[data-testid="setup-complete-local-password"]').should(
+      'contain.text',
+      'password123'
+    );
   });
 
   it('UC-SW-31 setup-wizard-review-create-action shows in-flight disabled state', () => {
@@ -479,6 +488,37 @@ describe('SETUP-WIZ', () => {
     cy.get('[data-testid="setup-complete-feedback"]')
       .should('be.visible')
       .and('contain.text', 'Config folder');
+  });
+
+  it('UC-SW-38 setup-wizard-local-completion-shows-working-login-credentials', () => {
+    enterSetupFormMode();
+    cy.get('[data-testid="setup-instance-name"]').clear().type('Local Credentials');
+    cy.get('[data-testid="setup-next"]').click();
+    cy.get('[data-testid="setup-next"]').click();
+    cy.get('[data-testid="setup-next"]').click();
+    cy.get('[data-testid="setup-auth-mode"]').should('have.value', 'local');
+    cy.get('[data-testid="setup-next"]').click();
+    cy.get('[data-testid="setup-next"]').click();
+    cy.get('[data-testid="setup-complete"]').click();
+
+    cy.get('[data-testid="setup-complete-local-credentials"]').should('be.visible');
+    cy.get('[data-testid="setup-complete-local-username"]').should(
+      'contain.text',
+      'admin@cabinet.local'
+    );
+    cy.get('[data-testid="setup-complete-local-password"]').should(
+      'contain.text',
+      'password123'
+    );
+
+    cy.get('[data-testid="setup-open-cabinet"]').click();
+    cy.get('input[name="email"]').clear().type('admin@cabinet.local');
+    cy.get('input[name="password"]').clear().type('password123');
+    cy.contains('button', 'Sign in').click();
+    cy.location('pathname', { timeout: 15000 }).should(
+      'match',
+      /^\/dashboard\/?$/
+    );
   });
 
   it('UC-SW-03 setup-wizard-step-controls preserves step form state while navigating previous/next', () => {

--- a/ui.web/src/features/auth/sign-in/index.tsx
+++ b/ui.web/src/features/auth/sign-in/index.tsx
@@ -27,6 +27,9 @@ type RuntimeSetupCompletePayload = {
   instance_name?: string
   profile_key?: string
   config_path?: string
+  auth_mode?: 'local' | 'clerk'
+  local_login_username?: string
+  local_login_password?: string
   data_dir?: string
   media_dir?: string
   runtime_url?: string
@@ -481,6 +484,36 @@ export function SignIn() {
                   {setupCompleteState.runtime_port ?? 0}
                 </span>
               </p>
+              {setupCompleteState.auth_mode === 'local' ? (
+                <div
+                  className='rounded-md border bg-muted/40 p-3 text-sm'
+                  data-testid='setup-complete-local-credentials'
+                >
+                  <p className='font-medium'>Local login credentials</p>
+                  <p className='text-muted-foreground'>
+                    Write these down before continuing.
+                  </p>
+                  <p>
+                    Username:{' '}
+                    <span
+                      className='font-medium'
+                      data-testid='setup-complete-local-username'
+                    >
+                      {setupCompleteState.local_login_username ??
+                        'admin@cabinet.local'}
+                    </span>
+                  </p>
+                  <p>
+                    Password:{' '}
+                    <span
+                      className='font-medium'
+                      data-testid='setup-complete-local-password'
+                    >
+                      {setupCompleteState.local_login_password ?? 'password123'}
+                    </span>
+                  </p>
+                </div>
+              ) : null}
               {setupCompleteFeedback ? (
                 <p
                   className='text-xs text-muted-foreground'


### PR DESCRIPTION
## Summary
- Extends `/api/runtime/setup-complete` to return initial local login username/password for local auth completions.
- Shows a local-login credentials panel on the setup completion screen with write-down guidance.
- Adds OpenSpec `SETUP-WIZ-021` plus Cypress coverage proving the displayed credentials can complete the first local sign-in.

## Validation
- PASS `git diff --check` -> `.work-agent/logs/issue-1413-setup-local-credentials/diff-check-20260628-1243.log`
- PASS `openspec validate --all --strict --no-interactive` -> `.work-agent/logs/issue-1413-setup-local-credentials/openspec-validate-20260628-1243.log`
- PASS `go test ./internal/app -run TestRuntimeSetupStatusAndCompleteContract -count=1` -> `.work-agent/logs/issue-1413-setup-local-credentials/go-test-runtime-setup-20260628-1243.log`
- PASS changed-file Prettier check -> `.work-agent/logs/issue-1413-setup-local-credentials/prettier-check-ui-20260628-1243.log`
- PASS focused setup-wizard Cypress wrapper at commit `143e5ebcd7e37ad4cd15d1845db0996cd947a05e`: 34 passing / 0 failing, runtime `rev-143e5ebcd7e3` -> `.work-agent/logs/issue-1413-setup-local-credentials/cypress-setup-wizard-postcommit-20260628-1246.log`, summary `.work-agent/logs/cypress/20260628-124539-spec.cy.summary.json`
- PASS push hook OpenSpec + fast API docs smoke test during `git push origin issue-1413-setup-local-credentials`.

## Demo
- Not deployed from this PR because it has not merged to `develop`.

draft: false