### PR TITLE
#827 preserve eBay handoff stock audit

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4000,6 +4000,8 @@ components:
             source_result_url: { type: string }
             observed_price: { type: number }
             observed_currency: { type: string }
+            stock_state: { type: string }
+            stock_count: { type: integer }
             seller: { type: string }
             triage_status: { type: string }
     WishlistEntryInput:

--- a/internal/app/discovery_wishlist_pricing_api_test.go
+++ b/internal/app/discovery_wishlist_pricing_api_test.go
@@ -96,7 +96,7 @@ func TestDiscoveryActionResponseReturnsEbayHandoffProvenance(t *testing.T) {
 	if !payload.OK || payload.Action != "add_to_wishlist" || payload.Candidate != "ebay-handoff-c1" {
 		t.Fatalf("unexpected action envelope: %+v", payload)
 	}
-	for _, field := range []string{"source", "source_provider", "query_set_id", "query_name", "provider_scope", "listing_id", "source_result_url", "observed_currency"} {
+	for _, field := range []string{"source", "source_provider", "query_set_id", "query_name", "provider_scope", "listing_id", "source_result_url", "observed_currency", "stock_state", "stock_count"} {
 		if _, ok := payload.Audit[field]; !ok {
 			t.Fatalf("expected audit field %q in response: %+v", field, payload.Audit)
 		}
@@ -107,6 +107,9 @@ func TestDiscoveryActionResponseReturnsEbayHandoffProvenance(t *testing.T) {
 	providerScope, ok := payload.Audit["provider_scope"].([]any)
 	if !ok || len(providerScope) != 1 || providerScope[0] != "ebay" {
 		t.Fatalf("expected eBay provider scope in response audit, got %+v", payload.Audit["provider_scope"])
+	}
+	if payload.Audit["stock_state"] != "in_stock" || payload.Audit["stock_count"] != float64(3) {
+		t.Fatalf("expected eBay stock attribution in response audit, got %+v", payload.Audit)
 	}
 }
 

--- a/internal/app/openapi_parity_test.go
+++ b/internal/app/openapi_parity_test.go
@@ -1222,6 +1222,8 @@ func TestOpenAPIDocumentsEbaySavedSearchHandoffContract(t *testing.T) {
 		"provider_scope:",
 		"source_result_url: { type: string }",
 		"observed_currency: { type: string }",
+		"stock_state: { type: string }",
+		"stock_count: { type: integer }",
 	} {
 		if !strings.Contains(actionResponseSchema, token) {
 			t.Fatalf("openapi DiscoveryActionResponse schema missing %q:\n%s", token, actionResponseSchema)

--- a/internal/discovery/service.go
+++ b/internal/discovery/service.go
@@ -595,14 +595,14 @@ func (s *Service) enrichDiscoveryActionPayload(ctx context.Context, candidateID 
 		enriched[key] = value
 	}
 	var sourceProvider, querySetID, queryName, providerScopeJSON string
-	var listingID, listingURL, title, observedCurrency, seller, firstSeen, lastSeen, status, reviewerNotes, sourceResultURL string
+	var listingID, listingURL, title, observedCurrency, seller, firstSeen, lastSeen, status, reviewerNotes, sourceResultURL, stockState string
 	var observedPrice, confidence float64
-	var needsReview int
+	var needsReview, stockCount int
 	if err := s.db.QueryRowContext(ctx, `
 		SELECT c.source, c.query_set_id, COALESCE(q.name, ''), COALESCE(q.provider_scope_json, '[]'),
 			c.listing_id, c.url, c.title, c.price, c.observed_currency, c.seller,
 			c.first_seen, c.last_seen, c.status, COALESCE(m.confidence, 0), COALESCE(m.needs_review, 1),
-			c.reviewer_notes, COALESCE(NULLIF(c.source_result_url, ''), c.url)
+			c.reviewer_notes, COALESCE(NULLIF(c.source_result_url, ''), c.url), c.stock_state, c.stock_count
 		FROM scanner_candidates c
 		LEFT JOIN scanner_query_sets q ON q.id = c.query_set_id
 		LEFT JOIN scanner_matches m ON m.candidate_id = c.id
@@ -611,7 +611,7 @@ func (s *Service) enrichDiscoveryActionPayload(ctx context.Context, candidateID 
 		&sourceProvider, &querySetID, &queryName, &providerScopeJSON,
 		&listingID, &listingURL, &title, &observedPrice, &observedCurrency, &seller,
 		&firstSeen, &lastSeen, &status, &confidence, &needsReview,
-		&reviewerNotes, &sourceResultURL,
+		&reviewerNotes, &sourceResultURL, &stockState, &stockCount,
 	); err != nil {
 		return enriched
 	}
@@ -632,6 +632,8 @@ func (s *Service) enrichDiscoveryActionPayload(ctx context.Context, candidateID 
 	enriched["needs_review"] = needsReview != 0
 	enriched["reviewer_notes"] = strings.TrimSpace(reviewerNotes)
 	enriched["source_result_url"] = strings.TrimSpace(sourceResultURL)
+	enriched["stock_state"] = strings.TrimSpace(stockState)
+	enriched["stock_count"] = stockCount
 	return enriched
 }
 

--- a/openspec/specs/integrations/provider-ebay/spec.md
+++ b/openspec/specs/integrations/provider-ebay/spec.md
@@ -77,7 +77,7 @@ Cabinet SHALL execute eBay listing queries using profile-scoped credentials and 
 - **AND** the scheduled scanner run OpenAPI contract MUST document the execution summary returned after enabled scheduled saved searches run, including `run_id`, `query_sets_executed`, `candidates_collected`, and `failures`, so eBay-scoped scheduled query clients do not treat the response as an untyped object.
 - **AND** the scanner candidates and discovery action OpenAPI contracts MUST document eBay saved-search handoff provenance fields, including `source="ebay"`, `query_set_id`, listing URL, `source_provider`, `query_name`, and `provider_scope`.
 - **AND** the scanner candidate OpenAPI contract MUST document normalized eBay stock observation fields `stock_state` and `stock_count` alongside candidate price/source fields so Market Watch and Discoveries clients can render stock state without relying on undocumented response keys.
-- **AND** the discovery action response MUST return the applied `action`, `candidate_id`, and enriched audit metadata so clients can verify eBay source provider, query id, query name, provider scope, listing URL, source result URL, observed price/currency, and seller immediately after a Market Watch handoff.
+- **AND** the discovery action response MUST return the applied `action`, `candidate_id`, and enriched audit metadata so clients can verify eBay source provider, query id, query name, provider scope, listing URL, source result URL, observed price/currency, seller, stock state, and stock count immediately after a Market Watch handoff.
 
 #### Scenario: Scanner run documents eBay auth error envelope
 - **GIVEN** an active profile runs an eBay-scoped scanner query without a usable bearer token, or with a token rejected by eBay


### PR DESCRIPTION
## Summary
- Preserve normalized eBay `stock_state` and `stock_count` in `/api/discovery/action` enriched audit metadata.
- Document the handoff audit stock fields in OpenAPI and the eBay provider OpenSpec contract.
- Extend focused API/OpenAPI tests for the stock audit contract.

## Validation
- RED captured: `go test ./internal/app -run "TestDiscoveryActionResponseReturnsEbayHandoffProvenance" -count=1` failed before implementation (`.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/go-test-discovery-handoff-red.log`).
- PASS `go test ./internal/app -run "TestDiscoveryActionResponseReturnsEbayHandoffProvenance|TestOpenAPIDocumentsEbaySavedSearchHandoffContract" -count=1`
- PASS `go test ./tests -run "TestEbayProviderSearchFailureTraceabilityImplemented|TestEbayProviderTraceabilityImplemented" -count=1`
- PASS `openspec validate --all --strict --no-interactive`
- PASS `git diff --check`
- PASS pre-commit OpenSpec validation
- PASS pre-push OpenSpec validation + fast API docs smoke test

## Logs
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/validation-results.json`
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/go-test-discovery-handoff-red.log`
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/go-test-discovery-handoff-final.log`
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/go-test-traceability-final.log`
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/openspec-validate-final.log`
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/git-diff-check-final.log`
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/git-commit.log`
- `.work-agent/logs/issue-827-ebay-handoff-stock-audit/20260630-1330/git-push.log`

Issue #827 remains open for broader production eBay API listing search and handoff workflow hardening.