### PR TITLE
#1421 Move Media actions into page header

### DIFF
--- a/openspec/specs/media/ui-screen-media/spec.md
+++ b/openspec/specs/media/ui-screen-media/spec.md
@@ -282,13 +282,13 @@ Cabinet SHALL expose explicit Cards and Rows view controls on the authenticated 
 - **THEN** Cabinet MUST restore the selected Media view mode from `cabinet.viewMode.media` without changing the active media filter or API query.
 
 ### Requirement UI-SCREEN-MEDIA-015: Media workspace table SHALL use Cabinet shared table affordances
-Cabinet SHALL render the Media page primary content with the shared table surface used by other Cabinet management pages, including toolbar search/filtering, sortable scan-friendly columns, stable row selection, row actions, and toolbar-scoped table actions. The Media workspace SHALL reclaim working space by omitting the former top summary-card row above the table workflow.
+Cabinet SHALL render the Media page primary content with the shared table surface used by other Cabinet management pages, including toolbar search/filtering, sortable scan-friendly columns, stable row selection, row actions, and header-scoped primary actions. The Media workspace SHALL reclaim working space by omitting the former top summary-card row above the table workflow.
 
 #### Scenario: Manage media from shared table surface
 - **GIVEN** the Media workspace has returned profile-scoped media assets
 - **WHEN** the user opens `/media`
 - **THEN** the primary content MUST render a `data-table-surface` table with thumbnail/title identity, analysis status, linkage state, upload timestamp, source/context, filename, row selection, and open/analyze/assign/archive actions.
-- **AND** the table toolbar MUST expose an accessible `Add new asset` action.
+- **AND** the page header action area MUST expose an accessible `Add new asset` action while the table toolbar remains focused on table search, filtering, and view controls.
 - **AND** the workspace MUST NOT render the former top summary cards for Assets, Unlinked, or Ready for review above the table workflow.
 - **AND** the table toolbar MUST provide search/filtering over media identity, status, linkage, source, and filename fields without switching away from the table.
 
@@ -308,8 +308,8 @@ Cabinet SHALL keep both Media Cards and Rows view modes on the same shared table
 - **THEN** the Media table body or card body region MUST be the scrolling surface
 - **AND** the page header, table toolbar, and pagination controls MUST remain reachable without relying on whole-page table scrolling.
 
-### Requirement UI-SCREEN-MEDIA-018: Media workspace SHALL keep all persistent controls inside the shared table toolbar
-Cabinet SHALL render `/media` as a compact table-first workspace where persistent Media controls live inside the shared table toolbar instead of in permanent page-level chrome above the table.
+### Requirement UI-SCREEN-MEDIA-018: Media workspace SHALL keep primary actions in the page header
+Cabinet SHALL render `/media` as a compact table-first workspace where primary Media actions live in the shared page header action area while table search, filters, view mode, and column controls remain inside the shared table toolbar.
 
 #### Scenario: Render compact Media workspace without duplicate page chrome
 - **GIVEN** the user opens `/media`
@@ -317,10 +317,19 @@ Cabinet SHALL render `/media` as a compact table-first workspace where persisten
 - **THEN** the workspace MUST render the shared Media table section at the top of the workspace
 - **AND** the workspace MUST NOT render a permanent in-page `Media` heading, page description, asset-count row, table-summary row, or All/Unlinked tab strip above the table.
 
+#### Scenario: Use Media primary actions from the page header
+- **GIVEN** the Media page header is visible
+- **WHEN** the user reviews persistent page actions
+- **THEN** the shared page header action area MUST contain Add media and Download selected controls.
+- **AND** the Add media action MUST open the Add media dialog through the same create path used by page-wide drop.
+- **AND** Download selected MUST remain disabled until one or more assets are selected and MUST use the `/api/media/downloads/preview` contract when activated.
+- **AND** the header action area MUST wrap cleanly on narrow widths without creating a duplicate in-body action row above the table.
+
 #### Scenario: Use Media controls from the table toolbar
 - **GIVEN** the Media table toolbar is visible
 - **WHEN** the user reviews persistent table controls
-- **THEN** the toolbar MUST contain `Filter media...` search, the Linked filter, Add media, Download selected, Cards, Rows, and the table `View` control.
+- **THEN** the toolbar MUST contain `Filter media...` search, the Linked filter, Cards, Rows, and the table `View` control.
+- **AND** the toolbar MUST NOT duplicate the Add media or Download selected page header actions.
 - **WHEN** the user selects Linked `Unlinked`
 - **THEN** Cabinet MUST keep using the `/api/media/assets?filter=unlinked` contract and update visible table or card results to unlinked media only.
 - **AND** Cards and Rows controls MUST stay adjacent to the table `View` control and share the same search, linkage filter, and pagination state.

--- a/ui.web/cypress/e2e/media/ui-screen-media/spec.cy.ts
+++ b/ui.web/cypress/e2e/media/ui-screen-media/spec.cy.ts
@@ -110,14 +110,20 @@ describe('ui-screen-media', () => {
     cy.get('[data-testid="media-shared-table"]')
       .should('be.visible')
       .and('have.attr', 'data-table-surface', 'true')
+    cy.get('[data-testid="media-global-header-actions"]').within(() => {
+      cy.get('[data-testid="media-upload-action"]').should('be.enabled')
+      cy.get('[data-testid="media-download-selected-action"]').should(
+        'be.disabled'
+      )
+    })
     cy.get('[data-testid="media-table-toolbar"]').within(() => {
       cy.get('[data-testid="media-table-search-input"]').should('be.visible')
       cy.get('[data-testid="media-linkage-filter-trigger"]')
         .should('be.visible')
         .and('contain', 'All')
-      cy.get('[data-testid="media-upload-action"]').should('be.enabled')
+      cy.get('[data-testid="media-upload-action"]').should('not.exist')
       cy.get('[data-testid="media-download-selected-action"]').should(
-        'be.disabled'
+        'not.exist'
       )
       cy.get('[data-testid="media-view-mode-cards"]').should('be.visible')
       cy.get('[data-testid="media-view-mode-rows"]').should('be.visible')

--- a/ui.web/src/features/media/index.tsx
+++ b/ui.web/src/features/media/index.tsx
@@ -55,6 +55,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Separator } from '@/components/ui/separator'
 import {
   Sheet,
   SheetContent,
@@ -1004,13 +1005,50 @@ export function Media() {
           iconTestId='media-page-icon'
         />
         <div
-          className='ms-auto flex items-center space-x-4'
+          className='ms-auto flex min-w-0 items-center gap-3'
           data-header-title-avoid='true'
         >
-          <LanguageSwitch />
-          <ThemeSwitch />
-          <ConfigDrawer />
-          <ProfileDropdown />
+          <div
+            className='flex min-w-0 flex-wrap items-center justify-end gap-2'
+            data-testid='media-global-header-actions'
+          >
+            <Button
+              type='button'
+              size='icon'
+              className='h-8 w-8'
+              aria-label='Add new asset'
+              title='Add media'
+              data-testid='media-upload-action'
+              onClick={() => {
+                setAddMediaOpen(true)
+                setAddMediaError(null)
+              }}
+            >
+              <ImagePlus className='h-4 w-4' aria-hidden='true' />
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              className='h-8'
+              disabled={selectedAssetIds.length === 0 || downloadLoading}
+              data-testid='media-download-selected-action'
+              onClick={() => void previewDownload()}
+            >
+              <Download className='h-4 w-4' aria-hidden='true' />
+              {downloadLoading ? 'Previewing...' : 'Download selected'}
+            </Button>
+          </div>
+          <Separator
+            orientation='vertical'
+            className='h-6'
+            data-testid='media-header-action-separator'
+          />
+          <div className='flex items-center gap-4'>
+            <LanguageSwitch />
+            <ThemeSwitch />
+            <ConfigDrawer />
+            <ProfileDropdown />
+          </div>
         </div>
       </Header>
 
@@ -1140,32 +1178,6 @@ export function Media() {
                 }
                 actions={
                   <>
-                    <Button
-                      type='button'
-                      size='icon'
-                      className='h-8 w-8'
-                      aria-label='Add new asset'
-                      data-testid='media-upload-action'
-                      onClick={() => {
-                        setAddMediaOpen(true)
-                        setAddMediaError(null)
-                      }}
-                    >
-                      <ImagePlus />
-                    </Button>
-                    <Button
-                      variant='outline'
-                      size='sm'
-                      className='h-8'
-                      disabled={
-                        selectedAssetIds.length === 0 || downloadLoading
-                      }
-                      data-testid='media-download-selected-action'
-                      onClick={() => void previewDownload()}
-                    >
-                      <Download />
-                      {downloadLoading ? 'Previewing...' : 'Download selected'}
-                    </Button>
                     <div
                       className='flex items-center gap-1'
                       aria-label='Media view mode'


### PR DESCRIPTION
## Summary
- Moves Media primary actions into the shared page header action lane.
- Keeps table toolbar scoped to search, linkage filter, Cards/Rows, and View controls.
- Updates Media OpenSpec contract and focused Cypress assertions for the new action placement.

## Validation
- `openspec validate --all --strict --no-interactive` PASS (`.work-agent/logs/issue-1421/openspec-validate-all-strict-rerun.log`)
- `npm exec eslint -- src/features/media/index.tsx cypress/e2e/media/ui-screen-media/spec.cy.ts` PASS (`.work-agent/logs/issue-1421/eslint-media-changed-files.log`)
- `npx prettier --check src/features/media/index.tsx cypress/e2e/media/ui-screen-media/spec.cy.ts ../openspec/specs/media/ui-screen-media/spec.md` PASS (`.work-agent/logs/issue-1421/prettier-check-media-changed-files-npx-rerun.log`)
- `pwsh -NoLogo -NoProfile -File .\cypress.ps1 -Spec cypress/e2e/media/ui-screen-media/spec.cy.ts -Browser chrome -RequireE2EHooks` PASS, 14/14 (`.work-agent/logs/issue-1421/cypress-media-ui-screen.log`)

Closes #1421