### PR TITLE
#1725 docs(cron): require project status on pickup

### DIFF
--- a/scripts/cron/CABINET-CONTINUITY.md
+++ b/scripts/cron/CABINET-CONTINUITY.md
@@ -21,6 +21,8 @@ Continue Cabinet work in the same Telegram group session that scheduled the cron
 - All normal Cabinet project rules still apply.
 - Follow Issue -> Spec -> Validate -> Commit for implementation work.
 - Keep work on one focused issue branch at a time.
+- When a cron turn picks a new eligible issue from `Ready`, `Backlog`, or another non-active state, move the linked GitHub Project item Status to `In progress` before starting implementation.
+- If project status cannot be updated, record the attempted command/error on the issue and treat the pickup as blocked unless the issue was already active.
 - Do not claim completion without concrete evidence.
 - For every turn, make bounded, reliable progress that can be seen in the Telegram update.
 - If blocked, capture exact blocker evidence, state what was checked, and either advance the same issue to the next concrete unblock step or report the blocker plainly.


### PR DESCRIPTION
## Summary
- mirror the Cabinet developer cron pickup rule in the repo cron continuity doc
- require newly picked issues to move their linked Project item Status to \In progress\ before implementation starts
- require failed project-status updates to be recorded on the issue and treated as blocked unless the issue was already active

## Evidence
- Live OpenClaw cron job \5713bf4d-ced8-4121-ac74-a18859f2b893\ reads \C:\\projects\\collectors-tech\\work-agents\\docs\\cabinet-continuity-cron-bootstrap.md\.
- Project proof for this fix: issue #1725 is on Cabinet project \cabinet\ with Status \In progress\.

## Validation
- Pre-push OpenSpec validation: 11 passed, 0 failed
- Pre-push fast API docs smoke: \ok github.com/collectors-tech/cabinet/internal/app\`n
## Related
- External cron-read bootstrap update is in collectors-tech/work-agents branch \issue-1725-cron-pickup-status\.

Closes #1725