### PR TITLE
#1837 docs: split MVP and Kickstarter planning docs

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,12 @@
+# Cabinet product planning docs
+
+This directory contains product planning and commercialisation documents that sit alongside the main Cabinet product overview.
+
+## Documents
+
+- [Beta MVP plan](beta-mvp.md)
+- [Kickstarter market validation plan](kickstarter-market-validation.md)
+
+## Scope
+
+These documents guide backlog shaping and product validation. They do not replace GitHub issues, OpenSpec requirements, validation evidence, or the manual delivery workflow described in the repository README.

--- a/docs/product/beta-mvp.md
+++ b/docs/product/beta-mvp.md
@@ -1,0 +1,285 @@
+# Cabinet Beta MVP Plan
+
+## Purpose
+
+This document defines the immediate Cabinet Beta MVP, the Free/paid packaging model, and the first commercial validation path.
+
+The goal is to make Cabinet sellable as a useful local-first collector workspace before the full decentralised trust network is implemented.
+
+## Product thesis
+
+Cabinet should first sell as a desktop-first, local-first collector workspace.
+
+The immediate value proposition is:
+
+> Cabinet helps collectors organise what they own, track what they want, find better buying opportunities, and prepare trades while keeping their collection private and portable.
+
+Cabinet Free should create trust and usage habit. Paid Cabinet should charge for collector intelligence: saved searches, discoveries, matching, evidence, guided workflows, backup confidence, import/export polish, and trade preparation.
+
+## Strategic split
+
+### Immediate beta product
+
+The Beta should focus on a useful app a collector can install, use, and pay for now:
+
+- private inventory
+- wishlist
+- collections
+- photos, media, and evidence
+- search and scanner flows
+- Market Watch
+- Discoveries
+- integrations
+- assistant-guided workflows
+- backup, restore, import, export, and maintenance
+
+### Long-term moat
+
+The long-term Cabinet architecture remains the differentiator, but should not block the first paid beta:
+
+- collector-owned identity
+- signed receipts
+- signed feedback vault
+- portable reputation
+- public Git/GitHub/GitLab/Codeberg/Radicle proof ledgers
+- store, venue, custodian, and master collector attestations
+- Radicle and P2P support
+- community verification
+
+These should be framed as the trust roadmap, not as required beta functionality.
+
+## Beta positioning
+
+Suggested beta positioning:
+
+> Cabinet is your private collector workspace: inventory, wishlist, collections, evidence, saved searches, discoveries, and trade preparation in one desktop-first app.
+
+Suggested paid positioning:
+
+> Cabinet Free organises your collection. Cabinet Plus helps you find the things you want before someone else does.
+
+## Beta MVP scope
+
+### Must-have Beta scope
+
+| Area | Beta scope | Commercial reason |
+|---|---|---|
+| Onboarding | Create/select profile, starter checklist, sample data | Gets user to value quickly |
+| Inventory | Add, edit, search, filter, view rows/cards, attach photos and identifiers | Core daily use |
+| Wishlist | Add wanted items, priority/status, mark purchased into inventory | Turns collecting intent into action |
+| Collections | Create/manage collections, assign/move items | Makes Cabinet feel like a real workspace |
+| Media/evidence | Item photos, primary image, condition/evidence notes | Builds trust in the collection record |
+| Import/export | CSV/JSON import/export, backup/restore | Reduces data-lock-in fear |
+| Market Watch | Saved searches across integrations, wishlist matching, run history | Main paid conversion hook |
+| Discoveries | Inbox/dashboard for watched results, wishlist matches, good-price candidates | Gives users a reason to return |
+| Assistant | Guided workflows for common tasks | Reduces learning friction |
+| Licensing | Free/Plus/Pro feature gates | Enables pricing tests |
+
+### Preview-only or later Beta scope
+
+These should be visible as roadmap items or paper prototypes only:
+
+| Area | Beta treatment |
+|---|---|
+| Signed trade receipts | Local/QR concept or JSON prototype only |
+| Feedback vault | Concept preview or local private record only |
+| Public Git/Radicle identity | Experimental setup screen or roadmap copy |
+| P2P local trading | Paper prototype or fake local demo flow |
+| Store/venue nodes | Not in immediate MVP |
+| Community governance | Not in immediate MVP |
+| Escrow/payment | Explicitly out of Cabinet core |
+
+## Packaging model
+
+### Cabinet Free
+
+Purpose: acquisition, trust building, local-first proof.
+
+Include:
+
+- one local profile
+- manual inventory, wishlist, and collections
+- basic item photos/media
+- basic search and filters
+- basic CSV/JSON export
+- manual backup
+- one saved Market Watch, manual run only
+- sample data and guided onboarding
+
+Candidate soft limits:
+
+- 250 inventory items
+- 100 wishlist items
+- 100 media attachments
+- 3 custom collections plus All Items
+
+Free should never trap user data. Export should remain available.
+
+### Cabinet Plus Beta
+
+Target user: serious collectors.
+
+Suggested test pricing:
+
+- AUD 9/month
+- AUD 79/year founding beta
+- later normal annual price: AUD 99/year
+
+Unlock:
+
+- higher or unlimited local inventory limits
+- unlimited collections/wishlists
+- more media/evidence capacity
+- 10 active Market Watches
+- scheduled watch runs
+- Discoveries dashboard
+- wishlist matching
+- import/export templates
+- stronger backup/restore workflows
+- guided assistant workflows
+
+### Cabinet Pro Beta
+
+Target user: power collectors, trade-heavy users, and small seller-style collectors.
+
+Suggested test pricing:
+
+- AUD 19/month
+- AUD 179/year founding beta
+- later normal annual price: AUD 199/year
+
+Unlock:
+
+- 50+ Market Watches
+- advanced integrations
+- purchase/reconciliation workflows
+- bulk import/export
+- advanced media/evidence workflows
+- assistant do-it-with-me workflows
+- early trade binder / receipt features
+- priority beta support
+
+### Future Store/Event tier
+
+Not immediate Beta.
+
+Potential later pricing:
+
+- AUD 49-99/month per store, club, or event host
+
+Potential unlocks:
+
+- event check-in
+- local catalogue cache
+- store attestations
+- event trade room
+- local discovery support
+
+## Pricing experiment
+
+Run the first beta as a willingness-to-pay test.
+
+### Test offers
+
+| Offer | Purpose |
+|---|---|
+| Free Beta | Prove install, trust, and repeat usage |
+| Founding Collector | AUD 49 for 12 months, limited first cohort |
+| Cabinet Plus Beta | AUD 79/year or AUD 9/month |
+| Cabinet Pro Beta | AUD 179/year or AUD 19/month |
+
+Do not only ask users whether they would pay. Ask for payment, deposit, or explicit upgrade commitment.
+
+### Success thresholds
+
+For an initial invited cohort of 20-30 collectors:
+
+- 12+ install and create or import real data
+- 8+ use Cabinet twice in one week
+- 5+ pay for Founding Collector, Plus, or Pro
+- 3+ say Market Watch or wishlist matching is the reason they paid
+- zero data-loss incidents
+- all users can export their data without help
+
+### Strong paid signals
+
+- User imports a real collection.
+- User adds more than 25 real wishlist items.
+- User creates more than one Market Watch.
+- User asks for more providers.
+- User checks Discoveries more than once.
+- User asks about backup/restore before paying.
+- User wants to use Cabinet at an event, swap meet, or store night.
+
+## Immediate backlog shape
+
+Create or link an umbrella issue:
+
+```text
+epic(beta): package Cabinet Free and paid beta MVP
+```
+
+Suggested child issues:
+
+1. Define Cabinet Free/Plus/Pro edition matrix.
+2. Implement local licence/entitlement gate using existing profile licence support.
+3. Build first-run Beta onboarding and starter checklist.
+4. Harden Inventory for beta save/edit/search/photo flows.
+5. Harden Wishlist for beta save, purchased-to-inventory, soft delete, and deleted filter flows.
+6. Harden Collections for beta metadata, soft delete, All Items protection, and item reassignment flows.
+7. Finish Market Watch as the paid conversion hook.
+8. Build Discoveries dashboard for watched results and wishlist matches.
+9. Add beta feedback and pricing-capture prompts.
+10. Prepare beta installer/release lane and release notes.
+11. Add assistant beta coverage for common workflows.
+
+## Market Watch as the paid spine
+
+Market Watch should be the strongest paid feature because it directly maps to money saved, missed opportunities avoided, and better buying decisions.
+
+User-facing promise:
+
+> Tell Cabinet what you are hunting for. Cabinet watches connected sources, matches results against your wishlist, and shows discoveries worth reviewing.
+
+Minimum beta behaviour:
+
+- create saved watch
+- choose provider/source
+- set keywords
+- set target price or notes
+- choose cadence where paid
+- run manually where free
+- show provider health
+- show run history
+- show discoveries/results inbox
+- hand off result to wishlist, purchase review, or inventory
+
+## Ready for private paid beta
+
+Cabinet is ready for a private paid beta when:
+
+- Inventory save/edit/search works reliably.
+- Wishlist purchased-to-inventory flow works reliably.
+- Collections are safe to manage.
+- Photos attach to correct items.
+- Backup/export are trustworthy.
+- Market Watch can produce visible useful discoveries.
+- Licensing gates do not block export or destroy user trust.
+
+## Non-goals
+
+- Do not turn Cabinet into an escrow/payment app.
+- Do not make selling the core beta promise.
+- Do not require public identity to use Cabinet Free.
+- Do not make Radicle/P2P a blocker for basic inventory and Market Watch value.
+- Do not hide export behind paid lockout.
+- Do not claim production integration reliability without validation evidence.
+
+## Acceptance criteria for this plan
+
+This plan is useful when:
+
+- Cabinet has a clear Free/paid packaging model.
+- Market Watch and Discoveries are treated as the immediate paid value spine.
+- The beta can be validated with real users and real payment intent.
+- The long-term trust architecture remains aligned without blocking the first sellable beta.

--- a/docs/product/kickstarter-market-validation.md
+++ b/docs/product/kickstarter-market-validation.md
@@ -1,0 +1,273 @@
+# Cabinet Kickstarter Market Validation Plan
+
+## Purpose
+
+This document defines a Kickstarter-style market validation plan for Cabinet.
+
+Kickstarter should validate whether collectors understand the Cabinet problem, trust the pitch, and will pay before the product is fully mature. It should not replace private beta proof.
+
+## Positioning
+
+Cabinet should not launch as a speculative marketplace replacement.
+
+The campaign should position Cabinet as:
+
+> A private collector vault first. Collector intelligence next. Peer-to-peer trade trust as the long-term protocol.
+
+Suggested campaign promise:
+
+> Cabinet is a local-first collector app that helps collectors organise what they own, track what they want, watch the market, and keep control of their records. Funding accelerates the paid intelligence layer and starts the path toward signed, portable, zero-fee collector-to-collector trade proof.
+
+## Safer claim language
+
+Avoid absolute claims that are difficult to prove.
+
+| Avoid | Use instead |
+|---|---|
+| Absolute data sovereignty | Local-first by default |
+| Unbreachable | No central Cabinet inventory database |
+| 100% offline | Core local vault works offline |
+| 0% marketplace fees | 0% Cabinet trade fee |
+| No central server | No central Cabinet-owned inventory database |
+| Invisible transactions | Private direct-trade workflows where users choose what to share |
+| Lifetime ownership of everything | Exportable records and scoped founding licences |
+
+Cabinet can make a strong privacy claim without overpromising:
+
+> Local-first by default. No central Cabinet inventory database. Optional connectivity only when the collector chooses it.
+
+## Campaign narrative
+
+### The problem
+
+Collectors are increasingly asked to put private collection data, wishlists, values, buying behaviour, and trade history into cloud accounts, marketplaces, and tracking-heavy apps.
+
+For high-value collectors, that creates three problems:
+
+1. **Privacy risk** — collection data can reveal wealth, taste, purchase behaviour, and storage patterns.
+2. **Data lock-in** — collection records can become trapped inside another company’s account system.
+3. **Fee pressure** — marketplace-style workflows can take a cut from trades or sales that collectors could handle directly.
+
+### The Cabinet answer
+
+Cabinet starts from a different assumption:
+
+> The collection belongs to the collector first.
+
+Cabinet gives collectors a private local vault for inventory, wishlists, collections, photos, evidence, export, and backup. Paid Cabinet adds collector intelligence: Market Watch, Discoveries, wishlist matching, import/export templates, and guided workflows.
+
+The long-term protocol adds signed trade receipts, feedback vaults, public proof ledgers, and optional P2P/store/event trust flows.
+
+## Three-phase campaign story
+
+### Phase 1 — Private Vault Beta
+
+The first deliverable is the private local collector workspace:
+
+- local-first inventory
+- wishlist
+- collections
+- photos and evidence
+- CSV/JSON export
+- manual backup
+- no account required for core local use
+
+### Phase 2 — Collector Intelligence
+
+The paid beta value is the intelligence layer:
+
+- Market Watch
+- Discoveries
+- wishlist matching
+- provider integrations
+- import/export templates
+- guided assistant workflows
+
+### Phase 3 — Trust Protocol
+
+The long-term trust roadmap is:
+
+- signed trade receipts
+- QR handoff
+- feedback vault
+- public proof ledgers
+- optional P2P/Radicle/store attestations
+
+Phase 3 should be a roadmap and stretch direction unless implemented and validated before campaign launch.
+
+## Suggested campaign name
+
+```text
+Cabinet: a private collector workspace for inventory, wishlists, discoveries, and trade prep
+```
+
+## Suggested headlines
+
+- Your collection is not a data product.
+- Private inventory. Portable records. Smarter collecting.
+- A local-first collector vault with optional market intelligence.
+- No central Cabinet inventory database. No forced marketplace.
+- Built for collectors who want control before connectivity.
+- Cabinet Free organises your collection. Cabinet Plus helps you find what you want before someone else does.
+
+## Video strategy
+
+The video should show real workflows rather than only ideology.
+
+### Opening hook
+
+Show the contrast between:
+
+- a cloud-tracked high-value collection with unknown data exposure
+- a local Cabinet vault where private inventory stays on the collector’s device
+
+### Demonstration sequence
+
+Show three concrete workflows:
+
+1. Add or import owned items into Inventory.
+2. Add wanted items into Wishlist and create a Market Watch.
+3. Review Discoveries and move one result into Wishlist, Purchase Review, or Inventory.
+
+### Roadmap sequence
+
+Show the future trust layer as a roadmap:
+
+- signed receipts
+- QR handoff
+- feedback vault
+- public proof ledgers
+- store/event attestations
+
+### Call to action
+
+Suggested CTA:
+
+> Back Cabinet to help build a private collector workspace that starts with local ownership and grows into portable collector trust.
+
+## Kickstarter reward strategy
+
+Use founding-year rewards rather than broad lifetime promises.
+
+| Tier | Price | Reward | Validation signal |
+|---|---:|---|---|
+| Supporter | AUD 5 | Updates and name on supporter page | Low-friction interest |
+| Early Vault Beta | AUD 29 | Early beta access and feedback channel | Product curiosity |
+| Founding Collector | AUD 49 | 12 months Cabinet Plus Beta | Willingness to pay |
+| Plus Founding Year | AUD 79 | 12 months Plus with founding badge | Strong paid intent |
+| Pro Founding Year | AUD 179 | 12 months Pro Beta and priority feedback | Power-user intent |
+| Collector Crew | AUD 299 | 5 Plus founding seats for a club or friend group | Group adoption signal |
+| Store/Club Pilot | AUD 799-999 | Discovery call and scoped pilot planning, not guaranteed deployment | B2B/community signal |
+
+## Lifetime licence caution
+
+Avoid broad lifetime promises.
+
+If a lifetime tier is used, scope it tightly:
+
+> Lifetime Local Vault Licence — lifetime access to shipped local-only premium vault features. Excludes paid cloud services, external API costs, future marketplace/provider fees, hosted infrastructure, and future protocol services.
+
+A founder-year or three-year reward is safer than an unlimited lifetime reward because Cabinet may later have real costs for integrations, hosted services, support, app distribution, or external providers.
+
+## Funding target
+
+Use a target that forces real validation.
+
+Candidate target:
+
+```text
+AUD 20,000
+```
+
+Why this target:
+
+- high enough to require real demand
+- achievable with 200-300 paid backers or fewer higher-tier backers
+- enough to fund a focused beta hardening cycle
+- failure still gives useful signal if pre-launch interest is weak
+
+## Validation thresholds
+
+| Outcome | Signal | Decision |
+|---|---|---|
+| Green | AUD 20k+ funded, 250+ backers, 100+ category surveys, 25+ users ready to import real data | Continue paid beta and prioritise paid spine |
+| Strong green | AUD 50k+, store/club interest, repeated provider requests | Add store/event and provider roadmap planning |
+| Yellow | AUD 8-20k interest but not funded or weak conversion | Continue private beta, reduce scope, refine positioning |
+| Red | Under 50 paid backers or weak pre-launch signups | Reposition before further build; test narrower category |
+
+## Pre-launch plan
+
+30-45 days before launch:
+
+1. Create a landing page with three promises: organise, watch, prepare.
+2. Publish short demo videos for inventory, wishlist, and Market Watch.
+3. Recruit slot car and card collectors first.
+4. Interview 10-15 collectors and 3-5 store/club organisers.
+5. Gather real screenshots, collection pain points, and wishlist examples.
+6. Run a pricing intent poll with payment/deposit option.
+7. Build a mailing list segmented by category.
+8. Open Kickstarter pre-launch page only after demo story is clear.
+
+## Kickstarter should not replace private beta
+
+Kickstarter should run only after Cabinet has a credible demo and at least a small private cohort.
+
+Recommended order:
+
+1. Private beta with 20-30 collectors.
+2. Founding Collector paid test.
+3. Kickstarter pre-launch page.
+4. Kickstarter campaign only if private beta usage and messaging are strong.
+5. Public beta hardening from campaign feedback.
+
+## Ready for Kickstarter pre-launch
+
+Cabinet is ready for Kickstarter pre-launch when:
+
+- app has a clear demo video
+- Market Watch has a believable working flow
+- pricing page or offer copy exists
+- beta users can explain Cabinet in their own words
+- at least 5 users have paid or committed to pay
+- the campaign does not overpromise decentralised trade/reputation features
+
+## Ready for Kickstarter launch
+
+Cabinet is ready for Kickstarter launch when:
+
+- pre-launch list has meaningful traction
+- reward tiers are deliverable
+- current Kickstarter rules, fees, eligibility, software reward constraints, and disclosure requirements have been verified
+- delivery dates are conservative
+- risks and limitations are plainly disclosed
+
+## Risks to disclose clearly
+
+- Cabinet is beta software.
+- Integrations may change or break when provider sites/APIs change.
+- Cabinet does not guarantee item prices, availability, or authenticity.
+- Cabinet does not process payments or escrow.
+- Cabinet does not take a Cabinet fee from direct collector-to-collector trades.
+- External payments, postage, insurance, platform fees, or payment processor fees may still apply outside Cabinet.
+- Data export remains part of the product promise.
+- Public identity, Radicle, P2P, store nodes, and reputation portability are roadmap work unless explicitly shipped.
+
+## Non-goals
+
+- Do not turn Cabinet into an escrow/payment app.
+- Do not make selling the core campaign promise.
+- Do not require public identity to use Cabinet Free.
+- Do not lead with production P2P unless it is implemented and validated.
+- Do not claim unbreachable security.
+- Do not hide export behind paid lockout.
+- Do not offer broad lifetime access without clear support and entitlement boundaries.
+
+## Acceptance criteria for this plan
+
+This plan is useful when:
+
+- Kickstarter is framed as market validation, not a substitute for product proof.
+- The campaign leads with the local-first collector vault and paid intelligence layer.
+- The trust protocol remains an aligned roadmap without overpromising implementation readiness.
+- Reward tiers measure real willingness to pay.
+- The campaign avoids centralised escrow/payment claims and keeps Cabinet’s trading-primary, selling-secondary direction.


### PR DESCRIPTION
## Summary

Splits the Cabinet product planning material into two dedicated markdown docs:

- `docs/product/beta-mvp.md`
- `docs/product/kickstarter-market-validation.md`

Also adds `docs/product/README.md` as the product planning docs index.

## Notes

- The MVP doc keeps the immediate beta focused on local-first inventory, wishlist, collections, media/evidence, Market Watch, Discoveries, assistant-guided workflows, backup, restore, import, export, and maintenance.
- The Kickstarter doc frames Kickstarter as market validation after private beta proof, not a replacement for product proof.
- The Kickstarter language avoids overpromising absolute security, broad lifetime access, marketplace replacement, escrow, or production P2P delivery before validation.

## Validation

Docs-only change.

- Runtime tests not run.
- OpenSpec validation not run because this only adds product/commercialisation documentation and does not change specs, APIs, migrations, runtime behaviour, or UI code.

Closes #1837.