### PR TITLE
#1613 update traceability backlog contract

### DIFF
--- a/tests/traceability_uniqueness_test.go
+++ b/tests/traceability_uniqueness_test.go
@@ -62,12 +62,6 @@ func TestRemainingTraceabilityBacklogRowsAreExplicit(t *testing.T) {
 			"TestGuidedWalkthroughModesGovernCommandPermissions",
 			"ASSISTANT-EXECUTION-010 preserves confirm-before-apply across walkthrough modes",
 		},
-		"ASSISTANT-EXECUTION-013": {
-			"| planned |",
-			"#1512/#1514",
-			"TestGuidedCommandBusDispatchesNavigationHighlightAndPreviewStates",
-			"ASSISTANT-EXECUTION-013 keeps side-panel Chat open while commands navigate",
-		},
 		"ASSISTANT-EXECUTION-014": {
 			"| planned |",
 			"#1507/#1514",
@@ -79,11 +73,6 @@ func TestRemainingTraceabilityBacklogRowsAreExplicit(t *testing.T) {
 			"#1513/#1514",
 			"TestGuidedInventoryItemUpdateRequiresConfirmationAndPersistsResult",
 			"ASSISTANT-EXECUTION-015 guides inventory item update with persistence proof",
-		},
-		"ASSISTANT-WORKSPACE-008": {
-			"| planned |",
-			"#1509/#1512/#1514",
-			"ASSISTANT-WORKSPACE-008 preserves guided side-panel state across route navigation",
 		},
 		"UI-SCREEN-CHAT-COPILOT-018": {
 			"| planned |",


### PR DESCRIPTION
## Summary
- removes implemented assistant rows from the remaining non-implemented traceability allowlist
- keeps the guard focused on rows that are still planned or partial

## Validation
- go test ./tests -count=1 -> PASS (.work-agent/logs/issue-1613/20260629-0732/go-test-tests.log)
- go test ./... -count=1 -> PASS (.work-agent/logs/issue-1613/20260629-0732/go-test-all.log)
- openspec validate --all --strict --no-interactive -> PASS (.work-agent/logs/issue-1613/20260629-0732/openspec-validate.log)
- pre-push OpenSpec + fast API docs smoke -> PASS

Unblocks #1550 / PR #1612.

Closes #1613