### PR TITLE
#1542 feat(market-watch): add friendly saved watch cadence controls

### DIFF
--- a/openspec/specs/integrations/ui-screen-market-watch/spec.md
+++ b/openspec/specs/integrations/ui-screen-market-watch/spec.md
@@ -17,6 +17,14 @@ Market Watch SHALL require selecting at least one provider before creating a que
 - **AND WHEN** user deletes the saved query set
 - **THEN** the query set MUST be removed from the visible Market Watch list
 
+#### Scenario: Friendly saved-watch cadence controls
+- **GIVEN** user creates or edits a saved Market Watch query
+- **WHEN** user chooses a friendly cadence such as manual, hourly, every 6 hours, daily, or weekly
+- **THEN** Market Watch MUST persist the corresponding schedule metadata without requiring raw cron syntax in the default flow
+- **AND WHEN** user pauses the watch while editing
+- **THEN** the saved watch MUST persist as disabled and show the paused cadence state in the visible list
+- **AND** custom cron entry MAY remain available as an advanced compatibility path
+
 ### Requirement UI-SCREEN-MARKET-WATCH-002: Market Watch SHALL execute runs scoped to selected provider(s)
 `Run Now` MUST execute only against query set provider scope.
 
@@ -202,7 +210,7 @@ Market Watch SHALL store saved-watch executions as durable run records and SHALL
 ## Use-Case IDs and E2E Mapping
 | UC ID | Flow | Expected Result | E2E Mapping |
 | --- | --- | --- | --- |
-| UC-MW-01 | Create query set with provider scope | Query set persists with provider metadata from either the form submit action or toolbar `+` create action | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-001 creates provider-scoped query sets from selector controls` |
+| UC-MW-01 | Create query set with provider scope | Query set persists with provider metadata from either the form submit action or toolbar `+` create action | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-001 creates provider-scoped query sets from selector controls`; `UI-SCREEN-MARKET-WATCH-001 + #1542 manages saved-watch create edit cadence pause and delete lifecycle` |
 | UC-MW-02 | Run scoped query | Runtime payload and results are provider-scoped | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-002 sends provider scope in run payload and shows provider-attributed results`; `UI-SCREEN-MARKET-WATCH-002 runs eBay-only saved searches through the provider route` |
 | UC-MW-03 | Handle run failure | Human-readable error + retry shown, then durable failure/query-set state reloads after recovery | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-003 surfaces run failure guidance and retry action` |
 | UC-MW-04 | Deterministic workspace states | Loading, empty, provider/auth attention, API load failure retry, and no-output detail states are explicit and testable | implemented: `ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` `UI-SCREEN-MARKET-WATCH-004 shows deterministic workspace states`; `UI-SCREEN-MARKET-WATCH-004 shows load failure with retry recovery`; `UI-SCREEN-MARKET-WATCH-004 keeps no-output detail state explicit` |

--- a/ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts
+++ b/ui.web/cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts
@@ -155,7 +155,7 @@ describe('integrations/ui-screen-market-watch', () => {
     cy.get('[data-testid="scanner-query-providers-qs-mw-barcode"]').should('contain', 'ebay')
   })
 
-  it('UI-SCREEN-MARKET-WATCH-001 manages saved-query create edit and delete lifecycle', () => {
+  it('UI-SCREEN-MARKET-WATCH-001 + #1542 manages saved-watch create edit cadence pause and delete lifecycle', () => {
     let querySets: Array<{
       id: string
       name: string
@@ -179,6 +179,7 @@ describe('integrations/ui-screen-market-watch', () => {
     cy.intercept('POST', '/api/scanner/query-sets', (req) => {
       expect(req.body.provider_scope).to.deep.equal(['bonzaslotcars'])
       expect(req.body.schedule_cron).to.equal('0 */6 * * *')
+      expect(req.body.enabled).to.equal(true)
       querySets = [
         {
           id: 'qs-mw-lifecycle',
@@ -195,7 +196,8 @@ describe('integrations/ui-screen-market-watch', () => {
       expect(req.body.name).to.equal('Bonza AFX Edited')
       expect(req.body.keywords).to.deep.equal(['AFX', 'Mega G+'])
       expect(req.body.provider_scope).to.deep.equal(['bonzaslotcars'])
-      expect(req.body.schedule_cron).to.equal('15 */4 * * *')
+      expect(req.body.schedule_cron).to.equal('0 9 * * *')
+      expect(req.body.enabled).to.equal(false)
       querySets = [
         {
           id: 'qs-mw-lifecycle',
@@ -219,6 +221,7 @@ describe('integrations/ui-screen-market-watch', () => {
     cy.get('[data-testid="market-watch-provider-single"]').select('bonzaslotcars')
     cy.get('[data-testid="scanner-new-query-name"]').type('Bonza AFX')
     cy.get('[data-testid="scanner-new-query-keywords"]').type('AFX')
+    cy.get('[data-testid="scanner-new-watch-cadence"]').select('Every 6 hours')
     cy.get('[data-testid="scanner-create-query"]').click()
     cy.wait('@createQuerySet')
     cy.get('[data-testid="scanner-query-providers-qs-mw-lifecycle"]').should(
@@ -233,7 +236,8 @@ describe('integrations/ui-screen-market-watch', () => {
     cy.get('[data-testid="scanner-edit-qs-mw-lifecycle"]').click()
     cy.get('[data-testid="scanner-edit-name-qs-mw-lifecycle"]').clear().type('Bonza AFX Edited')
     cy.get('[data-testid="scanner-edit-keywords-qs-mw-lifecycle"]').clear().type('AFX, Mega G+')
-    cy.get('[data-testid="scanner-edit-schedule-qs-mw-lifecycle"]').clear().type('15 */4 * * *')
+    cy.get('[data-testid="scanner-edit-enabled-qs-mw-lifecycle"]').click()
+    cy.get('[data-testid="scanner-edit-cadence-qs-mw-lifecycle"]').select('Daily')
     cy.get('[data-testid="scanner-save-qs-mw-lifecycle"]').click()
     cy.wait('@updateQuerySet')
     cy.contains('Bonza AFX Edited').should('be.visible')
@@ -244,7 +248,7 @@ describe('integrations/ui-screen-market-watch', () => {
     )
     cy.get('[data-testid="scanner-query-schedule-qs-mw-lifecycle"]').should(
       'contain',
-      '15 */4 * * *'
+      'Paused - Daily'
     )
 
     cy.get('[data-testid="scanner-delete-qs-mw-lifecycle"]').click()
@@ -319,6 +323,7 @@ describe('integrations/ui-screen-market-watch', () => {
     cy.get('[data-testid="market-watch-provider-single"]').select('ebay')
     cy.get('[data-testid="scanner-new-query-name"]').type('eBay Slot Cars')
     cy.get('[data-testid="scanner-new-query-keywords"]').type('AFX, Mega G+')
+    cy.get('[data-testid="scanner-new-watch-cadence"]').select('Custom')
     cy.get('[data-testid="scanner-new-query-schedule"]').clear().type('0 */6 * * *')
     cy.get('[data-testid="scanner-create-query"]').click()
     cy.wait('@createEbayQuerySet')
@@ -338,6 +343,7 @@ describe('integrations/ui-screen-market-watch', () => {
     cy.get('[data-testid="scanner-edit-keywords-qs-mw-ebay-lifecycle"]')
       .clear()
       .type('AFX, Mega G+, Tomy')
+    cy.get('[data-testid="scanner-edit-cadence-qs-mw-ebay-lifecycle"]').select('Custom')
     cy.get('[data-testid="scanner-edit-schedule-qs-mw-ebay-lifecycle"]')
       .clear()
       .type('30 */8 * * *')

--- a/ui.web/src/features/scanner/index.tsx
+++ b/ui.web/src/features/scanner/index.tsx
@@ -168,6 +168,38 @@ type CreateQueryValidation = {
   keywords?: string
 }
 
+const MARKET_WATCH_CADENCE_OPTIONS = [
+  { label: 'Manual only', value: 'manual', cron: '' },
+  { label: 'Every hour', value: 'hourly', cron: '0 * * * *' },
+  { label: 'Every 6 hours', value: 'every_6_hours', cron: '0 */6 * * *' },
+  { label: 'Daily', value: 'daily', cron: '0 9 * * *' },
+  { label: 'Weekly', value: 'weekly', cron: '0 9 * * 1' },
+  { label: 'Custom', value: 'custom', cron: '' },
+] as const
+
+type MarketWatchCadenceValue =
+  (typeof MARKET_WATCH_CADENCE_OPTIONS)[number]['value']
+
+function cadenceValueForCron(scheduleCron?: string): MarketWatchCadenceValue {
+  const normalized = scheduleCron?.trim() ?? ''
+  if (!normalized) {
+    return 'manual'
+  }
+  return (
+    MARKET_WATCH_CADENCE_OPTIONS.find(
+      (option) => option.cron === normalized && option.value !== 'manual'
+    )?.value ?? 'custom'
+  )
+}
+
+function cadenceLabelForCron(scheduleCron?: string): string {
+  const cadence = cadenceValueForCron(scheduleCron)
+  return (
+    MARKET_WATCH_CADENCE_OPTIONS.find((option) => option.value === cadence)
+      ?.label ?? 'Custom'
+  )
+}
+
 function parseActionErrorPayload(
   payload: unknown,
   fallback: string
@@ -332,6 +364,8 @@ export function Scanner() {
   const [newName, setNewName] = useState('')
   const [newKeywords, setNewKeywords] = useState('')
   const [newScheduleCron, setNewScheduleCron] = useState('0 */6 * * *')
+  const [newCadence, setNewCadence] =
+    useState<MarketWatchCadenceValue>('every_6_hours')
   const [createValidation, setCreateValidation] =
     useState<CreateQueryValidation>({})
   const [providerMode, setProviderMode] = useState<ProviderMode>('single')
@@ -360,6 +394,9 @@ export function Scanner() {
   const [editingName, setEditingName] = useState('')
   const [editingKeywords, setEditingKeywords] = useState('')
   const [editingScheduleCron, setEditingScheduleCron] = useState('')
+  const [editingCadence, setEditingCadence] =
+    useState<MarketWatchCadenceValue>('manual')
+  const [editingEnabled, setEditingEnabled] = useState(true)
   const [handoffStatus, setHandoffStatus] = useState<string | null>(null)
   const [quickScanStatus, setQuickScanStatus] = useState<string | null>(null)
   const [manualEntryTitle, setManualEntryTitle] = useState('')
@@ -544,6 +581,7 @@ export function Scanner() {
     setNewName('')
     setNewKeywords('')
     setNewScheduleCron('0 */6 * * *')
+    setNewCadence('every_6_hours')
   }
 
   const startEditQuerySet = (querySet: QuerySet) => {
@@ -551,6 +589,8 @@ export function Scanner() {
     setEditingName(querySet.name)
     setEditingKeywords((querySet.keywords ?? []).join(', '))
     setEditingScheduleCron(querySet.schedule_cron ?? '')
+    setEditingCadence(cadenceValueForCron(querySet.schedule_cron))
+    setEditingEnabled(querySet.enabled !== false)
   }
 
   const cancelEditQuerySet = () => {
@@ -558,6 +598,8 @@ export function Scanner() {
     setEditingName('')
     setEditingKeywords('')
     setEditingScheduleCron('')
+    setEditingCadence('manual')
+    setEditingEnabled(true)
   }
 
   const saveQuerySet = async (querySet: QuerySet) => {
@@ -572,6 +614,7 @@ export function Scanner() {
         .map((value) => value.trim())
         .filter(Boolean),
       schedule_cron: editingScheduleCron.trim(),
+      enabled: editingEnabled,
     }
     const response = await fetch(
       `/api/scanner/query-sets/${encodeURIComponent(querySet.id)}`,
@@ -1454,12 +1497,35 @@ export function Scanner() {
               </p>
             ) : null}
           </div>
-          <Input
-            value={newScheduleCron}
-            onChange={(event) => setNewScheduleCron(event.target.value)}
-            placeholder='Schedule cron (e.g. 0 */6 * * *)'
-            data-testid='scanner-new-query-schedule'
-          />
+          <select
+            className='h-9 rounded-md border bg-background px-3 text-sm'
+            value={newCadence}
+            onChange={(event) => {
+              const cadence = event.target.value as MarketWatchCadenceValue
+              setNewCadence(cadence)
+              const option = MARKET_WATCH_CADENCE_OPTIONS.find(
+                (item) => item.value === cadence
+              )
+              if (cadence !== 'custom') {
+                setNewScheduleCron(option?.cron ?? '')
+              }
+            }}
+            data-testid='scanner-new-watch-cadence'
+          >
+            {MARKET_WATCH_CADENCE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {newCadence === 'custom' ? (
+            <Input
+              value={newScheduleCron}
+              onChange={(event) => setNewScheduleCron(event.target.value)}
+              placeholder='Advanced schedule cron'
+              data-testid='scanner-new-query-schedule'
+            />
+          ) : null}
           <select
             className='h-9 rounded-md border bg-background px-3 text-sm'
             value={providerMode}
@@ -2137,13 +2203,48 @@ export function Scanner() {
                           }
                           data-testid={`scanner-edit-keywords-${querySet.id}`}
                         />
-                        <Input
-                          value={editingScheduleCron}
-                          onChange={(event) =>
-                            setEditingScheduleCron(event.target.value)
-                          }
-                          data-testid={`scanner-edit-schedule-${querySet.id}`}
-                        />
+                        <label className='inline-flex items-center gap-2 text-xs text-muted-foreground'>
+                          <input
+                            type='checkbox'
+                            checked={editingEnabled}
+                            onChange={(event) =>
+                              setEditingEnabled(event.target.checked)
+                            }
+                            data-testid={`scanner-edit-enabled-${querySet.id}`}
+                          />
+                          Enabled
+                        </label>
+                        <select
+                          className='h-9 rounded-md border bg-background px-3 text-sm'
+                          value={editingCadence}
+                          onChange={(event) => {
+                            const cadence =
+                              event.target.value as MarketWatchCadenceValue
+                            setEditingCadence(cadence)
+                            const option = MARKET_WATCH_CADENCE_OPTIONS.find(
+                              (item) => item.value === cadence
+                            )
+                            if (cadence !== 'custom') {
+                              setEditingScheduleCron(option?.cron ?? '')
+                            }
+                          }}
+                          data-testid={`scanner-edit-cadence-${querySet.id}`}
+                        >
+                          {MARKET_WATCH_CADENCE_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                        {editingCadence === 'custom' ? (
+                          <Input
+                            value={editingScheduleCron}
+                            onChange={(event) =>
+                              setEditingScheduleCron(event.target.value)
+                            }
+                            data-testid={`scanner-edit-schedule-${querySet.id}`}
+                          />
+                        ) : null}
                       </div>
                     ) : (
                       <>
@@ -2163,7 +2264,10 @@ export function Scanner() {
                       className='text-xs text-muted-foreground'
                       data-testid={`scanner-query-schedule-${querySet.id}`}
                     >
-                      Schedule: {querySet.schedule_cron || 'none'}
+                      Schedule:{' '}
+                      {querySet.enabled === false
+                        ? `Paused - ${cadenceLabelForCron(querySet.schedule_cron)}${querySet.schedule_cron ? ` (${querySet.schedule_cron})` : ''}`
+                        : querySet.schedule_cron || 'none'}
                     </p>
                   </div>
                   <div className='flex flex-wrap gap-2'>


### PR DESCRIPTION
## Summary
- Adds friendly Market Watch saved-watch cadence options for create/edit: manual, hourly, every 6 hours, daily, weekly, and custom.
- Preserves the advanced raw cron compatibility path only when `Custom` is selected.
- Persists pause/resume through the existing `enabled` field and shows paused cadence state in the saved query list.
- Binds #1542 to `UI-SCREEN-MARKET-WATCH-001` with Cypress coverage.

## Validation
- `openspec validate --all --strict --no-interactive` -> PASS (`.work-agent/logs/issue-1542/openspec-strict.log`)
- `npm exec eslint -- src/features/scanner/index.tsx cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts` from `ui.web` -> PASS (`.work-agent/logs/issue-1542/ui-lint-scanner-market-watch-post-custom-fix.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/integrations/ui-screen-market-watch/spec.cy.ts -Browser chrome -RequireE2EHooks` -> PASS, 25 passing (`.work-agent/logs/issue-1542/green-cypress-market-watch-1542-post-custom-fix.log`)
- Pre-commit OpenSpec hook -> PASS
- Pre-push OpenSpec + fast API docs smoke test -> PASS

## Notes
- Earlier red/diagnostic Cypress evidence is preserved in `.work-agent/logs/issue-1542/red-cypress-market-watch-1542.log` and `.work-agent/logs/issue-1542/green-cypress-market-watch-1542-final.log`.
- Demo deployment is pending merge to `develop`; this PR does not update the demo lane yet.

Closes #1542